### PR TITLE
fix(theme): unify theme color mode handling

### DIFF
--- a/packages/ui-library/src/composables/theme.spec.ts
+++ b/packages/ui-library/src/composables/theme.spec.ts
@@ -1,0 +1,150 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import { useRotkiTheme } from '@/composables/theme';
+import { ThemeMode } from '@/types/theme';
+
+// Helper to test composable with proper lifecycle hooks
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent);
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/theme', () => {
+  beforeEach(() => {
+    // Clear any existing theme classes and data attributes
+    document.documentElement.classList.remove('light', 'dark', 'auto');
+    delete document.documentElement.dataset.theme;
+  });
+
+  afterEach(() => {
+    // Clean up
+    document.documentElement.classList.remove('light', 'dark', 'auto');
+    delete document.documentElement.dataset.theme;
+    vi.restoreAllMocks();
+  });
+
+  describe('useRotkiTheme', () => {
+    it('should return all expected properties', () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      expect(result).toHaveProperty('config');
+      expect(result).toHaveProperty('init');
+      expect(result).toHaveProperty('isAutoControlled');
+      expect(result).toHaveProperty('isDark');
+      expect(result).toHaveProperty('isLight');
+      expect(result).toHaveProperty('setThemeConfig');
+      expect(result).toHaveProperty('state');
+      expect(result).toHaveProperty('store');
+      expect(result).toHaveProperty('switchThemeScheme');
+      expect(result).toHaveProperty('theme');
+      expect(result).toHaveProperty('toggleThemeMode');
+
+      unmount();
+    });
+
+    it('should set both class and data-theme attribute when switching to light mode', async () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      result.switchThemeScheme(ThemeMode.light);
+      await nextTick();
+
+      expect(document.documentElement.classList.contains('light')).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe('light');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+      unmount();
+    });
+
+    it('should set both class and data-theme attribute when switching to dark mode', async () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      result.switchThemeScheme(ThemeMode.dark);
+      await nextTick();
+
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+      unmount();
+    });
+
+    it('should update both class and data-theme when toggling theme mode', async () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      // Start with light mode
+      result.switchThemeScheme(ThemeMode.light);
+      await nextTick();
+
+      expect(document.documentElement.classList.contains('light')).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe('light');
+
+      // Toggle to dark
+      result.toggleThemeMode();
+      await nextTick();
+
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+      expect(document.documentElement.dataset.theme).toBe('dark');
+
+      unmount();
+    });
+
+    it('should keep class and data-theme in sync through multiple theme changes', async () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      const modes: ThemeMode[] = [ThemeMode.light, ThemeMode.dark, ThemeMode.light, ThemeMode.dark];
+
+      for (const mode of modes) {
+        result.switchThemeScheme(mode);
+        await nextTick();
+
+        const expectedClass = mode === ThemeMode.auto ? 'light' : mode;
+        expect(document.documentElement.dataset.theme).toBe(expectedClass);
+      }
+
+      unmount();
+    });
+
+    it('should correctly report isLight and isDark states', async () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      result.switchThemeScheme(ThemeMode.light);
+      await nextTick();
+
+      expect(get(result.isLight)).toBe(true);
+      expect(get(result.isDark)).toBe(false);
+
+      result.switchThemeScheme(ThemeMode.dark);
+      await nextTick();
+
+      expect(get(result.isLight)).toBe(false);
+      expect(get(result.isDark)).toBe(true);
+
+      unmount();
+    });
+
+    it('should correctly report isAutoControlled state', async () => {
+      const { result, unmount } = withSetup(() => useRotkiTheme());
+
+      result.switchThemeScheme(ThemeMode.auto);
+      await nextTick();
+
+      expect(get(result.isAutoControlled)).toBe(true);
+
+      result.switchThemeScheme(ThemeMode.light);
+      await nextTick();
+
+      expect(get(result.isAutoControlled)).toBe(false);
+
+      unmount();
+    });
+  });
+});

--- a/packages/ui-library/src/composables/theme.ts
+++ b/packages/ui-library/src/composables/theme.ts
@@ -17,15 +17,11 @@ const config: Ref<ThemeConfig> = ref({ ...defaultTheme });
  * @returns {ThemeContent}
  */
 export const useRotkiTheme = createSharedComposable<() => ThemeContent>(() => {
-  const { state, store } = useColorMode<ThemeMode>();
-
-  const { state: attributeState } = useColorMode<ThemeMode>({
-    attribute: 'data-theme',
-  });
-
-  // Keep attributeState in sync with state
-  watch(state, (newState) => {
-    set(attributeState, newState);
+  const { state, store } = useColorMode<ThemeMode>({
+    onChanged(mode, defaultHandler) {
+      defaultHandler(mode);
+      document.documentElement.dataset.theme = mode;
+    },
   });
 
   /**
@@ -61,14 +57,14 @@ export const useRotkiTheme = createSharedComposable<() => ThemeContent>(() => {
    * switch theme through dark/light/auto modes
    * @param {ThemeMode} mode
    */
-  const switchThemeScheme = (mode: ThemeMode) => {
+  const switchThemeScheme = (mode: ThemeMode): void => {
     set(store, mode || ThemeMode.auto);
   };
 
   /**
    * toggle between auto|light|dark
    */
-  const toggleThemeMode = () => {
+  const toggleThemeMode = (): void => {
     if (get(isAutoControlled))
       switchThemeScheme(ThemeMode.light);
     else if (get(isLight))
@@ -81,7 +77,7 @@ export const useRotkiTheme = createSharedComposable<() => ThemeContent>(() => {
    * sets the configuration for the theme
    * @param {ThemeConfig} newConfig
    */
-  const setThemeConfig = (newConfig: ThemeConfig) => {
+  const setThemeConfig = (newConfig: ThemeConfig): void => {
     set(config, newConfig);
   };
 
@@ -89,7 +85,7 @@ export const useRotkiTheme = createSharedComposable<() => ThemeContent>(() => {
    * theme initializer, must be called once from the app's entry
    * @param {InitThemeOptions} options
    */
-  const init = (options: InitThemeOptions) => {
+  const init = (options: InitThemeOptions): void => {
     switchThemeScheme(options.mode ?? ThemeMode.auto);
     setThemeConfig(options.config ?? { ...defaultTheme });
 

--- a/packages/ui-library/src/types/theme.ts
+++ b/packages/ui-library/src/types/theme.ts
@@ -1,4 +1,4 @@
-import type { BasicColorSchema } from '@vueuse/core';
+import type { BasicColorMode, BasicColorSchema } from '@vueuse/core';
 import type { ComputedRef, Ref } from 'vue';
 import type { GeneratedIcon } from '@/types/icons';
 import { contextColors } from '@/consts/colors';
@@ -33,17 +33,17 @@ export interface InitThemeOptions {
 }
 
 export interface ThemeContent {
-  theme: Ref<ThemeData | undefined>;
-  store: Ref<ThemeMode | BasicColorSchema>;
-  state: ComputedRef<ThemeMode | BasicColorSchema>;
-  config: Ref<ThemeConfig | undefined>;
+  config: Ref<ThemeConfig>;
+  init: (options: InitThemeOptions) => void;
   isAutoControlled: ComputedRef<boolean>;
   isDark: ComputedRef<boolean>;
   isLight: ComputedRef<boolean>;
-  init: (options: InitThemeOptions) => void;
-  switchThemeScheme: (mode: ThemeMode) => void;
-  toggleThemeMode: () => void;
   setThemeConfig: (newConfig: ThemeConfig) => void;
+  state: ComputedRef<ThemeMode | BasicColorMode>;
+  store: Ref<ThemeMode | BasicColorSchema>;
+  switchThemeScheme: (mode: ThemeMode) => void;
+  theme: ComputedRef<ThemeData>;
+  toggleThemeMode: () => void;
 }
 
 function createDefaultTheme(theme: 'light' | 'dark') {


### PR DESCRIPTION
- Change to a single use of useColorMode to handle both data-theme dark/light class.
- Fix the typing for ThemeContent

Closes #(issue_number)
