### PR TITLE
fix(RuiSwitch): remove glowing effect in disabled state

### DIFF
--- a/src/components/forms/switch/RuiSwitch.vue
+++ b/src/components/forms/switch/RuiSwitch.vue
@@ -195,7 +195,7 @@ const { hasError, hasSuccess } = useFormTextDetail(
   .input {
     @apply appearance-none relative w-full h-full rounded-full bg-rui-grey-400 transition-all duration-75 ease-in-out cursor-pointer;
 
-    &:active {
+    &:active:not(:disabled) {
       + .toggle {
         &:before {
           @apply opacity-20;


### PR DESCRIPTION
before
![before](https://github.com/user-attachments/assets/af217635-a74e-4423-a879-9a79f6e5bac9)

after
![after](https://github.com/user-attachments/assets/211ef50c-3adf-4707-a9c6-b19398f67c76)

Closes #290 


