### PR TITLE
chore: remove first-party auto-imports and use explicit imports

### DIFF
--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -9,6 +9,7 @@ import { useInputHandler } from '@/components/date-time-picker/use-input-handler
 import { useKeyboardHandler } from '@/components/date-time-picker/use-keyboard-handler';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
+import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 type DateFormat = 'year-first' | 'month-first' | 'day-first';
 

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -9,7 +9,7 @@ import RuiMenu, { type MenuProps } from '@/components/overlays/menu/RuiMenu.vue'
 import RuiProgress from '@/components/progress/RuiProgress.vue';
 import { type KeyOfType, useDropdownMenu, useDropdownOptionProperty } from '@/composables/dropdown-menu';
 import { useAutoCompleteFocus, useAutoCompleteKeyboardNavigation, useAutoCompleteSearch, useAutoCompleteValue } from '@/composables/forms/auto-complete';
-import { getTextToken } from '@/utils/helpers';
+import { getNonRootAttrs, getRootAttrs, getTextToken } from '@/utils/helpers';
 import { isEqual } from '@/utils/is-equal';
 
 export type AutoCompleteModelValue<TValue> = TValue extends Array<infer U> ? U[] : TValue | undefined;

--- a/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.vue
+++ b/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.vue
@@ -3,6 +3,7 @@ import type { ContextColorsType } from '@/consts/colors';
 import { objectPick } from '@vueuse/shared';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
+import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface Props {

--- a/packages/ui-library/src/components/forms/radio-button/radio-group/RuiRadioGroup.vue
+++ b/packages/ui-library/src/components/forms/radio-button/radio-group/RuiRadioGroup.vue
@@ -4,6 +4,7 @@ import { objectPick } from '@vueuse/shared';
 import { Fragment, isVNode } from 'vue';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import { assert } from '@/utils/assert';
+import { generateId } from '@/utils/generate-id';
 
 export interface Props {
   inline?: boolean;

--- a/packages/ui-library/src/components/forms/radio-button/radio/RuiRadio.vue
+++ b/packages/ui-library/src/components/forms/radio-button/radio/RuiRadio.vue
@@ -2,6 +2,7 @@
 import type { ContextColorsType } from '@/consts/colors';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
+import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface RadioProps<TValue> {

--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
@@ -4,6 +4,7 @@ import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu, { type MenuProps } from '@/components/overlays/menu/RuiMenu.vue';
 import RuiProgress from '@/components/progress/RuiProgress.vue';
 import { type KeyOfType, useDropdownMenu } from '@/composables/dropdown-menu';
+import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface Props<TValue, TItem> {
   options: TItem[];

--- a/packages/ui-library/src/components/forms/slider/RuiSlider.vue
+++ b/packages/ui-library/src/components/forms/slider/RuiSlider.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ContextColorsType } from '@/consts/colors';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
+import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface Props {

--- a/packages/ui-library/src/components/forms/switch/RuiSwitch.vue
+++ b/packages/ui-library/src/components/forms/switch/RuiSwitch.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { ContextColorsType } from '@/consts/colors';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
+import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface Props {

--- a/packages/ui-library/src/components/forms/text-area/RuiTextArea.vue
+++ b/packages/ui-library/src/components/forms/text-area/RuiTextArea.vue
@@ -6,6 +6,8 @@ import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { assert } from '@/utils/assert';
+import { useFormTextDetail } from '@/utils/form-text-detail';
+import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface Props {
   label?: string;

--- a/packages/ui-library/src/components/forms/text-field/RuiTextField.vue
+++ b/packages/ui-library/src/components/forms/text-field/RuiTextField.vue
@@ -6,6 +6,7 @@ import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { assert } from '@/utils/assert';
+import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
 export interface TextFieldProps {

--- a/packages/ui-library/src/components/helpers/RuiFormTextDetail.vue
+++ b/packages/ui-library/src/components/helpers/RuiFormTextDetail.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useFormTextDetail } from '@/utils/form-text-detail';
+
 const props = withDefaults(
   defineProps<{
     errorMessages?: string | string[];

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { ContextColorsType } from '@/consts/colors';
+import { useIcons } from '@/composables/icons';
 import { isRuiIcon, type RuiIcons } from '@/icons';
 
 export interface Props {

--- a/packages/ui-library/src/components/overlays/dialog/RuiDialog.vue
+++ b/packages/ui-library/src/components/overlays/dialog/RuiDialog.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { getNonRootAttrs, getRootAttrs, transformPropsUnit } from '@/utils/helpers';
+
 export interface DialogProps {
   modelValue?: boolean;
   persistent?: boolean;

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import { type PopperOptions, usePopper } from '@/composables/popper';
+import { useFormTextDetail } from '@/utils/form-text-detail';
 
 export interface MenuProps {
   modelValue?: boolean;

--- a/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.vue
+++ b/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.vue
@@ -1,7 +1,7 @@
 <script setup lang='ts'>
 import type { MaybeElement } from '@vueuse/core';
 import { type Ref, ref } from 'vue';
-import { getRootAttrs } from '@/utils/helpers';
+import { getRootAttrs, transformPropsUnit } from '@/utils/helpers';
 
 export interface NavigationDrawerProps {
   modelValue?: boolean;

--- a/packages/ui-library/src/components/overlays/notification/RuiNotification.vue
+++ b/packages/ui-library/src/components/overlays/notification/RuiNotification.vue
@@ -1,4 +1,6 @@
 <script lang='ts' setup>
+import { transformPropsUnit } from '@/utils/helpers';
+
 export interface NotificationProps {
   modelValue: boolean;
   timeout: number;

--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiDataTable from '@/components/tables/RuiDataTable.vue';
 import RuiTablePagination from '@/components/tables/RuiTablePagination.vue';
+import { createTableDefaults, TableSymbol } from '@/composables/defaults/table';
 import { assert } from '@/utils/assert';
 import { expectWrapperToHaveClass } from '~/tests/helpers/dom-helpers';
 

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -13,6 +13,9 @@ import RuiTableHead, { type GroupData, type GroupKeys, type NoneSortableTableCol
 import RuiTablePagination, { type TablePaginationData } from '@/components/tables/RuiTablePagination.vue';
 import noDataPlaceholder from '@/components/tables/table_no_data_placeholder.svg';
 import noDataPlaceholderDark from '@/components/tables/table_no_data_placeholder_dark.svg';
+import { useTable } from '@/composables/defaults/table';
+import { useStickyTableHeader } from '@/composables/sticky-header';
+import { useRotkiTheme } from '@/composables/theme';
 import { assert } from '@/utils/assert';
 
 export interface TableOptions<T> {

--- a/packages/ui-library/src/components/tables/RuiTablePagination.vue
+++ b/packages/ui-library/src/components/tables/RuiTablePagination.vue
@@ -2,6 +2,8 @@
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiMenuSelect from '@/components/forms/select/RuiMenuSelect.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
+import { useTable } from '@/composables/defaults/table';
+import { formatInteger } from '@/utils/helpers';
 
 export interface TablePaginationData {
   page: number;

--- a/packages/ui-library/src/components/tabs/tab/RuiTab.vue
+++ b/packages/ui-library/src/components/tabs/tab/RuiTab.vue
@@ -2,6 +2,7 @@
 import type { RouteLocationRaw } from 'vue-router';
 import type { ContextColorsType } from '@/consts/colors';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import { generateId } from '@/utils/generate-id';
 
 export interface Props {
   color?: ContextColorsType;

--- a/packages/ui-library/src/composables/icons.ts
+++ b/packages/ui-library/src/composables/icons.ts
@@ -30,6 +30,7 @@ import {
   LuTriangleAlert,
   LuX,
 } from '@/icons';
+import { assert } from '@/utils/assert';
 
 const requiredIcons: GeneratedIcon[] = [
   LuChevronsUpDown,

--- a/packages/ui-library/vite.config.ts
+++ b/packages/ui-library/vite.config.ts
@@ -15,10 +15,6 @@ export default defineConfig({
     AutoImport({
       imports: ['vue', '@vueuse/core', { '@vueuse/shared': ['get', 'set'] }],
       dts: 'src/auto-imports.d.ts',
-      dirs: [
-        'src/composables/**/!(theme.ts|icons.ts|breakpoint.ts)',
-        'src/utils/**',
-      ],
       vueTemplate: true,
     }),
   ],


### PR DESCRIPTION
Remove the `dirs` config from AutoImport in vite.config.ts so that first-party composables and utils require explicit imports, while keeping third-party auto-imports (Vue, VueUse). This improves code readability and makes dependency tracking explicit.

Closes #(issue_number)
