### PR TITLE
fix: some minor improvements for components

### DIFF
--- a/src/components/buttons/button/Button.vue
+++ b/src/components/buttons/button/Button.vue
@@ -66,7 +66,7 @@ const spinnerSize: ComputedRef<number> = computed(() => {
   <button
     :class="[
       css.btn,
-      css[color ?? ''],
+      css[color ?? 'grey'],
       css[size ?? ''],
       css[variant],
       `shadow-${usedElevation}`,
@@ -97,7 +97,6 @@ const spinnerSize: ComputedRef<number> = computed(() => {
 
 :global(.dark) {
   .btn {
-    @apply bg-rui-grey-300 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-light-text;
     @apply disabled:bg-white/[.12] #{!important};
 
     @each $color in c.$context-colors {
@@ -110,9 +109,13 @@ const spinnerSize: ComputedRef<number> = computed(() => {
       }
     }
 
-    &.outlined,
-    &.text {
-      @apply active:bg-white/10 hover:bg-white/[.04] text-rui-text;
+    &.grey {
+      @apply bg-rui-grey-300 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-light-text;
+
+      &.outlined,
+      &.text {
+        @apply active:bg-white/10 hover:bg-white/[.04] text-rui-text;
+      }
     }
   }
 }
@@ -120,7 +123,6 @@ const spinnerSize: ComputedRef<number> = computed(() => {
 .btn {
   @apply text-sm leading-[1.5rem] font-medium outline outline-1 outline-transparent outline-offset-[-1px] flex items-center justify-center space-x-2 relative;
   @apply px-4 py-1.5 rounded transition-all;
-  @apply bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text;
   @apply disabled:bg-black/[.12] disabled:text-rui-text-disabled disabled:active:text-rui-text-disabled #{!important};
 
   .label {
@@ -154,14 +156,30 @@ const spinnerSize: ComputedRef<number> = computed(() => {
     }
   }
 
+  &.grey {
+    @apply bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text;
+
+    &.outlined,
+    &.text {
+      @apply bg-transparent hover:bg-black/[.04] active:bg-black/10;
+    }
+
+    &.outlined {
+      @apply outline-rui-text;
+    }
+
+    &.text {
+      @apply text-rui-text-secondary;
+    }
+  }
+
   &.outlined,
   &.text {
-    @apply bg-transparent hover:bg-black/[.04] active:bg-black/10 text-rui-text-secondary;
     @apply disabled:bg-transparent disabled:active:bg-transparent #{!important};
   }
 
   &.outlined {
-    @apply outline-rui-text disabled:outline-rui-text-disabled;
+    @apply disabled:outline-rui-text-disabled;
   }
 
   &.text {

--- a/src/components/forms/auto-complete/AutoComplete.stories.ts
+++ b/src/components/forms/auto-complete/AutoComplete.stories.ts
@@ -69,13 +69,11 @@ const data = [
   { id: '7', text: 'Hello 7', disabled: false },
   { id: '8', text: 'Hello 8', disabled: true },
   { id: '9', text: 'Hello 9', disabled: false },
-  { id: '10', text: 'Hello 10', disabled: false },
-  { id: '11', text: 'Hello 11', disabled: false },
-  { id: '12', text: 'Hello 12', disabled: false },
-  { id: '13', text: 'Hello 13', disabled: false },
-  { id: '14', text: 'Hello 14', disabled: false },
-  { id: '15', text: 'Hello 15', disabled: false },
-  { id: '16', text: 'Hello 16', disabled: false },
+  ...[...new Array(300).keys()].map((i, index) => ({
+    id: `${index + 10}`,
+    text: `Hello ${index + 10}`,
+    disabled: false,
+  })),
 ];
 
 export const Default: Story = {

--- a/src/components/forms/revealable-text-field/RevealableTextField.vue
+++ b/src/components/forms/revealable-text-field/RevealableTextField.vue
@@ -21,7 +21,9 @@ const slots = useSlots();
     <template #append>
       <div class="flex items-center">
         <RuiButton
+          tabindex="-1"
           variant="text"
+          type="button"
           icon
           class="-mr-1 !p-2"
           @click="hidden = !hidden"

--- a/src/components/forms/text-field/TextField.vue
+++ b/src/components/forms/text-field/TextField.vue
@@ -214,6 +214,8 @@ const slots = useSlots();
     }
 
     &:not(:placeholder-shown),
+    &:autofill,
+    &:-webkit-autofill,
     &[data-has-value='true'],
     &:focus {
       + .label {
@@ -348,6 +350,8 @@ const slots = useSlots();
       }
 
       &:not(:placeholder-shown),
+      &:autofill,
+      &:-webkit-autofill,
       &[data-has-value='true'],
       &:focus {
         + .label {
@@ -373,6 +377,8 @@ const slots = useSlots();
       }
 
       &:not(:placeholder-shown),
+      &:autofill,
+      &:-webkit-autofill,
       &[data-has-value='true'],
       &:focus {
         + .label {
@@ -405,6 +411,8 @@ const slots = useSlots();
       }
 
       &:not(:placeholder-shown),
+      &:autofill,
+      &:-webkit-autofill,
       &[data-has-value='true'],
       &:focus {
         @apply border-t-transparent;

--- a/src/components/steppers/Stepper.stories.ts
+++ b/src/components/steppers/Stepper.stories.ts
@@ -16,6 +16,7 @@ const meta: Meta<Props> = {
   tags: ['autodocs'],
   render,
   argTypes: {
+    step: { control: 'number', table: { category: 'State' } },
     steps: { control: 'array', table: { category: 'State' } },
     iconTop: { control: 'boolean', table: { category: 'State' } },
     custom: { control: 'boolean', table: { category: 'State' } },
@@ -191,22 +192,20 @@ export const StepOnlyAndVertical: Story = {
 export const Custom: Story = {
   args: {
     custom: true,
+    step: 1,
     steps: [
       { title: 'Done', description: 'Lorem ipsum', state: StepperState.done },
       {
         title: 'Active',
         description: 'Lorem ipsum',
-        state: StepperState.active,
       },
       {
         title: 'Inactive',
         description: 'Lorem ipsum',
-        state: StepperState.inactive,
       },
       {
         title: 'Inactive',
         description: 'Lorem ipsum',
-        state: StepperState.inactive,
       },
     ],
   },
@@ -215,23 +214,21 @@ export const Custom: Story = {
 export const CustomVertical: Story = {
   args: {
     custom: true,
+    step: 1,
     orientation: StepperOrientation.vertical,
     steps: [
       { title: 'Done', description: 'Lorem ipsum', state: StepperState.done },
       {
         title: 'Active',
         description: 'Lorem ipsum',
-        state: StepperState.active,
       },
       {
         title: 'Inactive',
         description: 'Lorem ipsum',
-        state: StepperState.inactive,
       },
       {
         title: 'Inactive',
         description: 'Lorem ipsum',
-        state: StepperState.inactive,
       },
     ],
   },
@@ -240,6 +237,7 @@ export const CustomVertical: Story = {
 export const CustomWithColor: Story = {
   args: {
     custom: true,
+    step: 1,
     titleClass: 'text-rui-primary',
     subtitleClass: 'text-rui-primary/80',
     steps: [
@@ -247,17 +245,14 @@ export const CustomWithColor: Story = {
       {
         title: 'Active',
         description: 'Lorem ipsum',
-        state: StepperState.active,
       },
       {
         title: 'Inactive',
         description: 'Lorem ipsum',
-        state: StepperState.inactive,
       },
       {
         title: 'Inactive',
         description: 'Lorem ipsum',
-        state: StepperState.inactive,
       },
     ],
   },

--- a/src/components/steppers/StepperCustomIcon.vue
+++ b/src/components/steppers/StepperCustomIcon.vue
@@ -2,10 +2,15 @@
 import Icon from '@/components/icons/Icon.vue';
 import { StepperState } from '@/types/stepper';
 
-defineProps<{
-  state: StepperState;
-  index: number;
-}>();
+withDefaults(
+  defineProps<{
+    state?: StepperState;
+    index: number;
+  }>(),
+  {
+    state: StepperState.inactive,
+  },
+);
 
 const css = useCssModule();
 </script>

--- a/src/components/steppers/StepperIcon.vue
+++ b/src/components/steppers/StepperIcon.vue
@@ -2,10 +2,15 @@
 import Icon from '@/components/icons/Icon.vue';
 import { StepperState } from '@/types/stepper';
 
-defineProps<{
-  state: StepperState;
-  index: number;
-}>();
+withDefaults(
+  defineProps<{
+    state?: StepperState;
+    index: number;
+  }>(),
+  {
+    state: StepperState.inactive,
+  },
+);
 
 const css = useCssModule();
 </script>

--- a/src/types/stepper.ts
+++ b/src/types/stepper.ts
@@ -13,7 +13,7 @@ export type StepperState = (typeof StepperState)[keyof typeof StepperState];
 export interface StepperStep {
   title?: string;
   description?: string;
-  state: StepperState;
+  state?: StepperState;
 }
 
 export const StepperOrientation = {


### PR DESCRIPTION
Closes #(issue_number)

- [x] Add default color class to button, so it can override annoying preflight style from tailwind when we pass [type="button"] to the button #79 
- [x] Add virtual scroller to the autocomplete component, so it can handle large amount of the data. #80 
- [x] Add min width to the stepper circle. and also for the custom one, automatically set the state by passed step. #81 
- [x] Add a little adjustment for text field, when the field is autofilled. #82 