### PR TITLE
test(RevealableTextField): add e2e and unit test coverage with aria-label

### DIFF
--- a/apps/example/e2e/forms/revealable-text-field.spec.ts
+++ b/apps/example/e2e/forms/revealable-text-field.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('forms/RevealableTextField', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/text-fields');
+  });
+
+  test('should render with password type by default', async ({ page }) => {
+    const section = page.locator('h2', { hasText: 'Revealable Text Fields' }).locator('+ div');
+    const input = section.locator('input').first();
+
+    await expect(input).toHaveAttribute('type', 'password');
+  });
+
+  test('should toggle visibility on button click', async ({ page }) => {
+    const section = page.locator('h2', { hasText: 'Revealable Text Fields' }).locator('+ div');
+    const input = section.locator('input').first();
+    const toggleButton = section.locator('[data-id=toggle-visibility]').first();
+
+    await expect(input).toHaveAttribute('type', 'password');
+
+    await toggleButton.click();
+    await expect(input).toHaveAttribute('type', 'text');
+
+    await toggleButton.click();
+    await expect(input).toHaveAttribute('type', 'password');
+  });
+
+  test('should have aria-label on toggle button', async ({ page }) => {
+    const section = page.locator('h2', { hasText: 'Revealable Text Fields' }).locator('+ div');
+    const toggleButton = section.locator('[data-id=toggle-visibility]').first();
+
+    await expect(toggleButton).toHaveAttribute('aria-label', 'Show password');
+
+    await toggleButton.click();
+    await expect(toggleButton).toHaveAttribute('aria-label', 'Hide password');
+  });
+
+  test('should not allow toggle when disabled', async ({ page }) => {
+    const section = page.locator('h2', { hasText: 'Revealable Text Fields' }).locator('+ div');
+    const disabledInput = section.locator('input[disabled]').first();
+    // The disabled field is the 5th item (index 4) in the revealable section
+    const toggleButton = section.locator('[data-id=toggle-visibility]').nth(4);
+
+    await expect(disabledInput).toBeDisabled();
+    await expect(toggleButton).toBeDisabled();
+  });
+
+  test('should accept input value', async ({ page }) => {
+    const section = page.locator('h2', { hasText: 'Revealable Text Fields' }).locator('+ div');
+    const input = section.locator('input').first();
+
+    await input.fill('my-secret-password');
+    await expect(input).toHaveValue('my-secret-password');
+  });
+
+  test('should show clearable button when value present', async ({ page }) => {
+    const section = page.locator('h2', { hasText: 'Revealable Text Fields' }).locator('+ div');
+    // The last revealable text field has clearable=true and a pre-filled value
+    const clearableInput = section.locator('input').last();
+
+    await expect(clearableInput).toHaveValue('some values');
+    await clearableInput.focus();
+
+    const clearButton = section.locator('.clear-btn').last();
+    await expect(clearButton).toBeVisible();
+  });
+});

--- a/packages/ui-library/src/components/forms/revealable-text-field/RuiRevealableTextField.spec.ts
+++ b/packages/ui-library/src/components/forms/revealable-text-field/RuiRevealableTextField.spec.ts
@@ -66,4 +66,74 @@ describe('components/forms/revealable-text-field/RuiRevealableTextField.vue', ()
     await wrapper.setProps({ required: false });
     expect(wrapper.find('label').text()).not.toContain('﹡');
   });
+
+  it('should have aria-label on toggle button', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: '',
+      },
+    });
+
+    const button = wrapper.find('button');
+    expect(button.attributes('aria-label')).toBe('Show password');
+  });
+
+  it('should update aria-label when toggled', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: '',
+      },
+    });
+
+    const button = wrapper.find('button');
+    expect(button.attributes('aria-label')).toBe('Show password');
+
+    await button.trigger('click');
+    expect(button.attributes('aria-label')).toBe('Hide password');
+
+    await button.trigger('click');
+    expect(button.attributes('aria-label')).toBe('Show password');
+  });
+
+  it('should have data-id on toggle button', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: '',
+      },
+    });
+
+    expect(wrapper.find('[data-id=toggle-visibility]').exists()).toBeTruthy();
+  });
+
+  it('should disable toggle button when disabled', () => {
+    wrapper = createWrapper({
+      props: {
+        disabled: true,
+        modelValue: '',
+      },
+    });
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+
+  it('should render input with password type by default', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 'secret',
+      },
+    });
+
+    expect(wrapper.find('input').attributes('type')).toBe('password');
+  });
+
+  it('should pass variant prop to text field', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: '',
+        variant: 'outlined',
+      },
+    });
+
+    expect(wrapper.find('fieldset').exists()).toBeTruthy();
+  });
 });

--- a/packages/ui-library/src/components/forms/revealable-text-field/RuiRevealableTextField.vue
+++ b/packages/ui-library/src/components/forms/revealable-text-field/RuiRevealableTextField.vue
@@ -51,10 +51,12 @@ const hidden = ref<boolean>(true);
       <div class="flex items-center">
         <RuiButton
           :disabled="disabled"
+          :aria-label="hidden ? 'Show password' : 'Hide password'"
           tabindex="-1"
           variant="text"
           type="button"
           icon
+          data-id="toggle-visibility"
           class="-mr-1 !p-2"
           @click="hidden = !hidden"
         >


### PR DESCRIPTION
## Summary
- Add `aria-label` to the toggle visibility button (`Show password` / `Hide password`) for accessibility
- Add `data-id="toggle-visibility"` test hook on the toggle button
- Add 6 e2e tests covering password toggle, aria-label updates, disabled state, input, and clearable
- Expand unit tests from 3 to 9 covering aria-label, toggle state, disabled button, data-id, and variant passthrough

## Test plan
- [x] Unit tests pass: `pnpm run test:run --testNamePattern="RevealableTextField"` (9 tests)
- [x] E2E tests pass: `pnpm test:e2e:dev revealable-text-field.spec.ts` (6 tests)
- [x] Lint clean (no new warnings)
- [x] Typecheck passes
- [x] Production build succeeds