### PR TITLE
test(Slider): add e2e and unit test coverage with aria attributes

### DIFF
--- a/apps/example/e2e/forms/slider.spec.ts
+++ b/apps/example/e2e/forms/slider.spec.ts
@@ -20,4 +20,89 @@ test.describe('forms/Slider', () => {
 
     await expect(disabledSlider).toBeDisabled();
   });
+
+  test('should display label text', async ({ page }) => {
+    // Slider at index 2 has label "With Label"
+    const slider = page.locator('[data-cy=slider-2]');
+    await expect(slider).toContainText('With Label');
+
+    // Slider at index 0 has no label
+    const noLabelSlider = page.locator('[data-cy=slider-0]');
+    const labelDiv = noLabelSlider.locator('div[class*=label]');
+    await expect(labelDiv).toHaveCount(0);
+  });
+
+  test('should show thumb label when showThumbLabel is true', async ({ page }) => {
+    // Sliders at index 8-9 have showThumbLabel: true
+    const slider = page.locator('[data-cy=slider-8]');
+    await expect(slider).toContainText('Show Thumb Label');
+
+    const input = slider.locator('input[type="range"]');
+    // Thumb label is visible when interacting
+    await expect(input).toHaveValue('50');
+  });
+
+  test('should display hint text', async ({ page }) => {
+    // Slider at index 12 has hint "Slider hints"
+    const slider = page.locator('[data-cy=slider-12]');
+    await expect(slider).toContainText('Slider hints');
+  });
+
+  test('should display error messages', async ({ page }) => {
+    // Slider at index 14 has errorMessages
+    const slider = page.locator('[data-cy=slider-14]');
+    await expect(slider).toContainText('Slider error messages');
+
+    const input = slider.locator('input[type="range"]');
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  test('should display success messages', async ({ page }) => {
+    // Slider at index 15 has successMessages
+    const slider = page.locator('[data-cy=slider-15]');
+    await expect(slider).toContainText('Slider success messages');
+  });
+
+  test('should have aria-label on input when label is provided', async ({ page }) => {
+    // Slider at index 2 has label "With Label"
+    const input = page.locator('[data-cy=slider-2] input[type="range"]');
+    await expect(input).toHaveAttribute('aria-label', 'With Label');
+
+    // Slider at index 0 has no label, so aria-label should not be present
+    const noLabelInput = page.locator('[data-cy=slider-0] input[type="range"]');
+    await expect(noLabelInput).not.toHaveAttribute('aria-label');
+  });
+
+  test('should have aria-valuetext reflecting current value', async ({ page }) => {
+    const input = page.locator('[data-cy=slider-0] input[type="range"]');
+    await expect(input).toHaveAttribute('aria-valuetext', '50');
+
+    await input.fill('25');
+    await expect(input).toHaveAttribute('aria-valuetext', '25');
+  });
+
+  test('should not be interactable when disabled', async ({ page }) => {
+    // Slider at index 4 is disabled
+    const slider = page.locator('[data-cy=slider-4]');
+    const input = slider.locator('input[type="range"]');
+
+    await expect(input).toBeDisabled();
+    await expect(input).toHaveValue('50');
+
+    // Ticks and thumb label should not render when disabled
+    await expect(slider.locator('div[class*=slider__ticks]')).toHaveCount(0);
+    await expect(slider.locator('div[class*=slider__thumb_label]')).toHaveCount(0);
+  });
+
+  test('should update value with keyboard interaction', async ({ page }) => {
+    const input = page.locator('[data-cy=slider-0] input[type="range"]');
+    await expect(input).toHaveValue('50');
+
+    await input.focus();
+    await page.keyboard.press('ArrowRight');
+    await expect(input).toHaveValue('51');
+
+    await page.keyboard.press('ArrowLeft');
+    await expect(input).toHaveValue('50');
+  });
 });

--- a/apps/example/src/views/SliderView.vue
+++ b/apps/example/src/views/SliderView.vue
@@ -73,6 +73,7 @@ const textFields = ref<SliderData[]>([
         :key="i"
         v-model="field.value"
         :label="field.label"
+        :data-cy="`slider-${i}`"
         v-bind="field"
       />
     </div>

--- a/packages/ui-library/src/components/forms/slider/RuiSlider.spec.ts
+++ b/packages/ui-library/src/components/forms/slider/RuiSlider.spec.ts
@@ -164,6 +164,94 @@ describe('components/forms/slider/RuiSlider.vue', () => {
     expect(wrapper.find('.details div').exists()).toBeFalsy();
   });
 
+  it('should have aria-label on input when label is provided', () => {
+    wrapper = createWrapper({
+      props: {
+        label: 'Volume',
+        modelValue: 50,
+      },
+    });
+
+    expect(wrapper.find('input').attributes('aria-label')).toBe('Volume');
+  });
+
+  it('should not have aria-label on input when label is empty', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 50,
+      },
+    });
+
+    expect(wrapper.find('input').attributes('aria-label')).toBeUndefined();
+  });
+
+  it('should have aria-valuetext on input reflecting current value', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 30,
+      },
+    });
+
+    expect(wrapper.find('input').attributes('aria-valuetext')).toBe('30');
+
+    await wrapper.setProps({ modelValue: 75 });
+    expect(wrapper.find('input').attributes('aria-valuetext')).toBe('75');
+  });
+
+  it('should emit update:model-value when input value changes', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 50,
+      },
+    });
+
+    await wrapper.find('input').setValue(75);
+    expect(wrapper.emitted('update:model-value')).toBeTruthy();
+    expect(wrapper.emitted('update:model-value')![0]).toEqual(['75']);
+  });
+
+  it('should have aria-invalid when errorMessages are provided', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 50,
+      },
+    });
+
+    expect(wrapper.find('input').attributes('aria-invalid')).toBe('false');
+
+    await wrapper.setProps({ errorMessages: ['Error'] });
+    expect(wrapper.find('input').attributes('aria-invalid')).toBe('true');
+
+    await wrapper.setProps({ errorMessages: [] });
+    expect(wrapper.find('input').attributes('aria-invalid')).toBe('false');
+  });
+
+  it('should not render required asterisk when required is true but no label', () => {
+    wrapper = createWrapper({
+      props: {
+        required: true,
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('﹡');
+  });
+
+  it('should have data-error attribute when errorMessages present', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 50,
+      },
+    });
+
+    expect(wrapper.find('label').attributes('data-error')).toBeUndefined();
+
+    await wrapper.setProps({ errorMessages: ['Error'] });
+    expect(wrapper.find('label').attributes('data-error')).toBe('');
+
+    await wrapper.setProps({ errorMessages: [] });
+    expect(wrapper.find('label').attributes('data-error')).toBeUndefined();
+  });
+
   it('should show required asterisk when required prop is true', async () => {
     const label = 'Slider Label';
     wrapper = createWrapper({

--- a/packages/ui-library/src/components/forms/slider/RuiSlider.vue
+++ b/packages/ui-library/src/components/forms/slider/RuiSlider.vue
@@ -141,6 +141,8 @@ const tickSizeInPx = computed(() => `${get(tickSize)}px`);
             :step="step"
             :disabled="disabled"
             :aria-invalid="hasError"
+            :aria-label="label || undefined"
+            :aria-valuetext="String(vModel)"
             v-bind="getNonRootAttrs($attrs)"
           />
           <div :class="$style.slider">


### PR DESCRIPTION
## Summary
- Add `aria-label` and `aria-valuetext` attributes to the slider `<input>` element for screen reader accessibility
- Add 7 new unit tests covering ARIA attributes, v-model emissions, `data-error`, `aria-invalid`, and required asterisk edge case
- Add 9 new e2e tests covering label display, thumb label, hint/error/success messages, ARIA verification, disabled state, and keyboard interaction
- Add `data-cy` attributes to example SliderView for e2e targeting

## Test plan
- [x] Unit tests pass (20 total, 7 new)
- [x] E2e tests pass (10 total, 9 new)
- [x] Lint passes
- [x] Typecheck passes