### PR TITLE
feat(DateTimePicker): allow setting `now` as the max-date

### DIFF
--- a/src/components/date-time-picker/RuiDateTimePicker.spec.ts
+++ b/src/components/date-time-picker/RuiDateTimePicker.spec.ts
@@ -352,6 +352,28 @@ describe('date-time-picker/RuiDateTimePicker', () => {
     expect(vm.maxDate).toEqual(maxDate);
   });
 
+  it('handles "now" as maxDate correctly', async () => {
+    const wrapper = createWrapper({
+      props: {
+        maxDate: 'now',
+        modelValue: new Date(2023, 0, 25),
+      },
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+
+    const vm = wrapper.vm as any;
+    expect(vm.maxAllowedDate instanceof Date).toBeTruthy();
+
+    // Since we're using fake timers, the "now" date should be the fixed date
+    const expectedDate = new Date(fixedDate);
+    expect(vm.maxAllowedDate.getFullYear()).toBe(expectedDate.getFullYear());
+    expect(vm.maxAllowedDate.getMonth()).toBe(expectedDate.getMonth());
+    expect(vm.maxAllowedDate.getDate()).toBe(expectedDate.getDate());
+    expect(vm.maxAllowedDate.getHours()).toBe(expectedDate.getHours());
+    expect(vm.maxAllowedDate.getMinutes()).toBe(expectedDate.getMinutes());
+  });
+
   it('clears the value when clear button is clicked', async () => {
     const wrapper = createWrapper({
       props: {

--- a/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -24,7 +24,7 @@ type ModelValueType<T extends DateTimeModelType> =
 
 export interface RuiDateTimePickerProps {
   minDate?: Date | number;
-  maxDate?: Date | number;
+  maxDate?: Date | number | 'now';
   format?: DateFormat;
   type?: DateTimeModelType;
   accuracy?: TimeAccuracy;
@@ -111,6 +111,16 @@ const { setValue, update, getCurrent } = useInputHandler({
 const minAllowedDate = computed<Date>(() => props.minDate === undefined
   ? new Date(1970, 0, 1)
   : new Date(props.minDate));
+
+const maxAllowedDate = computed<Date | undefined>(() => {
+  if (props.maxDate === undefined) {
+    return undefined;
+  }
+  if (props.maxDate === 'now') {
+    return new Date();
+  }
+  return new Date(props.maxDate);
+});
 
 const dateFormat = computed<string>(() => {
   const dateFormat = props.format;
@@ -555,7 +565,7 @@ onMounted(() => {
         v-model:time-selection="timeSelection"
         v-model:selected-timezone="selectedTimezone"
         :accuracy="accuracy"
-        :max-date="maxDate"
+        :max-date="maxAllowedDate"
         :min-date="minAllowedDate"
         @set-now="setNow()"
       >


### PR DESCRIPTION
Closes #(issue_number)
