### PR TITLE
test(SimpleSelect): add comprehensive e2e and unit test coverage

### DIFF
--- a/apps/example/e2e/forms/simple-select.spec.ts
+++ b/apps/example/e2e/forms/simple-select.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('forms/SimpleSelect', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/simple-selects');
+  });
+
+  test('should render default variant with selected value', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-default]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toBeVisible();
+    await expect(select).toHaveValue('Option 1');
+  });
+
+  test('should render outlined variant', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-outlined]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toBeVisible();
+    await expect(select).toHaveValue('Option 1');
+    await expect(select).toHaveClass(/outlined/);
+  });
+
+  test('should change value on select', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-default]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toHaveValue('Option 1');
+    await select.selectOption('Option 3');
+    await expect(select).toHaveValue('Option 3');
+  });
+
+  test('should not allow interaction when disabled', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-disabled]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toBeDisabled();
+  });
+
+  test('should render disabled outlined variant', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-disabled-outlined]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toBeDisabled();
+    await expect(select).toHaveClass(/outlined/);
+  });
+
+  test('should have name attribute', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-named]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toHaveAttribute('name', 'country');
+  });
+
+  test('should work with number options', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-number-options]');
+    const select = wrapper.locator('[data-id=select]');
+
+    await expect(select).toHaveValue('10');
+    await select.selectOption('30');
+    await expect(select).toHaveValue('30');
+  });
+
+  test('should render chevron icon', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=ss-default]');
+
+    await expect(wrapper.locator('svg')).toBeVisible();
+  });
+});

--- a/apps/example/src/App.vue
+++ b/apps/example/src/App.vue
@@ -26,6 +26,7 @@ const navigation = ref([
       { to: '/tooltips', title: 'Tooltips' },
       { to: '/menus', title: 'Menus' },
       { to: '/menu-selects', title: 'Menu Selects' },
+      { to: '/simple-selects', title: 'Simple Selects' },
       { to: '/data-tables', title: 'Data Tables' },
       { to: '/cards', title: 'Cards' },
       { to: '/tabs', title: 'Tabs' },

--- a/apps/example/src/pages/simple-selects.vue
+++ b/apps/example/src/pages/simple-selects.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import SimpleSelectView from '@/views/SimpleSelectView.vue';
+</script>
+
+<template>
+  <SimpleSelectView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -306,6 +306,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/simple-selects': RouteRecordInfo<
+      '/simple-selects',
+      '/simple-selects',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/sliders': RouteRecordInfo<
       '/sliders',
       '/sliders',
@@ -612,6 +619,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/radios.vue': {
       routes:
         | '/radios'
+      views:
+        | never
+    }
+    'src/pages/simple-selects.vue': {
+      routes:
+        | '/simple-selects'
       views:
         | never
     }

--- a/apps/example/src/views/SimpleSelectView.vue
+++ b/apps/example/src/views/SimpleSelectView.vue
@@ -1,0 +1,101 @@
+<script lang="ts" setup>
+import { RuiSimpleSelect } from '@rotki/ui-library';
+import ComponentView from '@/components/ComponentView.vue';
+
+const stringOptions: string[] = ['Option 1', 'Option 2', 'Option 3', 'Option 4', 'Option 5'];
+const numberOptions: number[] = [10, 20, 30, 40, 50];
+
+const defaultValue = ref<string>('Option 1');
+const outlinedValue = ref<string>('Option 1');
+const disabledValue = ref<string>('Option 1');
+const disabledOutlinedValue = ref<string>('Option 1');
+const namedValue = ref<string>('Option 1');
+const numberValue = ref<number>(10);
+</script>
+
+<template>
+  <ComponentView data-cy="simple-selects">
+    <template #title>
+      Simple Selects
+    </template>
+
+    <div class="grid gap-6 grid-cols-2">
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Default
+        </h3>
+        <RuiSimpleSelect
+          v-model="defaultValue"
+          :options="stringOptions"
+          label="Default select"
+          data-cy="ss-default"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Outlined
+        </h3>
+        <RuiSimpleSelect
+          v-model="outlinedValue"
+          :options="stringOptions"
+          label="Outlined select"
+          variant="outlined"
+          data-cy="ss-outlined"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Disabled
+        </h3>
+        <RuiSimpleSelect
+          v-model="disabledValue"
+          :options="stringOptions"
+          label="Disabled select"
+          disabled
+          data-cy="ss-disabled"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Disabled Outlined
+        </h3>
+        <RuiSimpleSelect
+          v-model="disabledOutlinedValue"
+          :options="stringOptions"
+          label="Disabled outlined select"
+          disabled
+          variant="outlined"
+          data-cy="ss-disabled-outlined"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Named
+        </h3>
+        <RuiSimpleSelect
+          v-model="namedValue"
+          :options="stringOptions"
+          label="Country select"
+          name="country"
+          data-cy="ss-named"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Number Options
+        </h3>
+        <RuiSimpleSelect
+          v-model="numberValue"
+          :options="numberOptions"
+          label="Number select"
+          data-cy="ss-number-options"
+        />
+      </div>
+    </div>
+  </ComponentView>
+</template>

--- a/packages/ui-library/src/components/forms/select/RuiSimpleSelect.spec.ts
+++ b/packages/ui-library/src/components/forms/select/RuiSimpleSelect.spec.ts
@@ -47,4 +47,132 @@ describe('components/forms/select/RuiSimpleSelect.vue', () => {
     });
     expect(wrapper.find('select[disabled]').exists()).toBeTruthy();
   });
+
+  it('should render all options', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 0',
+        options,
+      },
+    });
+
+    const optionElements = wrapper.findAll('option');
+    expect(optionElements).toHaveLength(6);
+    expect(optionElements[0]?.text()).toBe('Option 0');
+    expect(optionElements[5]?.text()).toBe('Option 5');
+  });
+
+  it('should render outlined variant', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 0',
+        options,
+        variant: 'outlined',
+      },
+    });
+
+    expectWrapperToHaveClass(wrapper, 'select', /_outlined_/);
+  });
+
+  it('should render chevron icon', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 0',
+        options,
+      },
+    });
+
+    expect(wrapper.find('svg').exists()).toBeTruthy();
+  });
+
+  it('should set name attribute', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 0',
+        name: 'test',
+        options,
+      },
+    });
+
+    expect(wrapper.find('select').attributes('name')).toBe('test');
+  });
+
+  it('should render selected value', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 2',
+        options,
+      },
+    });
+
+    expect(
+      wrapper.find<HTMLSelectElement>('select').element.value,
+    ).toBe('Option 2');
+  });
+
+  it('should emit update:model-value on change', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 0',
+        options,
+      },
+    });
+
+    await wrapper.find('select').setValue('Option 3');
+    expect(wrapper.emitted('update:model-value')).toBeTruthy();
+    expect(wrapper.emitted('update:model-value')?.[0]).toEqual(['Option 3']);
+  });
+
+  it('should work with number options', () => {
+    const numberOptions = [1, 2, 3];
+    wrapper = createWrapper({
+      props: {
+        modelValue: 2,
+        options: numberOptions,
+      },
+    });
+
+    const optionElements = wrapper.findAll('option');
+    expect(optionElements).toHaveLength(3);
+    expect(optionElements[0]?.text()).toBe('1');
+    expect(optionElements[2]?.text()).toBe('3');
+  });
+
+  it('should have data-id="select" on select element', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'Option 0',
+        options,
+      },
+    });
+
+    expect(wrapper.find('[data-id=select]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id=select]').element.tagName).toBe('SELECT');
+  });
+
+  it('should set aria-label from label prop', () => {
+    wrapper = createWrapper({
+      props: {
+        label: 'Choose option',
+        modelValue: 'Option 0',
+        options,
+      },
+    });
+
+    expect(wrapper.find('select').attributes('aria-label')).toBe('Choose option');
+  });
+
+  it('should pass attrs to wrapper div', () => {
+    wrapper = createWrapper({
+      attrs: {
+        'data-cy': 'test',
+      },
+      props: {
+        modelValue: 'Option 0',
+        options,
+      },
+    });
+
+    expect(wrapper.attributes('data-cy')).toBe('test');
+  });
 });

--- a/packages/ui-library/src/components/forms/select/RuiSimpleSelect.vue
+++ b/packages/ui-library/src/components/forms/select/RuiSimpleSelect.vue
@@ -5,6 +5,7 @@ export interface Props {
   modelValue: string | number;
   options: string[] | number[];
   disabled?: boolean;
+  label?: string;
   name?: string;
   variant?: 'default' | 'outlined';
 }
@@ -16,6 +17,7 @@ defineOptions({
 
 const props = withDefaults(defineProps<Props>(), {
   disabled: false,
+  label: undefined,
   name: '',
   variant: 'default',
 });
@@ -46,6 +48,8 @@ const value = computed({
       ]"
       :name="name"
       :disabled="disabled"
+      :aria-label="label"
+      data-id="select"
     >
       <option
         v-for="(option, i) in options"
@@ -55,7 +59,10 @@ const value = computed({
         {{ option }}
       </option>
     </select>
-    <span :class="$style.icon__wrapper">
+    <span
+      :class="$style.icon__wrapper"
+      aria-hidden="true"
+    >
       <RuiIcon
         :class="$style.icon"
         name="lu-chevron-down"


### PR DESCRIPTION
## Summary
- Add `data-id="select"` test hook and `label` prop (maps to `aria-label`) to `RuiSimpleSelect`
- Add `aria-hidden="true"` on decorative chevron icon wrapper
- Create example page with 6 demo variants (default, outlined, disabled, disabled-outlined, named, number options)
- Add 8 e2e tests covering rendering, interaction, disabled state, name attribute, and number options
- Expand unit tests from 2 to 12 covering all props, events, variants, accessibility, and attrs inheritance

## Test plan
- [x] Unit tests pass: `pnpm run test:run --testNamePattern="SimpleSelect"` (12 tests)
- [x] E2E tests pass: `pnpm test:e2e:dev simple-select.spec.ts` (8 tests)
- [x] Lint clean (no new warnings)
- [x] Typecheck passes
- [x] Production build succeeds