### PR TITLE
test(Tabs): add e2e and unit test coverage with aria-selected and role attributes

### DIFF
--- a/apps/example/e2e/tabs.spec.ts
+++ b/apps/example/e2e/tabs.spec.ts
@@ -28,4 +28,66 @@ test.describe('tabs', () => {
     await tablist.locator('a:last-child').click();
     await expect(page).toHaveURL(/\/steppers/);
   });
+
+  test('should have role="tablist" on tab container', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    await expect(tablist).toBeVisible();
+  });
+
+  test('should have role="tab" on each tab button', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const tabs = wrapper.locator('[data-cy=tabs] [role=tab]');
+    await expect(tabs).toHaveCount(6);
+  });
+
+  test('should have aria-selected on active tab', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+
+    // First tab is active by default
+    await expect(tablist.locator('[role=tab]:first-child')).toHaveAttribute('aria-selected', 'true');
+    await expect(tablist.locator('[role=tab]:nth-child(3)')).toHaveAttribute('aria-selected', 'false');
+
+    // Click third tab
+    await tablist.locator('[role=tab]:nth-child(3)').click();
+    await expect(tablist.locator('[role=tab]:first-child')).toHaveAttribute('aria-selected', 'false');
+    await expect(tablist.locator('[role=tab]:nth-child(3)')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('should have role="tabpanel" on tab content items', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const panels = wrapper.locator('[data-cy=tab-items] [role=tabpanel]');
+    await expect(panels.first()).toBeVisible();
+  });
+
+  test('should render vertical tabs', async ({ page }) => {
+    // wrapper-1 is the first vertical tab set (primary color, vertical=true)
+    const wrapper = page.locator('[data-cy=wrapper-1]');
+    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    await expect(tablist).toBeVisible();
+
+    const tabs = wrapper.locator('[data-cy=tabs] [role=tab]');
+    await expect(tabs).toHaveCount(6);
+  });
+
+  test('should switch content when clicking different tabs', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    const tabcontent = wrapper.locator('[data-cy=tab-items]');
+
+    await expect(tabcontent).toHaveText('Tab 1 Content');
+
+    // Click tab 3
+    await tablist.locator('[role=tab]:nth-child(3)').click();
+    await expect(tabcontent).toHaveText('Tab 3 Content');
+
+    // Click tab 4
+    await tablist.locator('[role=tab]:nth-child(4)').click();
+    await expect(tabcontent).toHaveText('Tab 4 Content');
+
+    // Click back to tab 1
+    await tablist.locator('[role=tab]:first-child').click();
+    await expect(tabcontent).toHaveText('Tab 1 Content');
+  });
 });

--- a/packages/ui-library/src/components/tabs/tab-item/RuiTabItem.spec.ts
+++ b/packages/ui-library/src/components/tabs/tab-item/RuiTabItem.spec.ts
@@ -33,6 +33,11 @@ describe('components/tabs/tab-item/RuiTabItem.vue', () => {
     wrapper?.unmount();
   });
 
+  it('should have role="tabpanel" on root', () => {
+    wrapper = createWrapper();
+    expect(wrapper.element.getAttribute('role')).toBe('tabpanel');
+  });
+
   it('should not render if not active', () => {
     wrapper = createWrapper();
 

--- a/packages/ui-library/src/components/tabs/tab-item/RuiTabItem.vue
+++ b/packages/ui-library/src/components/tabs/tab-item/RuiTabItem.vue
@@ -19,7 +19,10 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <div :class="[$style.tab, { 'active-tab-item': active }]">
+  <div
+    role="tabpanel"
+    :class="[$style.tab, { 'active-tab-item': active }]"
+  >
     <Transition
       :enter-from-class="`opacity-0 ${reverse ? '-translate-x-8' : 'translate-x-8'}`"
       :leave-to-class="`opacity-0 !h-0 overflow-hidden ${

--- a/packages/ui-library/src/components/tabs/tab/RuiTab.spec.ts
+++ b/packages/ui-library/src/components/tabs/tab/RuiTab.spec.ts
@@ -125,6 +125,46 @@ describe('components/tabs/tab/RuiTab.vue', () => {
     expect(elem.attributes().href).toBeDefined();
   });
 
+  it('should have role="tab" on button', () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('button').attributes('role')).toBe('tab');
+  });
+
+  it('should have aria-selected="false" when not active', () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('button').attributes('aria-selected')).toBe('false');
+  });
+
+  it('should have aria-selected="true" when active', () => {
+    wrapper = createWrapper({ props: { active: true } });
+    expect(wrapper.find('button').attributes('aria-selected')).toBe('true');
+  });
+
+  it('should have aria-selected on disabled tab', () => {
+    wrapper = createWrapper({ props: { disabled: true } });
+    expect(wrapper.find('button').attributes('aria-selected')).toBe('false');
+    expect(wrapper.find('button').attributes('role')).toBe('tab');
+  });
+
+  it('should have role="tab" on link tab', () => {
+    wrapper = createWrapper({
+      props: { link: true, to: '/tabs' },
+    });
+    const link = wrapper.find('a');
+    expect(link.attributes('role')).toBe('tab');
+  });
+
+  it('should update aria-selected when active changes', async () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('button').attributes('aria-selected')).toBe('false');
+
+    await wrapper.setProps({ active: true });
+    expect(wrapper.find('button').attributes('aria-selected')).toBe('true');
+
+    await wrapper.setProps({ active: false });
+    expect(wrapper.find('button').attributes('aria-selected')).toBe('false');
+  });
+
   it('should set tabindex to -1 for all tab variations', async () => {
     // Test disabled tab
     let wrapper = createWrapper({

--- a/packages/ui-library/src/components/tabs/tab/RuiTab.vue
+++ b/packages/ui-library/src/components/tabs/tab/RuiTab.vue
@@ -86,6 +86,7 @@ function click() {
     hide-focus-indicator
     tabindex="-1"
     role="tab"
+    :aria-selected="active"
     v-bind="$attrs"
   >
     <template
@@ -103,6 +104,7 @@ function click() {
     :class="tabClass"
     :color="active ? color : undefined"
     role="tab"
+    :aria-selected="active"
     v-bind="$attrs"
     tabindex="-1"
     hide-focus-indicator
@@ -140,6 +142,7 @@ function click() {
       :href="isSelf ? undefined : href"
       :target="target"
       role="tab"
+      :aria-selected="active || (exact ? isExactActive : isActive)"
       no-outline
       tag="a"
       hide-focus-indicator

--- a/packages/ui-library/src/components/tabs/tabs/RuiTabs.spec.ts
+++ b/packages/ui-library/src/components/tabs/tabs/RuiTabs.spec.ts
@@ -174,4 +174,56 @@ describe('components/tabs/tabs/RuiTabs.vue', () => {
     assertExists(button0);
     expectToHaveClass(button0.element, /active-tab/);
   });
+
+  it('should have role="tablist" on tab container', () => {
+    wrapper = createWrapper();
+
+    const tablist = wrapper.find('[role="tablist"]');
+    expect(tablist.exists()).toBeTruthy();
+  });
+
+  it('should have role="tab" on each tab', async () => {
+    wrapper = createWrapper();
+
+    await nextTick();
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs).toHaveLength(4);
+  });
+
+  it('should have aria-selected on active tab only', async () => {
+    wrapper = createWrapper();
+
+    await nextTick();
+
+    const tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs[0]!.attributes('aria-selected')).toBe('true');
+    expect(tabs[1]!.attributes('aria-selected')).toBe('false');
+    expect(tabs[2]!.attributes('aria-selected')).toBe('false');
+    expect(tabs[3]!.attributes('aria-selected')).toBe('false');
+  });
+
+  it('should update aria-selected when tab changes', async () => {
+    const modelValue = ref<number>();
+    wrapper = createWrapper({
+      props: {
+        'modelValue': get(modelValue),
+        'onUpdate:modelValue': (e: any) => set(modelValue, e),
+      },
+    });
+
+    await nextTick();
+
+    let tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs[0]!.attributes('aria-selected')).toBe('true');
+
+    const button2 = tabs[2];
+    assertExists(button2);
+    await button2.trigger('click');
+    await nextTick();
+
+    tabs = wrapper.findAll('[role="tab"]');
+    expect(tabs[0]!.attributes('aria-selected')).toBe('false');
+    expect(tabs[2]!.attributes('aria-selected')).toBe('true');
+  });
 });


### PR DESCRIPTION
## Summary
- Add `aria-selected` to `RuiTab` for all three tab variants (button, disabled, link)
- Add `role="tabpanel"` to `RuiTabItem` content wrapper
- Add 11 new unit tests across tab components: `role="tablist"` on container, `role="tab"` on tabs (button/disabled/link), `aria-selected` toggle on active/inactive tabs, `aria-selected` reactivity, `role="tabpanel"` on tab content
- Add 6 new e2e tests: tablist/tab roles, aria-selected toggle on click, tabpanel role, vertical tabs, content switching

## Test plan
- [x] Unit tests pass (30 total across 4 tab components)
- [x] E2E tests pass (7 total)
- [x] Lint passes
- [x] Typecheck passes