### PR TITLE
fix(theme): use SSR-safe handler for data-theme attribute

### DIFF
--- a/packages/ui-library/src/composables/theme.ts
+++ b/packages/ui-library/src/composables/theme.ts
@@ -1,4 +1,4 @@
-import { useColorMode } from '@vueuse/core';
+import { getSSRHandler, useColorMode } from '@vueuse/core';
 import { computed, type ComputedRef, type Ref, ref } from 'vue';
 import {
   type ColorIntensity,
@@ -17,10 +17,20 @@ const config: Ref<ThemeConfig> = ref({ ...defaultTheme });
  * @returns {ThemeContent}
  */
 export const useRotkiTheme = createSharedComposable<() => ThemeContent>(() => {
+  const updateHTMLAttrs = getSSRHandler(
+    'updateHTMLAttrs',
+    (selector, attribute, value) => {
+      const el = typeof selector === 'string' ? window?.document.querySelector(selector) : null;
+      if (!el)
+        return;
+      el.setAttribute(attribute, value);
+    },
+  );
+
   const { state, store } = useColorMode<ThemeMode>({
     onChanged(mode, defaultHandler) {
       defaultHandler(mode);
-      document.documentElement.dataset.theme = mode;
+      updateHTMLAttrs('html', 'data-theme', mode);
     },
   });
 


### PR DESCRIPTION
Replace direct document access with VueUse's getSSRHandler pattern
to prevent errors during server-side rendering. This ensures the
data-theme attribute is set using the same SSR handler that Nuxt
and other frameworks can register for consistent behavior.

Closes #430
