### PR TITLE
test(Divider): add e2e and unit test coverage with aria attributes

### DIFF
--- a/apps/example/e2e/divider.spec.ts
+++ b/apps/example/e2e/divider.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Divider', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/dividers');
+  });
+
+  test('should render horizontal divider by default', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=divider-horizontal]');
+    const divider = wrapper.locator('[role=separator]');
+
+    await expect(divider).toBeVisible();
+    await expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  test('should render vertical divider', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=divider-vertical]');
+    const divider = wrapper.locator('[role=separator]');
+
+    await expect(divider).toBeVisible();
+    await expect(divider).toHaveAttribute('aria-orientation', 'vertical');
+  });
+});

--- a/apps/example/src/App.vue
+++ b/apps/example/src/App.vue
@@ -28,6 +28,7 @@ const navigation = ref([
       { to: '/menu-selects', title: 'Menu Selects' },
       { to: '/simple-selects', title: 'Simple Selects' },
       { to: '/data-tables', title: 'Data Tables' },
+      { to: '/dividers', title: 'Dividers' },
       { to: '/cards', title: 'Cards' },
       { to: '/tabs', title: 'Tabs' },
       { to: '/badges', title: 'Badges' },

--- a/apps/example/src/pages/dividers.vue
+++ b/apps/example/src/pages/dividers.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import DividerView from '@/views/DividerView.vue';
+</script>
+
+<template>
+  <DividerView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -222,6 +222,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/dividers': RouteRecordInfo<
+      '/dividers',
+      '/dividers',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/icons': RouteRecordInfo<
       '/icons',
       '/icons',
@@ -547,6 +554,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/dialogs.vue': {
       routes:
         | '/dialogs'
+      views:
+        | never
+    }
+    'src/pages/dividers.vue': {
+      routes:
+        | '/dividers'
       views:
         | never
     }

--- a/apps/example/src/views/DividerView.vue
+++ b/apps/example/src/views/DividerView.vue
@@ -1,0 +1,45 @@
+<script lang="ts" setup>
+import { RuiDivider } from '@rotki/ui-library';
+import ComponentView from '@/components/ComponentView.vue';
+</script>
+
+<template>
+  <ComponentView data-cy="dividers">
+    <template #title>
+      Dividers
+    </template>
+
+    <div class="flex flex-col gap-6">
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Horizontal (Default)
+        </h3>
+        <div
+          class="p-4 border rounded"
+          data-cy="divider-horizontal"
+        >
+          <p>Content above</p>
+          <RuiDivider class="my-4" />
+          <p>Content below</p>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Vertical
+        </h3>
+        <div
+          class="flex items-center gap-4 p-4 border rounded h-20"
+          data-cy="divider-vertical"
+        >
+          <span>Left</span>
+          <RuiDivider
+            vertical
+            class="h-full"
+          />
+          <span>Right</span>
+        </div>
+      </div>
+    </div>
+  </ComponentView>
+</template>

--- a/packages/ui-library/src/components/divider/RuiDivider.spec.ts
+++ b/packages/ui-library/src/components/divider/RuiDivider.spec.ts
@@ -34,4 +34,32 @@ describe('components/divider/RuiDivider.vue', () => {
     expectNotToHaveClass(wrapper.element, /border-l/);
     expectToHaveClass(wrapper.element, /border-t/);
   });
+
+  it('should have role="separator"', () => {
+    wrapper = createWrapper();
+    expect(wrapper.attributes('role')).toBe('separator');
+  });
+
+  it('should have aria-orientation="horizontal" by default', () => {
+    wrapper = createWrapper();
+    expect(wrapper.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('should have aria-orientation="vertical" when vertical', () => {
+    wrapper = createWrapper({
+      props: {
+        vertical: true,
+      },
+    });
+    expect(wrapper.attributes('aria-orientation')).toBe('vertical');
+  });
+
+  it('should pass attrs to root element', () => {
+    wrapper = createWrapper({
+      attrs: {
+        'data-cy': 'test-divider',
+      },
+    });
+    expect(wrapper.attributes('data-cy')).toBe('test-divider');
+  });
 });

--- a/packages/ui-library/src/components/divider/RuiDivider.vue
+++ b/packages/ui-library/src/components/divider/RuiDivider.vue
@@ -17,6 +17,8 @@ withDefaults(defineProps<Props>(), {
   <div
     :class="vertical ? 'border-l' : 'border-t'"
     class="border-default"
+    role="separator"
+    :aria-orientation="vertical ? 'vertical' : 'horizontal'"
     v-bind="$attrs"
   />
 </template>


### PR DESCRIPTION
## Summary
- Add `role="separator"` and `aria-orientation` to `RuiDivider` for accessibility
- Create example page with horizontal and vertical divider demos
- Add 2 e2e tests covering both orientations and aria attributes
- Expand unit tests from 2 to 6 covering role, aria-orientation, and attrs inheritance

## Test plan
- [x] Unit tests pass: `pnpm run test:run --testNamePattern="RuiDivider"` (6 tests)
- [x] E2E tests pass: `pnpm test:e2e:dev divider.spec.ts` (2 tests)
- [x] Lint clean (no new warnings)
- [x] Typecheck passes
- [x] Production build succeeds