### PR TITLE
test(Dialog): add aria, data-id attributes and test coverage

### DIFF
--- a/apps/example/e2e/overlays/dialog.spec.ts
+++ b/apps/example/e2e/overlays/dialog.spec.ts
@@ -25,12 +25,54 @@ test.describe('dialog', () => {
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // should not close the dialog
-    await page.locator('div[role=dialog] div[class*=_overlay_]').click({ force: true });
+    await page.locator('div[role=dialog] [data-id=overlay]').click({ force: true });
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // close the dialog
     await page.locator('button[data-cy=close]').click();
     await expect(page.locator('div[role=dialog]')).toHaveCount(0);
+  });
+
+  test('should have aria-modal attribute when open', async ({ page }) => {
+    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+
+    const activator = defaultDialog.locator('[data-cy=activator]');
+    await activator.click();
+
+    const dialog = page.locator('div[role=dialog]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    await page.locator('button[data-cy=close]').click();
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('should have aria-label attribute when provided', async ({ page }) => {
+    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+
+    const activator = defaultDialog.locator('[data-cy=activator]');
+    await activator.click();
+
+    const dialog = page.locator('div[role=dialog]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-label', 'Persistent dialog');
+
+    await page.locator('button[data-cy=close]').click();
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('should display content inside dialog', async ({ page }) => {
+    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+
+    const activator = defaultDialog.locator('[data-cy=activator]');
+    await activator.click();
+
+    const dialog = page.locator('div[role=dialog]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Contents 0');
+
+    await page.locator('button[data-cy=close]').click();
+    await expect(dialog).toHaveCount(0);
   });
 
   test('check non-persistent dialog', async ({ page }) => {
@@ -50,7 +92,7 @@ test.describe('dialog', () => {
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // should close the dialog too
-    await page.locator('div[role=dialog] div[class*=_overlay_]').click({ force: true });
+    await page.locator('div[role=dialog] [data-id=overlay]').click({ force: true });
     await expect(page.locator('div[role=dialog]')).toHaveCount(0);
   });
 });

--- a/apps/example/src/views/DialogView.vue
+++ b/apps/example/src/views/DialogView.vue
@@ -14,8 +14,8 @@ interface ExtraProperties {
 
 type DialogData = DialogProps & ExtraProperties;
 const dialogs = ref<DialogData[]>([
-  { label: 'Persistent', persistent: true },
-  { label: 'Non Persistent', persistent: false },
+  { label: 'Persistent', persistent: true, ariaLabel: 'Persistent dialog' },
+  { label: 'Non Persistent', persistent: false, ariaLabel: 'Non-persistent dialog' },
 ]);
 </script>
 

--- a/packages/ui-library/src/components/overlays/dialog/RuiDialog.spec.ts
+++ b/packages/ui-library/src/components/overlays/dialog/RuiDialog.spec.ts
@@ -56,7 +56,7 @@ describe('components/overlays/dialog/RuiDialog.vue', () => {
     dialog = queryByRole<HTMLDivElement>('dialog');
 
     assertExists(dialog);
-    expect(dialog.querySelector('div[class*=_content_]')).toBeTruthy();
+    expect(dialog.querySelector('[data-id=content]')).toBeTruthy();
     expect(dialog.querySelector('div[class*=_center_]')).toBeTruthy();
 
     // Click the button that call close function
@@ -81,7 +81,7 @@ describe('components/overlays/dialog/RuiDialog.vue', () => {
     const dialog = queryByRole<HTMLDivElement>('dialog');
     assertExists(dialog);
 
-    const contentWrapper = dialog.querySelector<HTMLDivElement>('div[class*=_content_]');
+    const contentWrapper = dialog.querySelector<HTMLDivElement>('[data-id=content]');
     assertExists(contentWrapper);
 
     expect(contentWrapper.style.width).toBe('98%');
@@ -109,7 +109,7 @@ describe('components/overlays/dialog/RuiDialog.vue', () => {
     assertExists(dialog);
 
     // Click on the overlay should close the dialog
-    const overlay = dialog.querySelector<HTMLDivElement>('div[class*=_overlay_]');
+    const overlay = dialog.querySelector<HTMLDivElement>('[data-id=overlay]');
     assertExists(overlay);
     overlay.click();
 
@@ -153,7 +153,7 @@ describe('components/overlays/dialog/RuiDialog.vue', () => {
     assertExists(dialog);
 
     // Click on the overlay should not close the dialog
-    const overlay = dialog.querySelector<HTMLDivElement>('div[class*=_overlay_]');
+    const overlay = dialog.querySelector<HTMLDivElement>('[data-id=overlay]');
     assertExists(overlay);
     overlay.click();
 
@@ -170,6 +170,76 @@ describe('components/overlays/dialog/RuiDialog.vue', () => {
     dialog = queryByRole<HTMLDivElement>('dialog');
 
     assertExists(dialog);
+  });
+
+  it('should have aria-modal="true" when open', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const dialog = queryByRole<HTMLDivElement>('dialog');
+    assertExists(dialog);
+
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('should have aria-label when prop is provided', async () => {
+    wrapper = createWrapper({
+      props: {
+        ariaLabel: 'Test dialog',
+      },
+    });
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const dialog = queryByRole<HTMLDivElement>('dialog');
+    assertExists(dialog);
+
+    expect(dialog.getAttribute('aria-label')).toBe('Test dialog');
+  });
+
+  it('should not have aria-label when prop is not provided', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const dialog = queryByRole<HTMLDivElement>('dialog');
+    assertExists(dialog);
+
+    expect(dialog.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('should have data-id attributes on overlay and content', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const dialog = queryByRole<HTMLDivElement>('dialog');
+    assertExists(dialog);
+
+    expect(dialog.querySelector('[data-id=overlay]')).toBeTruthy();
+    expect(dialog.querySelector('[data-id=content]')).toBeTruthy();
+  });
+
+  it('should display slot content inside dialog', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const dialog = queryByRole<HTMLDivElement>('dialog');
+    assertExists(dialog);
+
+    expect(dialog.textContent).toContain(text);
   });
 
   it('should click:outside and click:esc emitted', async () => {
@@ -193,7 +263,7 @@ describe('components/overlays/dialog/RuiDialog.vue', () => {
     assertExists(dialog);
 
     // Click on the overlay should not close the dialog
-    const overlay = dialog.querySelector<HTMLDivElement>('div[class*=_overlay_]');
+    const overlay = dialog.querySelector<HTMLDivElement>('[data-id=overlay]');
     assertExists(overlay);
 
     overlay.click();

--- a/packages/ui-library/src/components/overlays/dialog/RuiDialog.vue
+++ b/packages/ui-library/src/components/overlays/dialog/RuiDialog.vue
@@ -9,6 +9,7 @@ export interface DialogProps {
   bottomSheet?: boolean;
   contentClass?: any;
   zIndex?: string | number;
+  ariaLabel?: string;
 }
 
 defineOptions({
@@ -157,6 +158,8 @@ function onClickOutside() {
         :class="$style.wrapper"
         :style="{ zIndex }"
         role="dialog"
+        aria-modal="true"
+        :aria-label="ariaLabel"
         tabindex="0"
         v-bind="getNonRootAttrs($attrs)"
         @keydown.esc.stop="onEscClick()"
@@ -171,6 +174,7 @@ function onClickOutside() {
         >
           <div
             v-if="isOpen && internalValue"
+            data-id="overlay"
             :class="$style.overlay"
             @click.stop="onClickOutside()"
           />
@@ -179,6 +183,7 @@ function onClickOutside() {
           <div
             v-if="isOpen && internalValue"
             ref="contentRef"
+            data-id="content"
             :style="style"
             tabindex="0"
             :class="[$style.content, contentClass, { [$style.center]: !bottomSheet }]"


### PR DESCRIPTION
## Summary
- Added `aria-modal="true"` and `ariaLabel` prop to `RuiDialog` for accessibility
- Added `data-id="overlay"` and `data-id="content"` on internal elements for stable test selectors
- Expanded unit tests from 5 to 10 (aria-modal, aria-label, data-id hooks, slot content)
- Expanded e2e tests from 2 to 5 (aria-modal, aria-label, content display)
- Migrated existing tests from brittle CSS module selectors to `data-id` selectors
- Updated example DialogView to use `ariaLabel` prop

## Test plan
- [x] Unit tests pass: `pnpm run test:run --testNamePattern="RuiDialog"`
- [x] E2E tests pass: `pnpm test:e2e:dev dialog.spec.ts`
- [x] Lint clean
- [x] Typecheck clean
- [x] Build succeeds