### PR TITLE
test(BottomSheet): add e2e and unit test coverage with aria and data-id attributes

### DIFF
--- a/apps/example/e2e/overlays/bottom-sheet.spec.ts
+++ b/apps/example/e2e/overlays/bottom-sheet.spec.ts
@@ -25,7 +25,7 @@ test.describe('bottom-sheet', () => {
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // should not close the bottom sheet
-    await page.locator('div[role=dialog] div[class*=_overlay_]').click({ force: true });
+    await page.locator('div[role=dialog] [data-id=overlay]').click({ force: true });
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // close the bottom sheet
@@ -50,7 +50,37 @@ test.describe('bottom-sheet', () => {
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // should close the bottom sheet too
-    await page.locator('div[role=dialog] div[class*=_overlay_]').click({ force: true });
+    await page.locator('div[role=dialog] [data-id=overlay]').click({ force: true });
     await expect(page.locator('div[role=dialog]')).toHaveCount(0);
+  });
+
+  test('should have aria-modal attribute when open', async ({ page }) => {
+    const defaultBottomSheet = page.locator('div[data-cy=bottom-sheet-0]');
+
+    const activator = defaultBottomSheet.locator('[data-cy=activator]');
+    await activator.click();
+
+    const dialog = page.locator('div[role=dialog]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    await page.locator('button[data-cy=close]').click();
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('should apply custom width to bottom sheet content', async ({ page }) => {
+    const defaultBottomSheet = page.locator('div[data-cy=bottom-sheet-0]');
+
+    const activator = defaultBottomSheet.locator('[data-cy=activator]');
+    await activator.click();
+
+    const dialog = page.locator('div[role=dialog]');
+    await expect(dialog).toBeVisible();
+
+    const content = dialog.locator('[data-id=content]');
+    await expect(content).toHaveCSS('width', '900px');
+
+    await page.locator('button[data-cy=close]').click();
+    await expect(dialog).toHaveCount(0);
   });
 });

--- a/packages/ui-library/src/components/overlays/bottom-sheet/RuiBottomSheet.spec.ts
+++ b/packages/ui-library/src/components/overlays/bottom-sheet/RuiBottomSheet.spec.ts
@@ -58,7 +58,7 @@ describe('components/overlays/bottom-sheet/RuiBottomSheet.vue', () => {
     bottomSheet = queryByRole<HTMLDivElement>('dialog');
 
     assertExists(bottomSheet);
-    expect(bottomSheet.querySelector('div[class*=_content_]')).toBeTruthy();
+    expect(bottomSheet.querySelector('[data-id=content]')).toBeTruthy();
     expect(bottomSheet.querySelector('div[class*=_center_]')).toBeFalsy();
 
     // Click the button that call close function
@@ -83,7 +83,7 @@ describe('components/overlays/bottom-sheet/RuiBottomSheet.vue', () => {
     const bottomSheet = queryByRole<HTMLDivElement>('dialog');
     assertExists(bottomSheet);
 
-    const contentWrapper = bottomSheet.querySelector<HTMLDivElement>('div[class*=_content_]');
+    const contentWrapper = bottomSheet.querySelector<HTMLDivElement>('[data-id=content]');
     assertExists(contentWrapper);
 
     expect(contentWrapper.style.width).toBe('98%');
@@ -110,7 +110,7 @@ describe('components/overlays/bottom-sheet/RuiBottomSheet.vue', () => {
     assertExists(bottomSheet);
 
     // Click on the overlay should close the bottom sheet
-    const overlay = bottomSheet.querySelector<HTMLDivElement>('div[class*=_overlay_]');
+    const overlay = bottomSheet.querySelector<HTMLDivElement>('[data-id=overlay]');
     assertExists(overlay);
     overlay.click();
 
@@ -154,7 +154,7 @@ describe('components/overlays/bottom-sheet/RuiBottomSheet.vue', () => {
     assertExists(bottomSheet);
 
     // Click on the overlay should not close the bottom sheet
-    const overlay = bottomSheet.querySelector<HTMLDivElement>('div[class*=_overlay_]');
+    const overlay = bottomSheet.querySelector<HTMLDivElement>('[data-id=overlay]');
     assertExists(overlay);
     overlay.click();
 
@@ -171,5 +171,45 @@ describe('components/overlays/bottom-sheet/RuiBottomSheet.vue', () => {
     bottomSheet = queryByRole<HTMLDivElement>('dialog');
 
     assertExists(bottomSheet);
+  });
+
+  it('should have role="dialog" when open', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const bottomSheet = queryByRole<HTMLDivElement>('dialog');
+    assertExists(bottomSheet);
+
+    expect(bottomSheet.getAttribute('role')).toBe('dialog');
+  });
+
+  it('should have aria-modal="true" when open', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const bottomSheet = queryByRole<HTMLDivElement>('dialog');
+    assertExists(bottomSheet);
+
+    expect(bottomSheet.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('should have data-id attributes on overlay and content', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const bottomSheet = queryByRole<HTMLDivElement>('dialog');
+    assertExists(bottomSheet);
+
+    expect(bottomSheet.querySelector('[data-id=overlay]')).toBeTruthy();
+    expect(bottomSheet.querySelector('[data-id=content]')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Add unit tests verifying `role="dialog"`, `aria-modal="true"`, and `data-id` attributes are inherited from RuiDialog
- Add e2e tests for `aria-modal` attribute and custom width application
- Update existing test selectors from `class*=_overlay_`/`_content_` to `data-id` attributes for consistency with Dialog tests

## Test plan
- [x] Unit tests pass: `pnpm run test:run --testNamePattern="RuiBottomSheet"`
- [x] E2E tests pass: `pnpm test:e2e:dev overlays/bottom-sheet.spec.ts`
- [x] Lint passes: `pnpm run lint`