### PR TITLE
fix: alias RuiIcons to string instead of RuiIcons[number]

### DIFF
--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -124,8 +124,7 @@ import { type GeneratedIcon } from '@/types/icons';\n
     .map(x => `"${x.replace('ri-', '')}"`)
     .join(',')}] as const;\n`;
 
-  indexFileContent += `export type RuiIcons = (typeof RuiIcons)[number];\n`;
-
+  indexFileContent += `export type RuiIcons = string;\n`;
   indexFileContent += `
 export function isRuiIcon(x: any): x is RuiIcons {
   return RuiIcons.includes(x);

--- a/src/components/icons/RuiIcon.vue
+++ b/src/components/icons/RuiIcon.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
+import { type RuiIcons, isRuiIcon } from '@/icons';
 import type { ContextColorsType } from '@/consts/colors';
-import type { RuiIcons } from '@/icons';
 
 export interface Props {
   name: RuiIcons;
@@ -17,20 +17,18 @@ const props = withDefaults(defineProps<Props>(), {
   color: undefined,
 });
 
-const css = useCssModule();
 const { registeredIcons } = useIcons();
 
-const { name } = toRefs(props);
-
 const path: ComputedRef<string | undefined> = computed(() => {
-  const nameVal = get(name);
-  const iconName = `ri-${nameVal}`;
+  const name = props.name;
+  if (!isRuiIcon(name)) {
+    console.warn(`icon ${name} must be a valid RuiIcon`);
+  }
+  const iconName = `ri-${name}`;
   const found = get(registeredIcons)[iconName];
 
   if (!found) {
-    console.error(
-      `Icons "${nameVal}" not found. Make sure that you have register the icon when installing the RuiPlugin`,
-    );
+    console.error(`Icons "${name}" not found. Make sure that you have register the icon when installing the RuiPlugin`);
   }
   return found;
 });
@@ -38,7 +36,7 @@ const path: ComputedRef<string | undefined> = computed(() => {
 
 <template>
   <svg
-    :class="[css.remixicon, css[color ?? '']]"
+    :class="[$style.remixicon, $style[color ?? '']]"
     :height="size"
     :width="size"
     viewBox="0 0 24 24"


### PR DESCRIPTION
A Big union of literal strings like this can have performance implications, so it is best to avoid them.

Closes #(issue_number)
