### PR TITLE
style(Tab): adjust the horizontal padding

### DIFF
--- a/packages/ui-library/src/components/tabs/tab/RuiTab.vue
+++ b/packages/ui-library/src/components/tabs/tab/RuiTab.vue
@@ -166,7 +166,7 @@ function click() {
 <style lang="scss" module>
 .tab {
   @apply h-full min-w-[90px] max-w-[360px] flex items-center rounded-none cursor-pointer relative whitespace-nowrap shrink-0;
-  @apply px-4;
+  @apply px-4 #{!important};
 
   &--vertical {
     @apply h-[2.625rem] w-full max-w-none;


### PR DESCRIPTION
The padding was broken
<img width="2094" height="308" alt="image" src="https://github.com/user-attachments/assets/d191dbd8-bd3e-4e8c-bd34-0cb4f4e7ef85" />
