### PR TITLE
test(Tooltip): add e2e and unit test coverage with aria-describedby

### DIFF
--- a/apps/example/e2e/overlays/tooltip.spec.ts
+++ b/apps/example/e2e/overlays/tooltip.spec.ts
@@ -60,4 +60,35 @@ test.describe('tooltip', () => {
     // The tooltip would normally appear quickly if enabled, so we check it stays at 0
     await expect(page.locator('div[role=tooltip-content]')).toHaveCount(0, { timeout: 1000 });
   });
+
+  test('should show tooltip on keyboard focus', async ({ page }) => {
+    const defaultTooltip = page.locator('div[data-cy=tooltip-0]');
+    const activator = defaultTooltip.locator('#activator');
+
+    // Focus the activator via keyboard (tab)
+    await activator.focus();
+    await expect(page.locator('div[role=tooltip]')).toBeVisible();
+    await expect(page.locator('div[role=tooltip-content]')).toBeVisible();
+
+    // Blur should close the tooltip
+    await activator.blur();
+    await expect(page.locator('div[role=tooltip-content]')).toHaveCount(0);
+  });
+
+  test('should have aria-describedby linking activator to tooltip', async ({ page }) => {
+    const defaultTooltip = page.locator('div[data-cy=tooltip-0]');
+
+    // Initially no aria-describedby
+    await expect(defaultTooltip).not.toHaveAttribute('aria-describedby');
+
+    // Hover to open tooltip
+    await defaultTooltip.hover();
+    const tooltip = page.locator('div[role=tooltip]');
+    await expect(tooltip).toBeVisible();
+
+    // Activator wrapper should have aria-describedby matching tooltip id
+    const tooltipId = await tooltip.getAttribute('id');
+    expect(tooltipId).toBeTruthy();
+    await expect(defaultTooltip).toHaveAttribute('aria-describedby', tooltipId!);
+  });
 });

--- a/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.spec.ts
+++ b/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.spec.ts
@@ -223,6 +223,56 @@ describe('components/overlays/tooltip/RuiTooltip.vue', () => {
     expect(document.body.innerHTML).not.toMatch(new RegExp(text)); // Now hidden
   });
 
+  it('should have aria-describedby on activator when tooltip is visible', async () => {
+    wrapper = createWrapper({
+      props: {
+        text,
+      },
+    });
+
+    // Initially no aria-describedby
+    const wrapperEl = wrapper.element as HTMLElement;
+    expect(wrapperEl.getAttribute('aria-describedby')).toBeNull();
+
+    // Open tooltip
+    await wrapper.trigger('mouseover');
+    vi.advanceTimersByTime(1);
+    await flushPromises();
+
+    // Should have aria-describedby linking to tooltip
+    const describedBy = wrapperEl.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+
+    // The tooltip element should have a matching id
+    const tooltip = queryByRole<HTMLDivElement>('tooltip');
+    expect(tooltip).toBeTruthy();
+    expect(tooltip?.id).toBe(describedBy);
+
+    // Close tooltip
+    await wrapper.trigger('mouseleave');
+    vi.advanceTimersByTime(600);
+    await flushPromises();
+
+    // aria-describedby should be removed
+    expect(wrapperEl.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('should not have aria-describedby when disabled', async () => {
+    wrapper = createWrapper({
+      props: {
+        disabled: true,
+        text,
+      },
+    });
+
+    await wrapper.trigger('mouseover');
+    vi.advanceTimersByTime(1);
+    await flushPromises();
+
+    const wrapperEl = wrapper.element as HTMLElement;
+    expect(wrapperEl.getAttribute('aria-describedby')).toBeNull();
+  });
+
   it('should keep tooltip open when triggered by both hover and focus', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.vue
+++ b/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.vue
@@ -29,6 +29,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { closeDelay, openDelay, popper, disabled } = toRefs(props);
 
+const tooltipId = useId();
+
 const {
   reference: activator,
   popper: tooltip,
@@ -51,6 +53,7 @@ defineExpose({
     ref="activator"
     :class="$style.wrapper"
     :data-tooltip-disabled="disabled"
+    :aria-describedby="!disabled && open ? tooltipId : undefined"
     @mouseover="onOpen()"
     @mouseleave="onClose()"
     @focusin="onOpen()"
@@ -68,6 +71,7 @@ defineExpose({
     >
       <div
         v-if="popperEnter"
+        :id="tooltipId"
         ref="tooltip"
         :class="[
           $style.tooltip,


### PR DESCRIPTION
## Summary

- Add unique `id` (via `useId()`) on tooltip element and `aria-describedby` on activator wrapper linking to it when visible
- Expand unit tests (2 new → 10 total): aria-describedby toggling on open/close, no aria-describedby when disabled
- Expand e2e tests (2 new → 5 total): keyboard focus triggering tooltip, aria-describedby linkage verification

## Test plan

- [x] Unit tests pass (`pnpm run test:run --testNamePattern="RuiTooltip"`)
- [x] E2E tests pass (`pnpm test:e2e:dev overlays/tooltip.spec.ts`)
- [x] Lint clean
- [x] Typecheck clean