### PR TITLE
test(Stepper): add e2e and unit test coverage with aria attributes

### DIFF
--- a/apps/example/e2e/stepper.spec.ts
+++ b/apps/example/e2e/stepper.spec.ts
@@ -8,9 +8,59 @@ test.describe('steppers', () => {
   test('should render stepper with correct states', async ({ page }) => {
     await expect(page.locator('h2[data-cy=steppers]')).toContainText('Steppers');
 
-    const horizontalStepper = page.locator('div[class*=_stepper]').first();
+    const horizontalStepper = page.locator('[data-cy=stepper-0]');
 
     await expect(horizontalStepper.locator('div[class*=_step][class*=_inactive]')).toContainText('Inactive');
     await expect(horizontalStepper.locator('div[class*=_step][class*=_success]')).toContainText('Success');
+  });
+
+  test('should have role="list" and aria-label on stepper', async ({ page }) => {
+    const stepper = page.locator('[data-cy=stepper-0]');
+    await expect(stepper).toHaveAttribute('role', 'list');
+    await expect(stepper).toHaveAttribute('aria-label', 'Progress steps');
+  });
+
+  test('should have role="listitem" on each step', async ({ page }) => {
+    const stepper = page.locator('[data-cy=stepper-0]');
+    const items = stepper.locator('[role=listitem]');
+
+    // First stepper has 7 steps
+    await expect(items).toHaveCount(7);
+  });
+
+  test('should have aria-current="step" on active step', async ({ page }) => {
+    const stepper = page.locator('[data-cy=stepper-0]');
+    const activeStep = stepper.locator('[aria-current=step]');
+
+    await expect(activeStep).toHaveCount(1);
+    await expect(activeStep).toContainText('Active');
+  });
+
+  test('should render vertical stepper', async ({ page }) => {
+    // Stepper at index 1 is vertical
+    const stepper = page.locator('[data-cy=stepper-1]');
+    await expect(stepper).toBeVisible();
+
+    const items = stepper.locator('[role=listitem]');
+    await expect(items).toHaveCount(7);
+  });
+
+  test('should render icon-top stepper', async ({ page }) => {
+    // Stepper at index 2 has iconTop=true
+    const stepper = page.locator('[data-cy=stepper-2]');
+    await expect(stepper).toBeVisible();
+
+    const items = stepper.locator('[role=listitem]');
+    await expect(items).toHaveCount(7);
+  });
+
+  test('should render custom stepper variant', async ({ page }) => {
+    // Stepper at index 4 has custom=true
+    const stepper = page.locator('[data-cy=stepper-4]');
+    await expect(stepper).toBeVisible();
+
+    const items = stepper.locator('[role=listitem]');
+    await expect(items).toHaveCount(3);
+    await expect(stepper).toHaveAttribute('role', 'list');
   });
 });

--- a/apps/example/src/views/StepperView.vue
+++ b/apps/example/src/views/StepperView.vue
@@ -355,6 +355,7 @@ const footerSteppers = ref<FooterStepperData[]>([
     <RuiStepper
       v-for="(stepper, i) in steppers"
       :key="i"
+      :data-cy="`stepper-${i}`"
       class="mb-6"
       v-bind="stepper"
     />

--- a/packages/ui-library/src/components/steppers/RuiStepper.spec.ts
+++ b/packages/ui-library/src/components/steppers/RuiStepper.spec.ts
@@ -1,5 +1,5 @@
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
-import { afterEach, describe, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import RuiStepper from '@/components/steppers/RuiStepper.vue';
 import { StepperOrientation, StepperState, type StepperStep } from '@/types/stepper';
 import { expectToHaveClass } from '~/tests/helpers/dom-helpers';
@@ -26,6 +26,115 @@ describe('components/steppers/RuiStepper.vue', () => {
   it('should render properly', () => {
     wrapper = createWrapper({ props: { steps } });
     expectToHaveClass(wrapper.element, /_stepper_/);
+  });
+
+  it('should have role="list" and aria-label on root', () => {
+    wrapper = createWrapper({ props: { steps } });
+
+    expect(wrapper.element.getAttribute('role')).toBe('list');
+    expect(wrapper.element.getAttribute('aria-label')).toBe('Progress steps');
+  });
+
+  it('should have role="listitem" on each step', () => {
+    wrapper = createWrapper({ props: { steps } });
+
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items).toHaveLength(3);
+  });
+
+  it('should have aria-current="step" on active step only', () => {
+    wrapper = createWrapper({ props: { steps } });
+
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items[0]!.attributes('aria-current')).toBeUndefined(); // done
+    expect(items[1]!.attributes('aria-current')).toBe('step'); // active
+    expect(items[2]!.attributes('aria-current')).toBeUndefined(); // inactive
+  });
+
+  it('should render all step states', () => {
+    const allStates: StepperStep[] = [
+      { title: 'Inactive', state: StepperState.inactive },
+      { title: 'Active', state: StepperState.active },
+      { title: 'Done', state: StepperState.done },
+      { title: 'Error', state: StepperState.error },
+      { title: 'Warning', state: StepperState.warning },
+      { title: 'Info', state: StepperState.info },
+      { title: 'Success', state: StepperState.success },
+    ];
+
+    wrapper = createWrapper({ props: { steps: allStates } });
+
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items).toHaveLength(7);
+    expectToHaveClass(items[0]!.element, /_inactive_/);
+    expectToHaveClass(items[1]!.element, /_active_/);
+    expectToHaveClass(items[2]!.element, /_done_/);
+    expectToHaveClass(items[3]!.element, /_error_/);
+    expectToHaveClass(items[4]!.element, /_warning_/);
+    expectToHaveClass(items[5]!.element, /_info_/);
+    expectToHaveClass(items[6]!.element, /_success_/);
+  });
+
+  it('should auto-assign step states when step prop is provided', () => {
+    const plainSteps: StepperStep[] = [
+      { title: 'Step 1' },
+      { title: 'Step 2' },
+      { title: 'Step 3' },
+    ];
+
+    wrapper = createWrapper({ props: { steps: plainSteps, step: 2 } });
+
+    const items = wrapper.findAll('[role="listitem"]');
+    expectToHaveClass(items[0]!.element, /_done_/);
+    expectToHaveClass(items[1]!.element, /_active_/);
+    expect(items[1]!.attributes('aria-current')).toBe('step');
+    expectToHaveClass(items[2]!.element, /_inactive_/);
+  });
+
+  it('should render vertical orientation', () => {
+    wrapper = createWrapper({
+      props: { steps, orientation: StepperOrientation.vertical },
+    });
+
+    expectToHaveClass(wrapper.element, /_vertical_/);
+  });
+
+  it('should render custom stepper variant', () => {
+    wrapper = createWrapper({
+      props: { steps, custom: true },
+    });
+
+    expectToHaveClass(wrapper.element, /_custom_/);
+  });
+
+  it('should apply titleClass and subtitleClass when custom', () => {
+    wrapper = createWrapper({
+      props: {
+        steps,
+        custom: true,
+        titleClass: 'text-rui-primary',
+        subtitleClass: 'text-rui-info',
+      },
+    });
+
+    const firstStep = wrapper.findAll('[role="listitem"]')[0]!;
+    const label = firstStep.find('div[class*=label]');
+    const spans = label.findAll('span');
+    expect(spans[0]!.classes()).toContain('text-rui-primary');
+    expect(spans[1]!.classes()).toContain('text-rui-info');
+  });
+
+  it('should render loading indicator on step', () => {
+    const loadingSteps: StepperStep[] = [
+      { title: 'Loading', state: StepperState.active, loading: true },
+      { title: 'Idle', state: StepperState.inactive },
+    ];
+
+    wrapper = createWrapper({ props: { steps: loadingSteps } });
+
+    const items = wrapper.findAll('[role="listitem"]');
+    expect(items[0]!.find('[class*=indeterminate]').exists()).toBeTruthy();
+    expect(items[1]!.find('[class*=indeterminate]').exists()).toBeFalsy();
   });
 
   it('should pass props correctly', async () => {

--- a/packages/ui-library/src/components/steppers/RuiStepper.vue
+++ b/packages/ui-library/src/components/steppers/RuiStepper.vue
@@ -85,6 +85,8 @@ watch(step, () => {
 <template>
   <div
     ref="wrapperRef"
+    role="list"
+    aria-label="Progress steps"
     :class="[
       $style.stepper,
       $style[orientation ?? ''],
@@ -101,6 +103,8 @@ watch(step, () => {
         :class="$style.divider"
       />
       <div
+        role="listitem"
+        :aria-current="state === StepperState.active ? 'step' : undefined"
         :class="[
           $style.step,
           $style[state ?? StepperState.inactive],


### PR DESCRIPTION
## Summary
- Add ARIA attributes to `RuiStepper`: `role="list"`, `aria-label="Progress steps"` on root, `role="listitem"` on each step, `aria-current="step"` on active step
- Add 9 new unit tests covering: ARIA attributes, all step states, auto-assign via step prop, vertical/horizontal orientation, custom variant, titleClass/subtitleClass, loading indicator
- Add 7 e2e tests covering: step state rendering, ARIA attributes, vertical/icon-top/custom stepper variants
- Add `data-cy` attributes to StepperView for e2e targeting

## Test plan
- [x] Unit tests pass (11 total)
- [x] E2E tests pass (7 stepper tests)
- [x] Lint passes
- [x] Typecheck passes