### PR TITLE
test(NavigationDrawer): add e2e and unit test coverage with aria and data-id attributes

### DIFF
--- a/apps/example/e2e/overlays/navigation-drawer.spec.ts
+++ b/apps/example/e2e/overlays/navigation-drawer.spec.ts
@@ -44,4 +44,49 @@ test.describe('navigation drawer', () => {
     // The drawer should still be visible
     await expect(page.locator('aside[class*=_visible]')).toBeVisible();
   });
+
+  test('should render drawer on left by default', async ({ page }) => {
+    const defaultDrawer = page.locator('div[data-cy=navigation-drawer-0]');
+    await defaultDrawer.locator('[data-cy=activator]').click();
+
+    const aside = page.locator('aside[class*=_visible]');
+    await expect(aside).toBeVisible();
+    // Left drawer should have left position class
+    await expect(aside).toHaveClass(/\b_left_/);
+  });
+
+  test('should render drawer on right with position="right"', async ({ page }) => {
+    const rightDrawer = page.locator('div[data-cy=navigation-drawer-1]');
+    await rightDrawer.locator('[data-cy=activator]').click();
+
+    const aside = page.locator('aside[class*=_visible]');
+    await expect(aside).toBeVisible();
+    // Right drawer should have right position class
+    await expect(aside).toHaveClass(/\b_right_/);
+  });
+
+  test('should show overlay when overlay prop is true', async ({ page }) => {
+    const overlayDrawer = page.locator('div[data-cy=navigation-drawer-3]');
+    await overlayDrawer.locator('[data-cy=activator]').click();
+
+    const aside = page.locator('aside[class*=_visible]');
+    await expect(aside).toBeVisible();
+
+    // Overlay element should be present
+    const overlay = page.locator('[data-id=overlay]');
+    await expect(overlay).toBeVisible();
+
+    // Clicking overlay should close the drawer
+    await overlay.click();
+    await expect(page.locator('aside[class*=_visible]')).toHaveCount(0);
+  });
+
+  test('should have aria-label on drawer', async ({ page }) => {
+    const defaultDrawer = page.locator('div[data-cy=navigation-drawer-0]');
+    await defaultDrawer.locator('[data-cy=activator]').click();
+
+    const aside = page.locator('aside[class*=_visible]');
+    await expect(aside).toBeVisible();
+    await expect(aside).toHaveAttribute('aria-label', 'Left navigation');
+  });
 });

--- a/apps/example/src/views/NavigationDrawerView.vue
+++ b/apps/example/src/views/NavigationDrawerView.vue
@@ -9,10 +9,10 @@ interface ExtraProperties {
 
 type NavigationDrawerData = NavigationDrawerProps & ExtraProperties;
 const navigationDrawers = ref<NavigationDrawerData[]>([
-  { modelValue: false, label: 'Left', temporary: true },
-  { modelValue: false, label: 'Right', position: 'right', temporary: true },
-  { modelValue: false, label: 'Persistent', temporary: false },
-  { modelValue: false, label: 'With Overlay', temporary: true, overlay: true },
+  { modelValue: false, label: 'Left', temporary: true, ariaLabel: 'Left navigation' },
+  { modelValue: false, label: 'Right', position: 'right', temporary: true, ariaLabel: 'Right navigation' },
+  { modelValue: false, label: 'Persistent', temporary: false, ariaLabel: 'Persistent navigation' },
+  { modelValue: false, label: 'With Overlay', temporary: true, overlay: true, ariaLabel: 'Overlay navigation' },
 ]);
 </script>
 

--- a/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.spec.ts
+++ b/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.spec.ts
@@ -173,6 +173,67 @@ describe('components/overlays/navigation-drawer/RuiNavigationDrawer.vue', () => 
     expect(drawerElement).toBeFalsy();
   });
 
+  it('should render as aside element', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const drawer = queryBody<HTMLElement>('aside[class*=_visible_]');
+    assertExists(drawer);
+    expect(drawer.tagName).toBe('ASIDE');
+  });
+
+  it('should have aria-label when prop provided', async () => {
+    wrapper = createWrapper({
+      attrs: {
+        'aria-label': 'Main navigation',
+      },
+    });
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const drawer = queryBody<HTMLElement>('aside[class*=_visible_]');
+    assertExists(drawer);
+    expect(drawer.getAttribute('aria-label')).toBe('Main navigation');
+  });
+
+  it('should have aria-hidden when miniVariant is true and drawer is collapsed', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: false,
+        miniVariant: true,
+      },
+    });
+    await vi.runAllTimersAsync();
+
+    const drawer = queryBody<HTMLElement>('aside[class*=_content_]');
+    assertExists(drawer);
+    expect(drawer.getAttribute('aria-hidden')).toBe('true');
+
+    // Open drawer
+    await wrapper.setProps({ modelValue: true });
+    await vi.runAllTimersAsync();
+
+    const openDrawer = queryBody<HTMLElement>('aside[class*=_visible_]');
+    assertExists(openDrawer);
+    expect(openDrawer.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('should apply left position class by default', async () => {
+    wrapper = createWrapper();
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const drawer = queryBody<HTMLElement>('aside[class*=_visible_][class*=_left_]');
+    assertExists(drawer);
+  });
+
   it('should keep DOM element when miniVariant is true and modelValue is false', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.vue
+++ b/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.vue
@@ -12,6 +12,7 @@ export interface NavigationDrawerProps {
   overlay?: boolean;
   position?: 'left' | 'right';
   contentClass?: string | object | string[];
+  ariaLabel?: string;
 }
 
 defineOptions({
@@ -129,6 +130,7 @@ const activatorAttrs = computed(() => ({
       >
         <div
           v-if="isOpen && internalValue"
+          data-id="overlay"
           :class="$style.overlay"
           @click.stop="close()"
         />
@@ -148,6 +150,8 @@ const activatorAttrs = computed(() => ({
             [$style['with-overlay']]: overlay,
           },
         ]"
+        :aria-label="ariaLabel"
+        :aria-hidden="miniVariant && !(isOpen && internalValue) ? 'true' : undefined"
         v-bind="getRootAttrs($attrs)"
       >
         <slot v-bind="{ attrs: activatorAttrs, close }" />


### PR DESCRIPTION
## Summary

- Add `ariaLabel` prop and `aria-hidden` attribute for collapsed mini-variant state to improve accessibility
- Add `data-id="overlay"` on overlay element for e2e test targeting
- Expand unit tests (4 new → 10 total): aside element rendering, aria-label, aria-hidden for mini-variant, left position class
- Expand e2e tests (4 new → 6 total): left/right positioning, overlay behavior, aria-label verification

## Test plan

- [x] Unit tests pass (`pnpm run test:run --testNamePattern="NavigationDrawer"`)
- [x] E2E tests pass (`pnpm test:e2e:dev overlays/navigation-drawer.spec.ts`)
- [x] Lint clean
- [x] Typecheck clean