### PR TITLE
test(Menu): add e2e and unit test coverage with aria-haspopup and aria-expanded

### DIFF
--- a/apps/example/e2e/overlays/menu.spec.ts
+++ b/apps/example/e2e/overlays/menu.spec.ts
@@ -68,6 +68,70 @@ test.describe('menu', () => {
     await expect(page.locator('div[role=menu-content]')).toHaveCount(0);
   });
 
+  test('should have aria-expanded toggle on open/close', async ({ page }) => {
+    const menu = page.locator('div[data-cy=menu-0]');
+    const activatorWrapper = menu.locator('[aria-haspopup=true]');
+
+    // Initially aria-expanded should be false
+    await expect(activatorWrapper).toHaveAttribute('aria-expanded', 'false');
+
+    // Open menu
+    await menu.locator('[data-cy=activator]').click();
+    await expect(page.locator('div[role=menu-content]')).toBeVisible();
+    await expect(activatorWrapper).toHaveAttribute('aria-expanded', 'true');
+
+    // Close menu
+    await page.keyboard.press('Escape');
+    await expect(page.locator('div[role=menu-content]')).toHaveCount(0);
+    await expect(activatorWrapper).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('should close menu when clicking outside', async ({ page }) => {
+    const menu = page.locator('div[data-cy=menu-0]');
+    await menu.locator('[data-cy=activator]').click();
+    await expect(page.locator('div[role=menu-content]')).toBeVisible();
+
+    // Click outside the menu
+    await page.locator('h2[data-cy=menus]').click();
+    await expect(page.locator('div[role=menu-content]')).toHaveCount(0);
+  });
+
+  test('should not close persistent menu when clicking outside', async ({ page }) => {
+    // Persistent menu is at index 16
+    const menu = page.locator('div[data-cy=menu-16]');
+    await menu.scrollIntoViewIfNeeded();
+    await menu.locator('[data-cy=activator]').click();
+
+    const menuContent = page.locator('div[role=menu-content]');
+    await expect(menuContent).toBeVisible();
+
+    // Click outside should not close persistent menu
+    await page.locator('h2[data-cy=menus]').click();
+    await expect(menuContent).toBeVisible();
+
+    // Clicking the activator again should close it
+    await menu.locator('[data-cy=activator]').click();
+    await expect(menuContent).toHaveCount(0);
+  });
+
+  test('should focus menu content on open and return focus to activator on close', async ({ page }) => {
+    const menu = page.locator('div[data-cy=menu-0]');
+    const activator = menu.locator('[data-cy=activator]');
+
+    await activator.click();
+    await expect(page.locator('div[role=menu-content]')).toBeVisible();
+
+    // Menu content should be focused
+    await expect(page.locator('div[role=menu-content]')).toBeFocused();
+
+    // Close via Escape
+    await page.keyboard.press('Escape');
+    await expect(page.locator('div[role=menu-content]')).toHaveCount(0);
+
+    // Focus should return to the activator button
+    await expect(activator).toBeFocused();
+  });
+
   test('menu should be closed by clicking the menu content', async ({ page }) => {
     const menu = page.locator('div[data-cy=menu-12]');
     const activator = menu.locator('[data-cy=activator]');

--- a/apps/example/src/views/MenuView.vue
+++ b/apps/example/src/views/MenuView.vue
@@ -114,6 +114,13 @@ const menus = ref<SimpleMenu[]>([
     popper: { placement: 'right' },
     closeOnContentClick: true,
   },
+  {
+    disabled: false,
+    buttonText: 'Bottom (Persistent)',
+    buttonColor: 'primary',
+    popper: { placement: 'bottom' },
+    persistent: true,
+  },
 ]);
 </script>
 

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.spec.ts
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.spec.ts
@@ -261,6 +261,75 @@ describe('components/overlays/menu/RuiMenu.vue', () => {
     });
   });
 
+  it('should have aria-haspopup on activator wrapper', () => {
+    wrapper = createWrapper();
+
+    const activatorWrapper = wrapper.find('[data-menu-disabled]');
+    expect(activatorWrapper.attributes('aria-haspopup')).toBe('true');
+  });
+
+  it('should have aria-expanded="false" when closed and "true" when open', async () => {
+    wrapper = createWrapper();
+
+    const activatorWrapper = wrapper.find('[data-menu-disabled]');
+    expect(activatorWrapper.attributes('aria-expanded')).toBe('false');
+
+    // Open menu
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    expect(activatorWrapper.attributes('aria-expanded')).toBe('true');
+
+    // Close menu by clicking outside
+    document.body.click();
+    await vi.runAllTimersAsync();
+
+    expect(activatorWrapper.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('should have aria-haspopup on activator wrapper even when disabled', () => {
+    wrapper = createWrapper({
+      props: {
+        disabled: true,
+      },
+    });
+
+    const activatorWrapper = wrapper.find('[data-menu-disabled]');
+    expect(activatorWrapper.attributes('aria-haspopup')).toBe('true');
+    expect(activatorWrapper.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('should not close when persistent and clicking outside', async () => {
+    wrapper = createWrapper({
+      props: {
+        persistent: true,
+      },
+    });
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    expect(document.body.innerHTML).toMatch(new RegExp(text));
+
+    // Click outside should not close the menu
+    document.body.click();
+    await vi.runAllTimersAsync();
+
+    expect(document.body.innerHTML).toMatch(new RegExp(text));
+  });
+
+  it('should focus menu content when opened', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    // Menu content should be focused
+    const menuContent = queryByRole<HTMLElement>('menu-content');
+    assertExists(menuContent);
+    expect(document.activeElement).toBe(menuContent);
+  });
+
   it('should menu works with `closeOnContentClick=true`', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
@@ -196,6 +196,8 @@ const { hasError, hasSuccess } = useFormTextDetail(
       ref="activator"
       :class="[$style.wrapper, wrapperClass, { 'w-full': fullWidth }]"
       :data-menu-disabled="disabled"
+      aria-haspopup="true"
+      :aria-expanded="open"
     >
       <slot
         name="activator"


### PR DESCRIPTION
## Summary

- Add `aria-haspopup="true"` and `:aria-expanded` on activator wrapper to indicate menu presence and open state
- Add persistent menu example to example app view
- Expand unit tests (5 new → 13 total): aria-haspopup, aria-expanded toggling, aria attributes when disabled, persistent behavior, focus management
- Expand e2e tests (4 new → 8 total): aria-expanded state changes, outside click closing, persistent menu, focus management

## Test plan

- [x] Unit tests pass (`pnpm run test:run --testNamePattern="RuiMenu"`)
- [x] E2E tests pass (`pnpm test:e2e:dev overlays/menu.spec.ts`)
- [x] Lint clean
- [x] Typecheck clean