### PR TITLE
test(FooterStepper): add e2e and unit test coverage with aria attributes

### DIFF
--- a/apps/example/e2e/footer-stepper.spec.ts
+++ b/apps/example/e2e/footer-stepper.spec.ts
@@ -40,4 +40,54 @@ test.describe('footer steppers', () => {
     // Use first() since there are multiple pill elements
     await expect(pillStepper.locator('div[class*=_pills_] span[class*=_pill_]').first()).toBeVisible();
   });
+
+  test('should navigate forward and backward with buttons', async ({ page }) => {
+    const stepper = page.locator('[data-cy=footer-stepper-0]');
+    await expect(stepper.locator('span[class*=_numeric_]')).toContainText('1/5');
+
+    // Back should be disabled on first page
+    const backBtn = stepper.locator('button[aria-label=Previous]');
+    const nextBtn = stepper.locator('button[aria-label=Next]');
+    await expect(backBtn).toBeDisabled();
+
+    // Navigate forward
+    await nextBtn.click();
+    await expect(stepper.locator('span[class*=_numeric_]')).toContainText('2/5');
+    await expect(backBtn).toBeEnabled();
+
+    // Navigate back
+    await backBtn.click();
+    await expect(stepper.locator('span[class*=_numeric_]')).toContainText('1/5');
+    await expect(backBtn).toBeDisabled();
+  });
+
+  test('should have role="navigation" and aria-label on root', async ({ page }) => {
+    const stepper = page.locator('[data-cy=footer-stepper-0]');
+    await expect(stepper).toHaveAttribute('role', 'navigation');
+    await expect(stepper).toHaveAttribute('aria-label', 'Step navigation');
+  });
+
+  test('should have aria-label on navigation buttons', async ({ page }) => {
+    const stepper = page.locator('[data-cy=footer-stepper-0]');
+    await expect(stepper.locator('button[aria-label=Previous]')).toBeVisible();
+    await expect(stepper.locator('button[aria-label=Next]')).toBeVisible();
+  });
+
+  test('should have aria-current="step" on active bullet', async ({ page }) => {
+    // Footer stepper at index 1 is bullet variant with value=2
+    const stepper = page.locator('[data-cy=footer-stepper-1]');
+    const activeBullet = stepper.locator('[aria-current=step]');
+    await expect(activeBullet).toHaveCount(1);
+
+    // Click Next to advance
+    await stepper.locator('button[aria-label=Next]').click();
+    const newActive = stepper.locator('[aria-current=step]');
+    await expect(newActive).toHaveCount(1);
+  });
+
+  test('should hide buttons when hideButtons is true', async ({ page }) => {
+    // Footer stepper at index 2 has hideButtons=true
+    const stepper = page.locator('[data-cy=footer-stepper-2]');
+    await expect(stepper.locator('button')).toHaveCount(0);
+  });
 });

--- a/apps/example/src/views/StepperView.vue
+++ b/apps/example/src/views/StepperView.vue
@@ -368,6 +368,7 @@ const footerSteppers = ref<FooterStepperData[]>([
       v-for="(stepper, i) in footerSteppers"
       :key="i"
       v-model="stepper.value"
+      :data-cy="`footer-stepper-${i}`"
       class="mb-6"
       v-bind="stepper"
     />

--- a/packages/ui-library/src/components/steppers/RuiFooterStepper.spec.ts
+++ b/packages/ui-library/src/components/steppers/RuiFooterStepper.spec.ts
@@ -27,6 +27,122 @@ describe('components/steppers/RuiFooterStepper.vue', () => {
     expectToHaveClass(wrapper.element, /_numeric_/);
   });
 
+  it('should have role="navigation" and aria-label on root', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 1,
+        pages: 5,
+      },
+    });
+
+    expect(wrapper.element.getAttribute('role')).toBe('navigation');
+    expect(wrapper.element.getAttribute('aria-label')).toBe('Step navigation');
+  });
+
+  it('should have aria-label on navigation buttons', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 2,
+        pages: 5,
+      },
+    });
+
+    const buttons = wrapper.findAll('button');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]!.attributes('aria-label')).toBe('Previous');
+    expect(buttons[1]!.attributes('aria-label')).toBe('Next');
+  });
+
+  it('should render correct number of pages in numeric variant', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 3,
+        pages: 5,
+      },
+    });
+
+    expect(wrapper.find('span[class*=numeric]').text()).toBe('3/5');
+  });
+
+  it('should emit update:modelValue on next and back click', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 2,
+        pages: 5,
+      },
+    });
+
+    const buttons = wrapper.findAll('button');
+
+    // Click Next
+    await buttons[1]!.trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([3]);
+
+    // Click Back
+    await buttons[0]!.trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([1]);
+  });
+
+  it('should disable Back button on first page and Next on last page', async () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 1,
+        pages: 3,
+      },
+    });
+
+    const buttons = wrapper.findAll('button');
+    expect(buttons[0]!.attributes('disabled')).toBeDefined();
+    expect(buttons[1]!.attributes('disabled')).toBeUndefined();
+
+    await wrapper.setProps({ modelValue: 3 });
+    expect(buttons[0]!.attributes('disabled')).toBeUndefined();
+    expect(buttons[1]!.attributes('disabled')).toBeDefined();
+  });
+
+  it('should have aria-current="step" on active bullet', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 2,
+        pages: 5,
+        variant: 'bullet',
+      },
+    });
+
+    const bullets = wrapper.findAll('div[class*=bullets] span');
+    expect(bullets).toHaveLength(5);
+    expect(bullets[1]!.attributes('aria-current')).toBe('step');
+    expect(bullets[0]!.attributes('aria-current')).toBeUndefined();
+  });
+
+  it('should have aria-current="step" on active pill', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 4,
+        pages: 5,
+        variant: 'pill',
+      },
+    });
+
+    const pills = wrapper.findAll('div[class*=pills] span');
+    expect(pills).toHaveLength(5);
+    expect(pills[3]!.attributes('aria-current')).toBe('step');
+    expect(pills[0]!.attributes('aria-current')).toBeUndefined();
+  });
+
+  it('should hide buttons when hideButtons is true', () => {
+    wrapper = createWrapper({
+      props: {
+        modelValue: 1,
+        pages: 5,
+        hideButtons: true,
+        variant: 'bullet',
+      },
+    });
+
+    expect(wrapper.findAll('button')).toHaveLength(0);
+  });
+
   it('should pass props correctly', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/steppers/RuiFooterStepper.vue
+++ b/packages/ui-library/src/components/steppers/RuiFooterStepper.vue
@@ -50,12 +50,17 @@ function onClick(index: number) {
 </script>
 
 <template>
-  <div :class="[$style['footer-stepper'], $style[variant ?? '']]">
+  <div
+    role="navigation"
+    aria-label="Step navigation"
+    :class="[$style['footer-stepper'], $style[variant ?? '']]"
+  >
     <template v-if="variant === 'pill'">
       <div :class="$style.pills">
         <span
           v-for="i in pages"
           :key="i"
+          :aria-current="modelValue === i ? 'step' : undefined"
           :class="[$style.pill, { [$style.active]: modelValue === i }]"
         />
       </div>
@@ -63,6 +68,7 @@ function onClick(index: number) {
     <template v-else>
       <RuiButton
         v-if="!hideButtons"
+        aria-label="Previous"
         :class="{ [$style.arrow__button]: arrowButtons }"
         :disabled="modelValue <= 1"
         :icon="arrowButtons"
@@ -99,6 +105,7 @@ function onClick(index: number) {
         <span
           v-for="i in pages"
           :key="i"
+          :aria-current="modelValue === i ? 'step' : undefined"
           :class="[$style.bullet, { [$style.active]: modelValue === i }]"
           @click="onClick(i)"
         />
@@ -111,6 +118,7 @@ function onClick(index: number) {
       />
       <RuiButton
         v-if="!hideButtons"
+        aria-label="Next"
         :class="{ [$style.arrow__button]: arrowButtons }"
         :disabled="modelValue >= pages"
         :icon="arrowButtons"


### PR DESCRIPTION
## Summary
- Add `role="navigation"` and `aria-label="Step navigation"` on root element
- Add `aria-label="Previous"` and `aria-label="Next"` on navigation buttons
- Add `aria-current="step"` on active bullet and pill indicators
- Add 8 new unit tests covering ARIA attributes, navigation, page display, button disable states, hideButtons, and variant indicators
- Add 5 new e2e tests covering navigation, ARIA verification, active bullet tracking, and hideButtons
- Add `data-cy` attributes to example StepperView for e2e targeting

## Test plan
- [x] Unit tests pass (10 total, 8 new)
- [x] E2e tests pass (6 total, 5 new)
- [x] Lint passes
- [x] Typecheck passes