### PR TITLE
test(ColorPicker): add e2e and unit test coverage with aria attributes

### DIFF
--- a/apps/example/e2e/color-picker.spec.ts
+++ b/apps/example/e2e/color-picker.spec.ts
@@ -14,4 +14,51 @@ test.describe('color pickers', () => {
     const secondColorPicker = page.locator('div[data-cy=color-picker-1]');
     await expect(secondColorPicker.locator('input')).toHaveValue(/45858a/);
   });
+
+  test('should update color when typing hex value', async ({ page }) => {
+    const picker = page.locator('div[data-cy=color-picker-0]');
+    const input = picker.locator('input');
+
+    await input.fill('ff0000');
+    await input.blur();
+
+    // Color display should reflect the new color
+    const display = picker.locator('[data-cy=color-display]');
+    await expect(display).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+  });
+
+  test('should switch between hex and RGB input modes', async ({ page }) => {
+    const picker = page.locator('div[data-cy=color-picker-1]');
+
+    // Initially in hex mode - single input
+    await expect(picker.locator('input')).toHaveCount(1);
+    await expect(picker.locator('input')).toHaveValue('45858a');
+
+    // Click toggle button to switch to RGB mode
+    await picker.locator('button').click();
+
+    // Should now have 3 RGB inputs
+    const inputs = picker.locator('input');
+    await expect(inputs).toHaveCount(3);
+
+    // Switch back to hex mode
+    await picker.locator('button').click();
+    await expect(picker.locator('input')).toHaveCount(1);
+  });
+
+  test('should have aria-label on picker', async ({ page }) => {
+    const picker = page.locator('div[data-cy=color-picker-0]');
+    await expect(picker).toHaveAttribute('role', 'application');
+    await expect(picker).toHaveAttribute('aria-label', 'Color picker');
+
+    // Color board should have slider role
+    const board = picker.locator('.rui-color-board');
+    await expect(board).toHaveAttribute('role', 'slider');
+    await expect(board).toHaveAttribute('aria-label', 'Color saturation and brightness');
+
+    // Hue bar should have slider role
+    const hue = picker.locator('.rui-color-hue');
+    await expect(hue).toHaveAttribute('role', 'slider');
+    await expect(hue).toHaveAttribute('aria-label', 'Hue');
+  });
 });

--- a/packages/ui-library/src/components/color-picker/RuiColorBoard.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorBoard.vue
@@ -95,6 +95,9 @@ whenever(
 <template>
   <div
     ref="wrapper"
+    role="slider"
+    aria-label="Color saturation and brightness"
+    :aria-valuetext="`Saturation ${Math.round(state.saturation * 100)}%, Brightness ${Math.round(state.brightness * 100)}%`"
     class="rui-color-board"
     :class="$style.saturation"
     v-bind="$attrs"

--- a/packages/ui-library/src/components/color-picker/RuiColorHue.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorHue.vue
@@ -88,6 +88,11 @@ watch(modelValue, () => {
 <template>
   <div
     ref="barElement"
+    role="slider"
+    aria-label="Hue"
+    :aria-valuenow="modelValue"
+    aria-valuemin="0"
+    aria-valuemax="360"
     :class="$style.bar"
     class="rui-color-hue"
     v-bind="$attrs"

--- a/packages/ui-library/src/components/color-picker/RuiColorPicker.spec.ts
+++ b/packages/ui-library/src/components/color-picker/RuiColorPicker.spec.ts
@@ -152,6 +152,32 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     expect(wrapper.emitted('update:model-value')!.at(-1)![0]).toBe('80ffff');
   });
 
+  it('should have role="application" and aria-label on root', () => {
+    wrapper = createWrapper();
+
+    const root = wrapper.find('.rui-color-picker');
+    expect(root.attributes('role')).toBe('application');
+    expect(root.attributes('aria-label')).toBe('Color picker');
+  });
+
+  it('should have role="slider" and aria-label on color board', () => {
+    wrapper = createWrapper();
+
+    const board = wrapper.find('.rui-color-board');
+    expect(board.attributes('role')).toBe('slider');
+    expect(board.attributes('aria-label')).toBe('Color saturation and brightness');
+  });
+
+  it('should have role="slider" and aria attributes on hue bar', () => {
+    wrapper = createWrapper();
+
+    const hue = wrapper.find('.rui-color-hue');
+    expect(hue.attributes('role')).toBe('slider');
+    expect(hue.attributes('aria-label')).toBe('Hue');
+    expect(hue.attributes('aria-valuemin')).toBe('0');
+    expect(hue.attributes('aria-valuemax')).toBe('360');
+  });
+
   it('should handle clicks on the UI selector', async () => {
     wrapper = createWrapper();
     await vi.runAllTimersAsync();

--- a/packages/ui-library/src/components/color-picker/RuiColorPicker.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorPicker.vue
@@ -48,6 +48,8 @@ watch(state, (state) => {
 
 <template>
   <div
+    role="application"
+    aria-label="Color picker"
     class="rui-color-picker relative select-none bg-initial"
     v-bind="$attrs"
   >


### PR DESCRIPTION
## Summary

- Add `role="application"` and `aria-label="Color picker"` on root picker element
- Add `role="slider"` with `aria-label` and `aria-valuetext` on `RuiColorBoard` sub-component
- Add `role="slider"` with `aria-label`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax` on `RuiColorHue` sub-component
- Expand unit tests (3 new → 7 total): ARIA roles and labels on root, color board, and hue bar
- Expand e2e tests (3 new → 4 total): hex input, hex/RGB mode switching, ARIA attribute verification

## Test plan

- [x] Unit tests pass (`pnpm run test:run --testNamePattern="ColorPicker"`)
- [x] E2E tests pass (`pnpm test:e2e:dev color-picker.spec.ts`)
- [x] Lint clean
- [x] Typecheck clean