### PR TITLE
test(Accordion): add e2e and unit test coverage for aria-expanded and data-state

### DIFF
--- a/apps/example/e2e/accordions.spec.ts
+++ b/apps/example/e2e/accordions.spec.ts
@@ -39,4 +39,73 @@ test.describe('accordions', () => {
     await expect(accordions).not.toContainText('Accordion 1 Content');
     await expect(accordions).toContainText('Accordion 2 Content');
   });
+
+  test('should toggle aria-expanded on click', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const accordions = wrapper.locator('[data-cy=accordions]');
+    const trigger = accordions.locator('div:first-child [data-accordion-trigger]');
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Click second to close first (single mode)
+    await accordions.locator('div:nth-child(2) [data-accordion-trigger]').click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('should collapse accordion when clicking expanded header', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const accordions = wrapper.locator('[data-cy=accordions]');
+    const trigger = accordions.locator('div:first-child [data-accordion-trigger]');
+
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(accordions).toContainText('Accordion 1 Content');
+
+    // Click same header again to collapse
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(accordions).not.toContainText('Accordion 1 Content');
+  });
+
+  test('should have data-state attribute on accordion', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const accordions = wrapper.locator('[data-cy=accordions]');
+    const accordion = accordions.locator('> [data-accordion]').first();
+
+    await expect(accordion).toHaveAttribute('data-state', 'closed');
+
+    await accordion.locator('[data-accordion-trigger]').click();
+    await expect(accordion).toHaveAttribute('data-state', 'open');
+  });
+
+  test('should have role="button" and aria-controls on trigger', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const trigger = wrapper.locator('[data-cy=accordions] div:first-child [data-accordion-trigger]');
+
+    await expect(trigger).toHaveAttribute('role', 'button');
+    await expect(trigger).toHaveAttribute('tabindex', '0');
+    await expect(trigger).toHaveAttribute('aria-controls');
+  });
+
+  test('should have role="region" on content with aria-labelledby', async ({ page }) => {
+    const wrapper = page.locator('[data-cy=wrapper-0]');
+    const accordions = wrapper.locator('[data-cy=accordions]');
+    const trigger = accordions.locator('div:first-child [data-accordion-trigger]');
+
+    // Open accordion to reveal content
+    await trigger.click();
+
+    const content = accordions.locator('div:first-child [data-accordion-content]');
+    await expect(content).toHaveAttribute('role', 'region');
+    await expect(content).toHaveAttribute('aria-labelledby');
+
+    // Verify aria-controls matches content id
+    const triggerId = await trigger.getAttribute('id');
+    const contentId = await content.getAttribute('id');
+    await expect(trigger).toHaveAttribute('aria-controls', contentId!);
+    await expect(content).toHaveAttribute('aria-labelledby', triggerId!);
+  });
 });

--- a/packages/ui-library/src/components/accordions/accordion/RuiAccordion.spec.ts
+++ b/packages/ui-library/src/components/accordions/accordion/RuiAccordion.spec.ts
@@ -93,6 +93,42 @@ describe('components/accordions/accordion/RuiAccordion.vue', () => {
     expect(content.attributes('aria-labelledby')).toBe(trigger.attributes('id'));
   });
 
+  it('should have aria-expanded="false" when closed', () => {
+    wrapper = createWrapper();
+
+    const trigger = wrapper.find('[data-accordion-trigger]');
+    expect(trigger.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('should update aria-expanded when open changes', async () => {
+    wrapper = createWrapper();
+
+    const trigger = wrapper.find('[data-accordion-trigger]');
+    expect(trigger.attributes('aria-expanded')).toBe('false');
+
+    await wrapper.setProps({ open: true });
+    expect(trigger.attributes('aria-expanded')).toBe('true');
+
+    await wrapper.setProps({ open: false });
+    expect(trigger.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('should have data-state attribute reflecting open state', async () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-accordion]').attributes('data-state')).toBe('closed');
+
+    await wrapper.setProps({ open: true });
+    expect(wrapper.find('[data-accordion]').attributes('data-state')).toBe('open');
+  });
+
+  it('should emit click on trigger click', async () => {
+    wrapper = createWrapper();
+
+    await wrapper.find('[data-accordion-trigger]').trigger('click');
+    expect(wrapper.emitted('click')).toHaveLength(1);
+  });
+
   it('should toggle on keyboard events', async () => {
     wrapper = createWrapper();
 


### PR DESCRIPTION
## Summary
- Add 4 new unit tests for `RuiAccordion`: `aria-expanded="false"` when closed, `aria-expanded` reactivity on open change, `data-state` attribute toggle, click emit on trigger
- Add 5 new e2e tests: `aria-expanded` toggle on click, collapse on re-click, `data-state` attribute, `role="button"` with `aria-controls` on trigger, `role="region"` with `aria-labelledby` on content (verifying id cross-references)
- No ARIA changes needed — component already had comprehensive accessibility attributes

## Test plan
- [x] Unit tests pass (12 total: 9 RuiAccordion, 3 RuiAccordions)
- [x] E2E tests pass (7 total)
- [x] Lint passes
- [x] Typecheck passes