### PR TITLE
refactor(storybook): migrate all stories to CSF Next

### DIFF
--- a/packages/ui-library/.storybook/preview.ts
+++ b/packages/ui-library/.storybook/preview.ts
@@ -1,4 +1,4 @@
-import { type Preview, setup } from '@storybook/vue3-vite';
+import { definePreview, setup } from '@storybook/vue3-vite';
 import { useEffect, useGlobals } from 'storybook/preview-api';
 import { useRotkiTheme } from '@/composables/theme';
 import { RuiPlugin } from './rui';
@@ -10,7 +10,8 @@ setup((app) => {
   app.use(RuiPlugin);
 });
 
-const preview: Preview = {
+export default definePreview({
+  addons: [],
   parameters: {
     controls: {
       matchers: {
@@ -48,6 +49,4 @@ const preview: Preview = {
 
     return story();
   }],
-};
-
-export default preview;
+});

--- a/packages/ui-library/scripts/new-story.ts
+++ b/packages/ui-library/scripts/new-story.ts
@@ -64,30 +64,31 @@ describe('${directory}/${componentName}', () => {
 
   fs.writeFileSync(
     storyFile,
-    `import ${componentName} from './${componentName}.vue';
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+    `import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import ${componentName} from './${componentName}.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<typeof ${componentName}> = args => ({
-  components: { ${componentName} },
-  setup() {
-    return { args };
-  },
-  template: \`<${componentName} v-bind="args" />\`,
-});
+function render(args: ComponentPropsAndSlots<typeof ${componentName}>) {
+  return {
+    components: { ${componentName} },
+    setup() {
+      return { args };
+    },
+    template: \`<${componentName} v-bind="args" />\`,
+  };
+}
 
-const meta: Meta<typeof ${componentName}> = {
+const meta = preview.meta({
   argTypes: {},
   component: ${componentName},
   render,
   tags: ['autodocs'],
   title: 'Components/${directory.split(path.sep).map(x => pascalCase(x)).join('/')}/${componentName}',
-};
+});
 
-type Story = StoryObj<typeof ${componentName}>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
 export default meta;
 `,

--- a/packages/ui-library/src/components/accordions/accordions/RuiAccordions.stories.ts
+++ b/packages/ui-library/src/components/accordions/accordions/RuiAccordions.stories.ts
@@ -1,46 +1,50 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiAccordion from '@/components/accordions/accordion/RuiAccordion.vue';
-import RuiAccordions, { type Props as AccordionsProps } from '@/components/accordions/accordions/RuiAccordions.vue';
+import RuiAccordions from '@/components/accordions/accordions/RuiAccordions.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<AccordionsProps> = args => ({
-  components: { RuiAccordion, RuiAccordions },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiAccordions>) {
+  return {
+    components: { RuiAccordion, RuiAccordions },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `
-    <div>
-      <RuiAccordions v-bind="args" v-model='modelValue'>
-        <RuiAccordion>
-          <template #header>
-            Accordion 1 header
-          </template>
-          <template #default>
-            Accordion 1 content
-          </template>
-        </RuiAccordion>
-        <RuiAccordion eager>
-          <template #header>
-            Accordion 2 header
-          </template>
-          <template #default>
-            Accordion 2 content
-          </template>
-        </RuiAccordion>
-      </RuiAccordions>
-    </div>
-  `,
-});
+      return { args, modelValue };
+    },
+    template: `
+      <div>
+        <RuiAccordions v-bind="args" v-model='modelValue'>
+          <RuiAccordion>
+            <template #header>
+              Accordion 1 header
+            </template>
+            <template #default>
+              Accordion 1 content
+            </template>
+          </RuiAccordion>
+          <RuiAccordion eager>
+            <template #header>
+              Accordion 2 header
+            </template>
+            <template #default>
+              Accordion 2 content
+            </template>
+          </RuiAccordion>
+        </RuiAccordions>
+      </div>
+    `,
+  };
+}
 
-const meta: Meta<AccordionsProps> = {
+const meta = preview.meta({
   argTypes: {
     modelValue: { control: 'text' },
     multiple: { control: 'boolean', table: { category: 'State' } },
@@ -49,18 +53,16 @@ const meta: Meta<AccordionsProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Accordions',
-};
+});
 
-type Story = StoryObj<AccordionsProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Multiple: Story = {
+export const Multiple = meta.story({
   args: {
     multiple: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/alerts/RuiAlert.stories.ts
+++ b/packages/ui-library/src/components/alerts/RuiAlert.stories.ts
@@ -1,18 +1,21 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiAlert, { type Props } from '@/components/alerts/RuiAlert.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiAlert from '@/components/alerts/RuiAlert.vue';
 import { contextColors } from '@/consts/colors';
 import { RuiIcons } from '@/icons';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiAlert },
-  setup() {
-    return { args };
-  },
-  template: `
-    <RuiAlert v-bind="args" class="w-[400px]" />`,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiAlert>) {
+  return {
+    components: { RuiAlert },
+    setup() {
+      return { args };
+    },
+    template: `
+      <RuiAlert v-bind="args" class="w-[400px]" />`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     actionText: { control: 'text' },
     description: { control: 'text' },
@@ -32,74 +35,72 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Alert',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
   },
-};
+});
 
-export const Error: Story = {
+export const Error = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
     type: 'error',
   },
-};
+});
 
-export const Warning: Story = {
+export const Warning = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
     type: 'warning',
   },
-};
+});
 
-export const Info: Story = {
+export const Info = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
     type: 'info',
   },
-};
+});
 
-export const Success: Story = {
+export const Success = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
     type: 'success',
   },
-};
+});
 
-export const Filled: Story = {
+export const Filled = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
     type: 'error',
     variant: 'filled',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     description: 'Description',
     title: 'Title',
     type: 'error',
     variant: 'outlined',
   },
-};
+});
 
-export const WithActionButton: Story = {
+export const WithActionButton = meta.story({
   args: {
     actionText: 'Action',
     description: 'Description',
     title: 'Title',
     type: 'error',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.stories.ts
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.stories.ts
@@ -1,18 +1,18 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiButtonGroup, { type Props as ButtonProps } from '@/components/buttons/button-group/RuiButtonGroup.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiButtonGroup from '@/components/buttons/button-group/RuiButtonGroup.vue';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type Props = ButtonProps<string | number>;
-
-const render: StoryFn<Props> = args => ({
-  components: { RuiButton, RuiButtonGroup, RuiIcon },
-  setup() {
-    const count = ref(0);
-    return { args, count };
-  },
-  template: `
+function render(args: ComponentPropsAndSlots<typeof RuiButtonGroup<string | number>>) {
+  return {
+    components: { RuiButton, RuiButtonGroup, RuiIcon },
+    setup() {
+      const count = ref(0);
+      return { args, count };
+    },
+    template: `
     <div v-if="'modelValue' in args">
       <RuiButtonGroup v-bind="args" v-model="args.modelValue">
         <RuiButton>
@@ -41,9 +41,10 @@ const render: StoryFn<Props> = args => ({
       <div class="mt-4 text-rui-text">Count: {{ count }}</div>
     </div>
   `,
-});
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     activeColor: { control: 'select', options: contextColors },
     color: { control: 'select', options: contextColors },
@@ -56,156 +57,154 @@ const meta: Meta<Props> = {
     },
     vertical: { control: 'boolean' },
   },
-  component: RuiButtonGroup as any,
+  component: RuiButtonGroup<string | number>,
   render,
   tags: ['autodocs'],
   title: 'Components/Button/ButtonGroup',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Vertical: Story = {
+export const Vertical = meta.story({
   args: {
     vertical: true,
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
   },
-};
+});
 
-export const SmallGap: Story = {
+export const SmallGap = meta.story({
   args: {
     gap: 'sm',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     variant: 'outlined',
   },
-};
+});
 
-export const Text: Story = {
+export const Text = meta.story({
   args: {
     variant: 'text',
   },
-};
+});
 
-export const DefaultToggle: Story = {
+export const DefaultToggle = meta.story({
   args: {
     color: 'primary',
     modelValue: 0,
   },
-};
+});
 
-export const ToggleRequired: Story = {
+export const ToggleRequired = meta.story({
   args: {
     color: 'primary',
     modelValue: 0,
     required: true,
   },
-};
+});
 
-export const VerticalToggle: Story = {
+export const VerticalToggle = meta.story({
   args: {
     color: 'primary',
     modelValue: 0,
     vertical: true,
   },
-};
+});
 
-export const Toggle: Story = {
+export const Toggle = meta.story({
   args: {
     color: 'primary',
     modelValue: 0,
   },
-};
+});
 
-export const OutlinedToggle: Story = {
+export const OutlinedToggle = meta.story({
   args: {
     color: 'primary',
     modelValue: 0,
     variant: 'outlined',
   },
-};
+});
 
-export const TextToggle: Story = {
+export const TextToggle = meta.story({
   args: {
     color: 'primary',
     modelValue: 0,
     variant: 'text',
   },
-};
+});
 
-export const ActiveColorToggle: Story = {
+export const ActiveColorToggle = meta.story({
   args: {
     activeColor: 'warning',
     color: 'primary',
     modelValue: 0,
     variant: 'text',
   },
-};
+});
 
-export const DefaultToggleMultiple: Story = {
+export const DefaultToggleMultiple = meta.story({
   args: {
     color: 'primary',
     modelValue: [0],
   },
-};
+});
 
-export const ToggleMultipleRequired: Story = {
+export const ToggleMultipleRequired = meta.story({
   args: {
     color: 'primary',
     modelValue: [0],
     required: true,
   },
-};
+});
 
-export const VerticalToggleMultiple: Story = {
+export const VerticalToggleMultiple = meta.story({
   args: {
     color: 'primary',
     modelValue: [0],
     vertical: true,
   },
-};
+});
 
-export const ToggleMultiple: Story = {
+export const ToggleMultiple = meta.story({
   args: {
     color: 'primary',
     modelValue: [0],
   },
-};
+});
 
-export const OutlinedToggleMultiple: Story = {
+export const OutlinedToggleMultiple = meta.story({
   args: {
     color: 'primary',
     modelValue: [0],
     variant: 'outlined',
   },
-};
+});
 
-export const TextToggleMultiple: Story = {
+export const TextToggleMultiple = meta.story({
   args: {
     color: 'primary',
     modelValue: [0],
     variant: 'text',
   },
-};
+});
 
-export const ActiveColorMultiple: Story = {
+export const ActiveColorMultiple = meta.story({
   args: {
     activeColor: 'warning',
     color: 'primary',
     modelValue: [0],
     variant: 'text',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -1,18 +1,16 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiButton, { type Props } from '@/components/buttons/button/RuiButton.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type PropsAndLabel = Props & {
-  label: string;
-};
-
-const render: StoryFn<PropsAndLabel> = args => ({
-  components: { RuiButton },
-  setup() {
-    const clicks = ref(0);
-    return { args, clicks };
-  },
-  template: `
+function render(args: ComponentPropsAndSlots<typeof RuiButton>) {
+  return {
+    components: { RuiButton },
+    setup() {
+      const clicks = ref(0);
+      return { args, clicks };
+    },
+    template: `
     <RuiButton v-bind="args" @click="clicks++">
       <template #prepend></template>
       {{ args.label }}
@@ -20,9 +18,10 @@ const render: StoryFn<PropsAndLabel> = args => ({
     </RuiButton>
     <div class="mt-4 text-rui-text">Clicked: {{ clicks }} times</div>
   `,
-});
+  };
+}
 
-const meta: Meta<PropsAndLabel> = {
+const meta = preview.meta({
   argTypes: {
     color: { control: 'select', options: contextColors },
     disabled: { control: 'boolean', table: { category: 'State' } },
@@ -40,7 +39,7 @@ const meta: Meta<PropsAndLabel> = {
       table: { category: 'Shape' },
     },
   },
-  component: RuiButton as any,
+  component: RuiButton,
   parameters: {
     docs: {
       controls: { exclude: ['prepend', 'append', 'default'] },
@@ -49,174 +48,172 @@ const meta: Meta<PropsAndLabel> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Button/Button',
-};
+});
 
-type Story = StoryObj<PropsAndLabel>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     label: 'Default',
   },
-};
+});
 
-export const HideFocusIndicator: Story = {
+export const HideFocusIndicator = meta.story({
   args: {
     hideFocusIndicator: true,
     label: 'No focus outline',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
     label: 'Medium',
   },
-};
+});
 
-export const PrimaryText: Story = {
+export const PrimaryText = meta.story({
   args: {
     color: 'primary',
     label: 'Large',
     variant: 'text',
   },
-};
+});
 
-export const PrimaryRounded: Story = {
+export const PrimaryRounded = meta.story({
   args: {
     color: 'primary',
     label: 'Medium',
     rounded: true,
   },
-};
+});
 
-export const PrimarySmall: Story = {
+export const PrimarySmall = meta.story({
   args: {
     color: 'primary',
     label: 'Small',
     size: 'sm',
   },
-};
+});
 
-export const PrimaryLarge: Story = {
+export const PrimaryLarge = meta.story({
   args: {
     color: 'primary',
     label: 'Large',
     size: 'lg',
   },
-};
+});
 
-export const PrimaryLargeRounded: Story = {
+export const PrimaryLargeRounded = meta.story({
   args: {
     color: 'primary',
     label: 'Large',
     rounded: true,
     size: 'lg',
   },
-};
+});
 
-export const PrimaryDisabled: Story = {
+export const PrimaryDisabled = meta.story({
   args: {
     color: 'primary',
     disabled: true,
     label: 'Medium',
   },
-};
+});
 
-export const PrimaryOutlined: Story = {
+export const PrimaryOutlined = meta.story({
   args: {
     color: 'primary',
     label: 'Primary Outlined',
     variant: 'outlined',
   },
-};
+});
 
-export const PrimaryLoading: Story = {
+export const PrimaryLoading = meta.story({
   args: {
     color: 'primary',
     label: 'Primary Loading',
     loading: true,
   },
-};
+});
 
-export const PrimaryOutlinedWithElevation: Story = {
+export const PrimaryOutlinedWithElevation = meta.story({
   args: {
     color: 'primary',
     elevation: 4,
     label: 'Primary Outlined',
     variant: 'outlined',
   },
-};
+});
 
-export const Secondary: Story = {
+export const Secondary = meta.story({
   args: {
     color: 'secondary',
     label: 'Secondary Button',
   },
-};
+});
 
-export const SecondaryText: Story = {
+export const SecondaryText = meta.story({
   args: {
     color: 'secondary',
     label: 'Secondary Button',
     size: 'lg',
     variant: 'text',
   },
-};
+});
 
-export const SecondaryOutlined: Story = {
+export const SecondaryOutlined = meta.story({
   args: {
     color: 'secondary',
     label: 'Outlined Button',
     variant: 'outlined',
   },
-};
+});
 
-export const ErrorButton: Story = {
+export const ErrorButton = meta.story({
   args: {
     color: 'error',
     label: 'Error Button',
   },
-};
+});
 
-export const ErrorButtonText: Story = {
+export const ErrorButtonText = meta.story({
   args: {
     color: 'error',
     label: 'Error Button',
     size: 'lg',
     variant: 'text',
   },
-};
+});
 
-export const ErrorOutlined: Story = {
+export const ErrorOutlined = meta.story({
   args: {
     color: 'error',
     label: 'Error Button',
     variant: 'outlined',
   },
-};
+});
 
-export const ErrorOutlinedDisabled: Story = {
+export const ErrorOutlinedDisabled = meta.story({
   args: {
     color: 'error',
     disabled: true,
     label: 'Error Button',
     variant: 'outlined',
   },
-};
+});
 
-export const List: Story = {
+export const List = meta.story({
   args: {
     label: 'List',
     variant: 'list',
   },
-};
+});
 
-export const FloatingActionButton: Story = {
+export const FloatingActionButton = meta.story({
   args: {
     color: 'primary',
     label: 'Floating Action Button',
     variant: 'fab',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/calendar/RuiCalendar.stories.ts
+++ b/packages/ui-library/src/components/calendar/RuiCalendar.stories.ts
@@ -1,27 +1,30 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiCalendar from '@/components/calendar/RuiCalendar.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<typeof RuiCalendar> = args => ({
-  components: { RuiCalendar },
-  name: 'RuiCalendarStory',
-  setup() {
-    const iso = computed<string>(() => {
-      if (args.modelValue) {
-        return new Date(args.modelValue).toISOString();
-      }
-      return '-';
-    });
-    return { args, iso };
-  },
-  template: `
-    <div class="flex gap-4">
-      <RuiCalendar v-model="args.modelValue" v-bind="args" />
-      <div class="text-rui-text">{{ iso }}</div>
-    </div>
-  `,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiCalendar>) {
+  return {
+    components: { RuiCalendar },
+    name: 'RuiCalendarStory',
+    setup() {
+      const iso = computed<string>(() => {
+        if (args.modelValue) {
+          return new Date(args.modelValue).toISOString();
+        }
+        return '-';
+      });
+      return { args, iso };
+    },
+    template: `
+      <div class="flex gap-4">
+        <RuiCalendar v-model="args.modelValue" v-bind="args" />
+        <div class="text-rui-text">{{ iso }}</div>
+      </div>
+    `,
+  };
+}
 
-const meta: Meta<typeof RuiCalendar> = {
+const meta = preview.meta({
   argTypes: {
     'allowEmpty': { control: 'boolean' },
     'maxDate': { control: 'date' },
@@ -42,30 +45,28 @@ const meta: Meta<typeof RuiCalendar> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Calendar',
-};
+});
 
-type Story = StoryObj<typeof RuiCalendar>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const AllowEmpty: Story = {
+export const AllowEmpty = meta.story({
   args: {
     allowEmpty: true,
   },
-};
+});
 
-export const WithMinDate: Story = {
+export const WithMinDate = meta.story({
   args: {
     minDate: new Date(2025, 1, 10),
   },
-};
+});
 
-export const WithMaxDate: Story = {
+export const WithMaxDate = meta.story({
   args: {
     maxDate: new Date(2025, 3, 1),
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/cards/RuiCard.stories.ts
+++ b/packages/ui-library/src/components/cards/RuiCard.stories.ts
@@ -1,53 +1,52 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import { objectOmit } from '@vueuse/shared';
 import RuiButton, { type Props as ButtonProps } from '@/components/buttons/button/RuiButton.vue';
-import RuiCard, { type Props as CardProps } from '@/components/cards/RuiCard.vue';
+import RuiCard from '@/components/cards/RuiCard.vue';
+import preview from '~/.storybook/preview';
 
-type Props = CardProps & {
-  image?: string;
-  header?: string;
-  customHeader?: string;
-  subheader?: string;
+type CardStoryArgs = ComponentPropsAndSlots<typeof RuiCard> & {
   content?: string;
-  prepend?: string;
+  customHeader?: string;
   actions?: (ButtonProps & { text: string })[];
 };
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiButton, RuiCard },
-  setup: () => {
-    const cardArgs = computed(() =>
-      objectOmit(args, ['header', 'subheader', 'content', 'actions']),
-    );
+function render(args: CardStoryArgs) {
+  return {
+    components: { RuiButton, RuiCard },
+    setup: () => {
+      const cardArgs = computed(() =>
+        objectOmit(args, ['header', 'subheader', 'content', 'actions']),
+      );
 
-    return { args, cardArgs };
-  },
-  template: `
-      <div>
-        <RuiCard v-bind="cardArgs">
-          <template v-if="args.image" #image><img :src="args.image" alt="card image" /></template>
-          <template v-if="args.prepend" #prepend>{{ args.prepend }}</template>
-          <template v-if="args.header" #header>{{ args.header }}</template>
-          <template v-if="args.customHeader" #custom-header><h5 class="p-4 text-rui-error text-h5">
-            {{ args.customHeader }}</h5></template>
-          <template v-if="args.subheader" #subheader>
-            {{ args.subheader }}
-          </template>
-          <p v-if="args.content">{{ args.content }}</p>
-          <template v-if="args.actions" #footer>
-            <RuiButton
-                v-for="(action, i) in args.actions"
-                v-bind="action"
-                :key="i"
-            >
-              {{ action.text }}
-            </RuiButton>
-          </template>
-        </RuiCard>
-      </div>`,
-});
+      return { args, cardArgs };
+    },
+    template: `
+        <div>
+          <RuiCard v-bind="cardArgs">
+            <template v-if="args.image" #image><img :src="args.image" alt="card image" /></template>
+            <template v-if="args.prepend" #prepend>{{ args.prepend }}</template>
+            <template v-if="args.header" #header>{{ args.header }}</template>
+            <template v-if="args.customHeader" #custom-header><h5 class="p-4 text-rui-error text-h5">
+              {{ args.customHeader }}</h5></template>
+            <template v-if="args.subheader" #subheader>
+              {{ args.subheader }}
+            </template>
+            <p v-if="args.content">{{ args.content }}</p>
+            <template v-if="args.actions" #footer>
+              <RuiButton
+                  v-for="(action, i) in args.actions"
+                  v-bind="action"
+                  :key="i"
+              >
+                {{ action.text }}
+              </RuiButton>
+            </template>
+          </RuiCard>
+        </div>`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     customHeader: '',
     dense: false,
@@ -79,7 +78,6 @@ const meta: Meta<Props> = {
       options: ['flat', 'outlined'],
     },
   },
-  component: RuiCard,
   parameters: {
     docs: {
       controls: { exclude: ['default', 'footer'] },
@@ -88,11 +86,9 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Card',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     actions: [
       { color: 'secondary', size: 'lg', text: 'Action 1', variant: 'text' },
@@ -102,26 +98,26 @@ export const Default: Story = {
     header: 'Card header',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const NoActions: Story = {
+export const NoActions = meta.story({
   args: {
     content: 'Lorem ipsum dolor sit amet consect '.repeat(50),
     header: 'Card header',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const DividedNoActions: Story = {
+export const DividedNoActions = meta.story({
   args: {
     content: 'Lorem ipsum dolor sit amet consect '.repeat(50),
     divide: true,
     header: 'Card header',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const Divided: Story = {
+export const Divided = meta.story({
   args: {
     actions: [
       { color: 'secondary', size: 'lg', text: 'Action 1', variant: 'text' },
@@ -132,9 +128,9 @@ export const Divided: Story = {
     header: 'Card header',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const DividedPrepend: Story = {
+export const DividedPrepend = meta.story({
   args: {
     actions: [
       { color: 'secondary', size: 'lg', text: 'Action 1', variant: 'text' },
@@ -146,9 +142,9 @@ export const DividedPrepend: Story = {
     prepend: 'OP',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const WithImage: Story = {
+export const WithImage = meta.story({
   args: {
     actions: [
       { color: 'secondary', size: 'lg', text: 'Action 1', variant: 'text' },
@@ -159,9 +155,9 @@ export const WithImage: Story = {
     image: 'https://placehold.co/960x320',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const DividedWithImage: Story = {
+export const DividedWithImage = meta.story({
   args: {
     actions: [
       { color: 'secondary', size: 'lg', text: 'Action 1', variant: 'text' },
@@ -173,9 +169,9 @@ export const DividedWithImage: Story = {
     image: 'https://placehold.co/960x320',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const Dense: Story = {
+export const Dense = meta.story({
   args: {
     actions: [
       { color: 'secondary', size: 'sm', text: 'Action 1', variant: 'text' },
@@ -186,9 +182,9 @@ export const Dense: Story = {
     header: 'Card header',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const DenseFlat: Story = {
+export const DenseFlat = meta.story({
   args: {
     actions: [
       {
@@ -213,9 +209,9 @@ export const DenseFlat: Story = {
     subheader: 'Card subheader',
     variant: 'flat',
   },
-};
+});
 
-export const DenseDivide: Story = {
+export const DenseDivide = meta.story({
   args: {
     actions: [
       {
@@ -237,9 +233,9 @@ export const DenseDivide: Story = {
     header: 'Card header',
     subheader: 'Card subheader',
   },
-};
+});
 
-export const Elevated: Story = {
+export const Elevated = meta.story({
   args: {
     actions: [
       {
@@ -259,9 +255,9 @@ export const Elevated: Story = {
     subheader: 'Card subheader',
     variant: 'flat',
   },
-};
+});
 
-export const HighElevation: Story = {
+export const HighElevation = meta.story({
   args: {
     actions: [
       {
@@ -281,9 +277,9 @@ export const HighElevation: Story = {
     subheader: 'Card subheader',
     variant: 'flat',
   },
-};
+});
 
-export const CustomHeader: Story = {
+export const CustomHeader = meta.story({
   args: {
     actions: [
       {
@@ -304,6 +300,6 @@ export const CustomHeader: Story = {
     subheader: 'Card subheader',
     variant: 'flat',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/chips/RuiChip.stories.ts
+++ b/packages/ui-library/src/components/chips/RuiChip.stories.ts
@@ -1,31 +1,33 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiChip, { type Props as ChipProps } from '@/components/chips/RuiChip.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiChip from '@/components/chips/RuiChip.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type Props = ChipProps & { prepend: string; children: string };
+type ChipStoryArgs = ComponentPropsAndSlots<typeof RuiChip> & { children?: string; prepend?: string };
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiChip },
-  setup() {
-    const show = ref(true);
-    const hideShow = () => {
-      set(show, false);
-      setTimeout(() => {
-        set(show, true);
-      }, 2000);
-    };
-    return { args, hideShow, show };
-  },
-  template: `
-    <div>
-    <RuiChip v-if="show" v-bind="args" @remove="hideShow()">
-      <template #prepend v-if="args.prepend">{{ args.prepend }}</template>
-      {{ args.children }}
-    </RuiChip>
-    </div>`,
-});
-
-const meta: Meta<Props> = {
+function render(args: ChipStoryArgs) {
+  return {
+    components: { RuiChip },
+    setup() {
+      const show = ref(true);
+      const hideShow = () => {
+        set(show, false);
+        setTimeout(() => {
+          set(show, true);
+        }, 2000);
+      };
+      return { args, hideShow, show };
+    },
+    template: `
+      <div>
+      <RuiChip v-if="show" v-bind="args" @remove="hideShow()">
+        <template #prepend v-if="args.prepend">{{ args.prepend }}</template>
+        {{ args.children }}
+      </RuiChip>
+      </div>`,
+  };
+}
+const meta = preview.meta({
   argTypes: {
     children: { control: 'text' },
     clickable: { control: 'boolean' },
@@ -46,7 +48,6 @@ const meta: Meta<Props> = {
       options: ['filled', 'outlined'],
     },
   },
-  component: RuiChip,
   parameters: {
     docs: {
       controls: {
@@ -57,11 +58,9 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Chip',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     children: 'Chip',
     closeable: false,
@@ -70,9 +69,9 @@ export const Default: Story = {
     size: 'md',
     variant: 'filled',
   },
-};
+});
 
-export const Tile: Story = {
+export const Tile = meta.story({
   args: {
     children: 'Chip',
     closeable: false,
@@ -82,9 +81,9 @@ export const Tile: Story = {
     tile: true,
     variant: 'filled',
   },
-};
+});
 
-export const Clickable: Story = {
+export const Clickable = meta.story({
   args: {
     children: 'Chip',
     clickable: true,
@@ -93,9 +92,9 @@ export const Clickable: Story = {
     size: 'md',
     variant: 'filled',
   },
-};
+});
 
-export const Dismissible: Story = {
+export const Dismissible = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -104,44 +103,44 @@ export const Dismissible: Story = {
     size: 'md',
     variant: 'filled',
   },
-};
+});
 
-export const DismissiblePrefix: Story = {
-  args: {
-    children: 'Chip',
-    closeable: true,
-    color: 'grey',
-    disabled: false,
-    prepend: 'BTC',
-    size: 'md',
-    variant: 'filled',
-  },
-};
-
-export const SmallDismissible: Story = {
-  args: {
-    children: 'Chip',
-    closeable: true,
-    color: 'grey',
-    disabled: false,
-    size: 'sm',
-    variant: 'filled',
-  },
-};
-
-export const SmallDismissiblePrefix: Story = {
+export const DismissiblePrefix = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
     color: 'grey',
     disabled: false,
     prepend: 'BTC',
+    size: 'md',
+    variant: 'filled',
+  },
+});
+
+export const SmallDismissible = meta.story({
+  args: {
+    children: 'Chip',
+    closeable: true,
+    color: 'grey',
+    disabled: false,
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const Primary: Story = {
+export const SmallDismissiblePrefix = meta.story({
+  args: {
+    children: 'Chip',
+    closeable: true,
+    color: 'grey',
+    disabled: false,
+    prepend: 'BTC',
+    size: 'sm',
+    variant: 'filled',
+  },
+});
+
+export const Primary = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -150,9 +149,9 @@ export const Primary: Story = {
     size: 'md',
     variant: 'filled',
   },
-};
+});
 
-export const PrimarySmall: Story = {
+export const PrimarySmall = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -161,9 +160,9 @@ export const PrimarySmall: Story = {
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const PrimarySmallDisabled: Story = {
+export const PrimarySmallDisabled = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -172,9 +171,9 @@ export const PrimarySmallDisabled: Story = {
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const Secondary: Story = {
+export const Secondary = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -183,9 +182,9 @@ export const Secondary: Story = {
     size: 'md',
     variant: 'filled',
   },
-};
+});
 
-export const SecondarySmall: Story = {
+export const SecondarySmall = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -194,9 +193,9 @@ export const SecondarySmall: Story = {
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const SecondarySmallDisabled: Story = {
+export const SecondarySmallDisabled = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -205,9 +204,9 @@ export const SecondarySmallDisabled: Story = {
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const Error: Story = {
+export const Error = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -216,9 +215,9 @@ export const Error: Story = {
     size: 'md',
     variant: 'filled',
   },
-};
+});
 
-export const ErrorSmall: Story = {
+export const ErrorSmall = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -227,9 +226,9 @@ export const ErrorSmall: Story = {
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const ErrorSmallDisabled: Story = {
+export const ErrorSmallDisabled = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -238,9 +237,9 @@ export const ErrorSmallDisabled: Story = {
     size: 'sm',
     variant: 'filled',
   },
-};
+});
 
-export const OutlinedDefault: Story = {
+export const OutlinedDefault = meta.story({
   args: {
     children: 'Chip',
     closeable: false,
@@ -249,9 +248,9 @@ export const OutlinedDefault: Story = {
     size: 'md',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDismissible: Story = {
+export const OutlinedDismissible = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -260,9 +259,9 @@ export const OutlinedDismissible: Story = {
     size: 'md',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedSmallDismissible: Story = {
+export const OutlinedSmallDismissible = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -271,9 +270,9 @@ export const OutlinedSmallDismissible: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedPrimary: Story = {
+export const OutlinedPrimary = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -282,9 +281,9 @@ export const OutlinedPrimary: Story = {
     size: 'md',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedPrimarySmall: Story = {
+export const OutlinedPrimarySmall = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -293,9 +292,9 @@ export const OutlinedPrimarySmall: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedPrimarySmallDisabled: Story = {
+export const OutlinedPrimarySmallDisabled = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -304,9 +303,9 @@ export const OutlinedPrimarySmallDisabled: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedSecondary: Story = {
+export const OutlinedSecondary = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -315,9 +314,9 @@ export const OutlinedSecondary: Story = {
     size: 'md',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedSecondarySmall: Story = {
+export const OutlinedSecondarySmall = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -326,9 +325,9 @@ export const OutlinedSecondarySmall: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedSecondarySmallDisabled: Story = {
+export const OutlinedSecondarySmallDisabled = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -337,9 +336,9 @@ export const OutlinedSecondarySmallDisabled: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedError: Story = {
+export const OutlinedError = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -348,9 +347,9 @@ export const OutlinedError: Story = {
     size: 'md',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedErrorPrefix: Story = {
+export const OutlinedErrorPrefix = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -360,9 +359,9 @@ export const OutlinedErrorPrefix: Story = {
     size: 'md',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedErrorSmall: Story = {
+export const OutlinedErrorSmall = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -371,9 +370,9 @@ export const OutlinedErrorSmall: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedErrorSmallDisabled: Story = {
+export const OutlinedErrorSmallDisabled = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -382,9 +381,9 @@ export const OutlinedErrorSmallDisabled: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedErrorSmallDisabledPrefixed: Story = {
+export const OutlinedErrorSmallDisabledPrefixed = meta.story({
   args: {
     children: 'Chip',
     closeable: true,
@@ -394,6 +393,6 @@ export const OutlinedErrorSmallDisabledPrefixed: Story = {
     size: 'sm',
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/color-picker/RuiColorPicker.stories.ts
+++ b/packages/ui-library/src/components/color-picker/RuiColorPicker.stories.ts
@@ -1,25 +1,29 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiCard from '@/components/cards/RuiCard.vue';
-import RuiColorPicker, { type Props } from '@/components/color-picker/RuiColorPicker.vue';
+import RuiColorPicker from '@/components/color-picker/RuiColorPicker.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiCard, RuiColorPicker },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiColorPicker>) {
+  return {
+    components: { RuiCard, RuiColorPicker },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `<RuiCard class='!w-[300px]'><RuiColorPicker v-model="modelValue" v-bind="args" /></RuiCard>`,
-});
+      return { args, modelValue };
+    },
+    template: `<RuiCard class='!w-[300px]'><RuiColorPicker v-model="modelValue" v-bind="args" /></RuiCard>`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     modelValue: { control: 'text' },
   },
@@ -32,18 +36,16 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/ColorPicker',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const PreDefinedValue: Story = {
+export const PreDefinedValue = meta.story({
   args: {
     modelValue: '45858a',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.stories.ts
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.stories.ts
@@ -1,39 +1,42 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import { TimeAccuracy } from '@/consts/time-accuracy';
+import preview from '~/.storybook/preview';
 import RuiDateTimePicker from './RuiDateTimePicker.vue';
 
-const render: StoryFn<typeof RuiDateTimePicker> = args => ({
-  components: { RuiDateTimePicker },
-  setup() {
-    const iso = computed<string>(() => {
-      if (args.modelValue) {
-        return new Date(args.modelValue).toISOString();
-      }
-      return '-';
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiDateTimePicker>) {
+  return {
+    components: { RuiDateTimePicker },
+    setup() {
+      const iso = computed<string>(() => {
+        if (args.modelValue) {
+          return new Date(args.modelValue).toISOString();
+        }
+        return '-';
+      });
 
-    const epoch = computed<string>(() => {
-      if (args.modelValue) {
-        const epoch = new Date(args.modelValue).getTime();
-        return epoch >= 0 ? epoch.toString() : '-';
-      }
-      return '-';
-    });
+      const epoch = computed<string>(() => {
+        if (args.modelValue) {
+          const epoch = new Date(args.modelValue).getTime();
+          return epoch >= 0 ? epoch.toString() : '-';
+        }
+        return '-';
+      });
 
-    return { args, epoch, iso };
-  },
-  template: `<div>
-    <RuiDateTimePicker v-bind="args" v-model="args.modelValue" />
-    <div class="text-rui-text">
-      <span class='font-medium'>Date:</span> {{ iso }}
-    </div>
-    <div class="text-rui-text">
-      <span class='font-medium'>Epoch</span> {{ epoch }}
-    </div>
-  </div>`,
-});
+      return { args, epoch, iso };
+    },
+    template: `<div>
+      <RuiDateTimePicker v-bind="args" v-model="args.modelValue" />
+      <div class="text-rui-text">
+        <span class='font-medium'>Date:</span> {{ iso }}
+      </div>
+      <div class="text-rui-text">
+        <span class='font-medium'>Epoch</span> {{ epoch }}
+      </div>
+    </div>`,
+  };
+}
 
-const meta: Meta<typeof RuiDateTimePicker> = {
+const meta = preview.meta({
   argTypes: {
     accuracy: {
       control: 'select',
@@ -56,48 +59,46 @@ const meta: Meta<typeof RuiDateTimePicker> = {
   render,
   tags: ['autodocs'],
   title: 'Components/DateTimePicker',
-};
+});
 
-type Story = StoryObj<typeof RuiDateTimePicker>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     modelValue: new Date(),
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     accuracy: TimeAccuracy.SECOND,
     modelValue: new Date(),
     variant: 'outlined',
   },
-};
+});
 
-export const Optional: Story = {
+export const Optional = meta.story({
   args: {
     accuracy: TimeAccuracy.SECOND,
     allowEmpty: true,
     modelValue: undefined,
     variant: 'outlined',
   },
-};
+});
 
-export const WithMaxNow: Story = {
+export const WithMaxNow = meta.story({
   args: {
     accuracy: TimeAccuracy.SECOND,
     maxDate: 'now',
     modelValue: new Date(),
     variant: 'outlined',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     modelValue: new Date(),
     required: true,
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/divider/RuiDivider.stories.ts
+++ b/packages/ui-library/src/components/divider/RuiDivider.stories.ts
@@ -1,16 +1,19 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiDivider, { type Props } from '@/components/divider/RuiDivider.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiDivider from '@/components/divider/RuiDivider.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiDivider },
-  setup() {
-    return { args };
-  },
-  template: `
-    <RuiDivider :class="args.vertical ? 'h-96 mx-4' : 'w-96 my-4'" v-bind="args" />`,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiDivider>) {
+  return {
+    components: { RuiDivider },
+    setup() {
+      return { args };
+    },
+    template: `
+      <RuiDivider :class="args.vertical ? 'h-96 mx-4' : 'w-96 my-4'" v-bind="args" />`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     vertical: { control: 'boolean' },
   },
@@ -18,18 +21,16 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Divider',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Vertical: Story = {
+export const Vertical = meta.story({
   args: {
     vertical: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.stories.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.stories.ts
@@ -1,31 +1,34 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots, Decorator } from '@storybook/vue3-vite';
 import { options, type SelectOption } from '@/__test__/options';
-import RuiAutoComplete, { type AutoCompleteModelValue, type AutoCompleteProps } from '@/components/forms/auto-complete/RuiAutoComplete.vue';
+import RuiAutoComplete from '@/components/forms/auto-complete/RuiAutoComplete.vue';
+import preview from '~/.storybook/preview';
 
-type ComponentProps<TValue = string, TItem = SelectOption> = AutoCompleteProps<TValue, TItem> & {
-  modelValue: AutoCompleteModelValue<TValue>;
-};
+type AutoCompleteProps = ComponentPropsAndSlots<typeof RuiAutoComplete<string, SelectOption>>;
 
-const render: StoryFn<ComponentProps> = args => ({
-  components: {
-    RuiAutoComplete: RuiAutoComplete as any,
-  },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+type AutoCompleteMetaArgs = Required<Pick<AutoCompleteProps, 'clearable' | 'disabled' | 'options'>>;
 
-    return { args, modelValue };
-  },
-  template: `<RuiAutoComplete v-bind="args" v-model="modelValue" />`,
-});
+function render(args: AutoCompleteProps) {
+  return {
+    components: {
+      RuiAutoComplete: RuiAutoComplete<string, SelectOption>,
+    },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          args.modelValue = val;
+        },
+      });
 
-const meta: Meta<ComponentProps> = {
+      return { args, modelValue };
+    },
+    template: `<RuiAutoComplete v-bind="args" v-model="modelValue" />`,
+  };
+}
+
+const meta = preview.meta<typeof RuiAutoComplete<string, SelectOption>, Decorator, AutoCompleteMetaArgs>({
   args: {
     clearable: true,
     disabled: false,
@@ -43,7 +46,7 @@ const meta: Meta<ComponentProps> = {
       options: ['default', 'outlined', 'filled'],
     },
   },
-  component: RuiAutoComplete as any,
+  component: RuiAutoComplete<string, SelectOption>,
   parameters: {
     docs: {
       controls: { exclude: ['update:model-value'] },
@@ -52,52 +55,50 @@ const meta: Meta<ComponentProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/AutoComplete',
-};
+});
 
-type Story<TValue = string> = StoryObj<ComponentProps<TValue>>;
-
-type PrimitiveStory<TValue = string> = StoryObj<ComponentProps<TValue, string>>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     keyAttr: 'id',
     modelValue: undefined,
     textAttr: 'label',
   },
-};
+});
 
-export const PrimitiveItems: PrimitiveStory = {
+// @ts-expect-error PrimitiveItems uses string[] options instead of SelectOption[]
+export const PrimitiveItems = meta.story({
   args: {
     options: options.map(item => item.label),
   },
-};
+});
 
-export const MultipleValue: PrimitiveStory<string[]> = {
+// @ts-expect-error MultipleValue uses string[] options and array modelValue
+export const MultipleValue = meta.story({
   args: {
     modelValue: [],
     options: options.map(item => item.label),
   },
-};
+});
 
-export const DefaultDisabled: Story = {
+export const DefaultDisabled = meta.story({
   args: {
     disabled: true,
     keyAttr: 'id',
     modelValue: undefined,
     textAttr: 'label',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     keyAttr: 'id',
     modelValue: undefined,
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDisabled: Story = {
+export const OutlinedDisabled = meta.story({
   args: {
     disabled: true,
     keyAttr: 'id',
@@ -105,9 +106,9 @@ export const OutlinedDisabled: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDense: Story = {
+export const OutlinedDense = meta.story({
   args: {
     dense: false,
     disabled: true,
@@ -116,9 +117,9 @@ export const OutlinedDense: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDisabledDense: Story = {
+export const OutlinedDisabledDense = meta.story({
   args: {
     dense: true,
     disabled: true,
@@ -127,9 +128,10 @@ export const OutlinedDisabledDense: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const Chips: Story<string[]> = {
+// @ts-expect-error Chips uses string[] modelValue for multi-select
+export const Chips = meta.story({
   args: {
     chips: true,
     dense: true,
@@ -138,9 +140,9 @@ export const Chips: Story<string[]> = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const CustomValue: Story = {
+export const CustomValue = meta.story({
   args: {
     customValue: true,
     dense: false,
@@ -149,9 +151,9 @@ export const CustomValue: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     keyAttr: 'id',
     modelValue: undefined,
@@ -159,6 +161,6 @@ export const Required: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.stories.ts
+++ b/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.stories.ts
@@ -1,37 +1,40 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiCheckbox, { type Props } from '@/components/forms/checkbox/RuiCheckbox.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type PropsAndLabel = Props & { label: string };
+function render(args: ComponentPropsAndSlots<typeof RuiCheckbox>) {
+  return {
+    components: { RuiCheckbox },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-const render: StoryFn<PropsAndLabel> = args => ({
-  components: { RuiCheckbox },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+      const indeterminate = computed({
+        get() {
+          return args.indeterminate;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.indeterminate = val;
+        },
+      });
+      return { args, indeterminate, modelValue };
+    },
+    template: `<RuiCheckbox v-bind="args" v-model="modelValue" v-model:indeterminate="indeterminate">
+      {{ args.label }}
+    </RuiCheckbox>`,
+  };
+}
 
-    const indeterminate = computed({
-      get() {
-        return args.indeterminate;
-      },
-      set(val) {
-        args.indeterminate = val;
-      },
-    });
-    return { args, indeterminate, modelValue };
-  },
-  template: `<RuiCheckbox v-bind="args" v-model="modelValue" v-model:indeterminate="indeterminate">
-    {{ args.label }}
-  </RuiCheckbox>`,
-});
-
-const meta: Meta<PropsAndLabel> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
     successMessages: [],
@@ -58,87 +61,85 @@ const meta: Meta<PropsAndLabel> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/Checkbox',
-};
+});
 
-type Story = StoryObj<PropsAndLabel>;
-
-export const Checked: Story = {
+export const Checked = meta.story({
   args: {
     modelValue: true,
   },
-};
+});
 
-export const Indeterminate: Story = {
+export const Indeterminate = meta.story({
   args: {
     indeterminate: true,
   },
-};
+});
 
-export const Large: Story = {
+export const Large = meta.story({
   args: {
     size: 'lg',
   },
-};
+});
 
-export const Small: Story = {
+export const Small = meta.story({
   args: {
     size: 'sm',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
   },
-};
+});
 
-export const WithLabel: Story = {
+export const WithLabel = meta.story({
   args: {
     label: 'With Label',
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
     label: 'Disabled',
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
     label: 'Label',
   },
-};
+});
 
-export const WithSuccessMessage: Story = {
+export const WithSuccessMessage = meta.story({
   args: {
     label: 'Label',
     successMessages: ['With success messages'],
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
     label: 'Label',
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
     label: 'Label',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Required Checkbox',
     required: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/radio-button/radio-group/RuiRadioGroup.stories.ts
+++ b/packages/ui-library/src/components/forms/radio-button/radio-group/RuiRadioGroup.stories.ts
@@ -1,33 +1,35 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiRadioGroup, { type Props } from '@/components/forms/radio-button/radio-group/RuiRadioGroup.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiRadioGroup from '@/components/forms/radio-button/radio-group/RuiRadioGroup.vue';
 import RuiRadio from '@/components/forms/radio-button/radio/RuiRadio.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type RuiRadioGroupProps = Props & { modelValue: string };
-const render: StoryFn<RuiRadioGroupProps> = args => ({
-  components: {
-    RuiRadio: RuiRadio as any,
-    RuiRadioGroup: RuiRadioGroup as any,
-  },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiRadioGroup<string>>) {
+  return {
+    components: {
+      RuiRadio: RuiRadio<string>,
+      RuiRadioGroup: RuiRadioGroup<string>,
+    },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `<RuiRadioGroup v-bind="args" v-model="modelValue">
+      return { args, modelValue };
+    },
+    template: `<RuiRadioGroup v-bind="args" v-model="modelValue">
     <RuiRadio value="yes">yes</RuiRadio>
     <RuiRadio value="no">no</RuiRadio>
   </RuiRadioGroup>`,
-});
+  };
+}
 
-const meta: Meta<RuiRadioGroupProps> = {
+const meta = preview.meta({
   argTypes: {
     color: { control: 'select', options: contextColors },
     disabled: { control: 'boolean', table: { category: 'State' } },
@@ -41,48 +43,46 @@ const meta: Meta<RuiRadioGroupProps> = {
     size: { control: 'select', options: ['medium', 'sm', 'lg'] },
     successMessages: { control: 'object' },
   },
-  component: RuiRadioGroup as any,
+  component: RuiRadioGroup<string>,
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/Radio/RadioGroup',
-};
+});
 
-type Story = StoryObj<RuiRadioGroupProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Inline: Story = {
+export const Inline = meta.story({
   args: {
     inline: true,
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Required Group',
     required: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/radio-button/radio/RuiRadio.stories.ts
+++ b/packages/ui-library/src/components/forms/radio-button/radio/RuiRadio.stories.ts
@@ -1,30 +1,31 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiRadio, { type RadioProps } from '@/components/forms/radio-button/radio/RuiRadio.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiRadio from '@/components/forms/radio-button/radio/RuiRadio.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type PropsAndLabel = RadioProps<string> & { label: string; modelValue: string };
-
-const render: StoryFn<PropsAndLabel> = args => ({
-  components: {
-    RuiRadio: RuiRadio as any,
-  },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
-    return { args, modelValue };
-  },
-  template: `<RuiRadio v-bind="args" v-model="modelValue">
+function render(args: ComponentPropsAndSlots<typeof RuiRadio<string>>) {
+  return {
+    components: {
+      RuiRadio: RuiRadio<string>,
+    },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          args.modelValue = val;
+        },
+      });
+      return { args, modelValue };
+    },
+    template: `<RuiRadio v-bind="args" v-model="modelValue">
   {{ args.default }}
   </RuiRadio>`,
-});
+  };
+}
 
-const meta: Meta<PropsAndLabel> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
   },
@@ -40,7 +41,7 @@ const meta: Meta<PropsAndLabel> = {
     size: { control: 'select', options: ['medium', 'sm', 'lg'] },
     value: { control: 'text' },
   },
-  component: RuiRadio as any,
+  component: RuiRadio<string>,
   parameters: {
     docs: {
       controls: { exclude: ['default'] },
@@ -49,84 +50,82 @@ const meta: Meta<PropsAndLabel> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/Radio/Radio',
-};
+});
 
-type Story = StoryObj<PropsAndLabel>;
-
-export const Checked: Story = {
+export const Checked = meta.story({
   args: {
     modelValue: 'test',
     value: 'test',
   },
-};
+});
 
-export const Large: Story = {
+export const Large = meta.story({
   args: {
     size: 'lg',
     value: 'test',
   },
-};
+});
 
-export const Small: Story = {
+export const Small = meta.story({
   args: {
     size: 'sm',
     value: 'test',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
     value: 'test',
   },
-};
+});
 
-export const WithLabel: Story = {
+export const WithLabel = meta.story({
   args: {
     label: 'With Label',
     value: 'test',
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
     label: 'Disabled',
     value: 'test',
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
     label: 'Label',
     value: 'test',
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
     label: 'Label',
     value: 'test',
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
     label: 'Label',
     value: 'test',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Required Radio',
     required: true,
     value: 'test',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/revealable-text-field/RuiRevealableTextField.stories.ts
+++ b/packages/ui-library/src/components/forms/revealable-text-field/RuiRevealableTextField.stories.ts
@@ -1,28 +1,32 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiRevealableTextField, { type Props } from '@/components/forms/revealable-text-field/RuiRevealableTextField.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiRevealableTextField from '@/components/forms/revealable-text-field/RuiRevealableTextField.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type RuiRevealableTextFieldProps = Props & { modelValue: string };
-const render: StoryFn<RuiRevealableTextFieldProps> = args => ({
-  components: { RuiRevealableTextField },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiRevealableTextField>) {
+  return {
+    components: { RuiRevealableTextField },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `<RuiRevealableTextField v-model="modelValue" v-bind="args" />`,
-});
+      return { args, modelValue };
+    },
+    template: `<RuiRevealableTextField v-model="modelValue" v-bind="args" />`,
+  };
+}
 
-const meta: Meta<RuiRevealableTextFieldProps> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
+    modelValue: undefined,
     successMessages: [],
   },
   argTypes: {
@@ -63,19 +67,17 @@ const meta: Meta<RuiRevealableTextFieldProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/RevealableTextField',
-};
+});
 
-type Story = StoryObj<RuiRevealableTextFieldProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     label: 'Password',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const PrimaryText: Story = {
+export const PrimaryText = meta.story({
   args: {
     appendIcon: 'lu-eye',
     label: 'Password',
@@ -83,9 +85,9 @@ export const PrimaryText: Story = {
     textColor: 'primary',
     variant: 'outlined',
   },
-};
+});
 
-export const SuccessText: Story = {
+export const SuccessText = meta.story({
   args: {
     appendIcon: 'lu-eye',
     label: 'Password',
@@ -93,42 +95,42 @@ export const SuccessText: Story = {
     textColor: 'success',
     variant: 'outlined',
   },
-};
+});
 
-export const ErrorsMessage: Story = {
+export const ErrorsMessage = meta.story({
   args: {
     errorMessages: ['Lorem ipsum dolor'],
     label: 'Password',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const SuccessMessage: Story = {
+export const SuccessMessage = meta.story({
   args: {
     label: 'Password',
     placeholder: 'Placeholder',
     successMessages: ['Lorem ipsum dolor'],
     variant: 'outlined',
   },
-};
+});
 
-export const Hinted: Story = {
+export const Hinted = meta.story({
   args: {
     hint: 'Lorem ipsum dolor',
     label: 'Password',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Password',
     placeholder: 'Placeholder',
     required: true,
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.stories.ts
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.stories.ts
@@ -1,29 +1,34 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots, Decorator } from '@storybook/vue3-vite';
 import { options, type SelectOption } from '@/__test__/options';
-import RuiMenuSelect, { type Props } from '@/components/forms/select/RuiMenuSelect.vue';
+import RuiMenuSelect from '@/components/forms/select/RuiMenuSelect.vue';
+import preview from '~/.storybook/preview';
 
-type SelectProps<T extends SelectOption | string = SelectOption> = Props<string, T> & { modelValue: string | undefined };
+type MenuSelectProps = ComponentPropsAndSlots<typeof RuiMenuSelect<string, SelectOption>>;
 
-const render: StoryFn<SelectProps> = args => ({
-  components: {
-    RuiMenuSelect: RuiMenuSelect as any,
-  },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+type MenuSelectMetaArgs = Required<Pick<MenuSelectProps, 'disabled' | 'options' | 'variant'>>;
 
-    return { args, modelValue };
-  },
-  template: `<RuiMenuSelect v-bind="args" v-model="modelValue" />`,
-});
+function render(args: MenuSelectProps) {
+  return {
+    components: {
+      RuiMenuSelect: RuiMenuSelect<string, SelectOption>,
+    },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          args.modelValue = val;
+        },
+      });
 
-const meta: Meta<SelectProps> = {
+      return { args, modelValue };
+    },
+    template: `<RuiMenuSelect v-bind="args" v-model="modelValue" />`,
+  };
+}
+
+const meta = preview.meta<typeof RuiMenuSelect<string, SelectOption>, Decorator, MenuSelectMetaArgs>({
   args: {
     disabled: false,
     options,
@@ -40,7 +45,7 @@ const meta: Meta<SelectProps> = {
       options: ['default', 'outlined', 'filled'],
     },
   },
-  component: RuiMenuSelect as any,
+  component: RuiMenuSelect<string, SelectOption>,
   parameters: {
     docs: {
       controls: { exclude: ['update:model-value'] },
@@ -49,43 +54,42 @@ const meta: Meta<SelectProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/MenuSelect',
-};
+});
 
-type Story<T extends SelectOption | string = SelectOption> = StoryObj<SelectProps<T>>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     keyAttr: 'id',
     modelValue: undefined,
     textAttr: 'label',
   },
-};
+});
 
-export const PrimitiveItems: Story<string> = {
+// @ts-expect-error PrimitiveItems uses string[] options instead of SelectOption[]
+export const PrimitiveItems = meta.story({
   args: {
     options: options.map(item => item.label),
   },
-};
+});
 
-export const DefaultDisabled: Story = {
+export const DefaultDisabled = meta.story({
   args: {
     disabled: true,
     keyAttr: 'id',
     modelValue: undefined,
     textAttr: 'label',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     keyAttr: 'id',
     modelValue: undefined,
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDisabled: Story = {
+export const OutlinedDisabled = meta.story({
   args: {
     disabled: true,
     keyAttr: 'id',
@@ -93,9 +97,9 @@ export const OutlinedDisabled: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDense: Story = {
+export const OutlinedDense = meta.story({
   args: {
     dense: false,
     disabled: true,
@@ -104,9 +108,9 @@ export const OutlinedDense: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDisabledDense: Story = {
+export const OutlinedDisabledDense = meta.story({
   args: {
     dense: true,
     disabled: true,
@@ -115,9 +119,9 @@ export const OutlinedDisabledDense: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     keyAttr: 'id',
     modelValue: undefined,
@@ -125,6 +129,6 @@ export const Required: Story = {
     textAttr: 'label',
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/select/RuiSimpleSelect.stories.ts
+++ b/packages/ui-library/src/components/forms/select/RuiSimpleSelect.stories.ts
@@ -1,24 +1,32 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiSimpleSelect, { type Props } from '@/components/forms/select/RuiSimpleSelect.vue';
+import type { ComponentPropsAndSlots, Decorator } from '@storybook/vue3-vite';
+import RuiSimpleSelect from '@/components/forms/select/RuiSimpleSelect.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiSimpleSelect },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+type SimpleSelectProps = ComponentPropsAndSlots<typeof RuiSimpleSelect>;
 
-    return { args, modelValue };
-  },
-  template: `<RuiSimpleSelect v-bind="args" v-model="modelValue" />`,
-});
+type SimpleSelectMetaArgs = Required<Pick<SimpleSelectProps, 'disabled' | 'options' | 'variant'>>;
 
-const meta: Meta<Props> = {
+function render(args: SimpleSelectProps) {
+  return {
+    components: { RuiSimpleSelect },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
+
+      return { args, modelValue };
+    },
+    template: `<RuiSimpleSelect v-bind="args" v-model="modelValue" />`,
+  };
+}
+
+const meta = preview.meta<typeof RuiSimpleSelect, Decorator, SimpleSelectMetaArgs>({
   args: {
     disabled: false,
     options: [...new Array(10)].map((_, i) => `Option ${i}`),
@@ -43,36 +51,34 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/SimpleSelect',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     modelValue: 'Option 1',
   },
-};
+});
 
-export const DefaultDisabled: Story = {
+export const DefaultDisabled = meta.story({
   args: {
     disabled: true,
     modelValue: 'Option 1',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     modelValue: 'Option 1',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedDisabled: Story = {
+export const OutlinedDisabled = meta.story({
   args: {
     disabled: true,
     modelValue: 'Option 1',
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/slider/RuiSlider.stories.ts
+++ b/packages/ui-library/src/components/forms/slider/RuiSlider.stories.ts
@@ -1,28 +1,32 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiSlider, { type Props } from '@/components/forms/slider/RuiSlider.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiSlider from '@/components/forms/slider/RuiSlider.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiSlider },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiSlider>) {
+  return {
+    components: { RuiSlider },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `<div>
-    <RuiSlider v-bind="args" v-model="modelValue" />
-    <div class="text-rui-text">Value: {{ modelValue }}</div>
-  </div>`,
-});
+      return { args, modelValue };
+    },
+    template: `<div>
+      <RuiSlider v-bind="args" v-model="modelValue" />
+      <div class="text-rui-text">Value: {{ modelValue }}</div>
+    </div>`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
     successMessages: [],
@@ -54,58 +58,56 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/Slider',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const Secondary: Story = {
+export const Secondary = meta.story({
   args: {
     color: 'secondary',
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const Vertical: Story = {
+export const Vertical = meta.story({
   args: {
     label: 'Label',
     modelValue: 0,
     vertical: true,
   },
-};
+});
 
-export const ShowThumbLabel: Story = {
+export const ShowThumbLabel = meta.story({
   args: {
     label: 'Label',
     modelValue: 0,
     showThumbLabel: true,
   },
-};
+});
 
-export const ShowTicks: Story = {
+export const ShowTicks = meta.story({
   args: {
     label: 'Label',
     modelValue: 0,
     showTicks: true,
   },
-};
+});
 
-export const HideTrack: Story = {
+export const HideTrack = meta.story({
   args: {
     hideTrack: true,
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const TriStateStyle: Story = {
+export const TriStateStyle = meta.story({
   args: {
     label: 'Label',
     max: 2,
@@ -116,55 +118,55 @@ export const TriStateStyle: Story = {
     tickClass: '!bg-rui-grey-200 dark:!bg-rui-grey-800',
     tickSize: 12,
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
     label: 'Label',
     modelValue: 0,
   },
-};
+});
 
-export const WithSuccessMessage: Story = {
+export const WithSuccessMessage = meta.story({
   args: {
     label: 'Label',
     modelValue: 0,
     successMessages: ['With success messages'],
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Required Slider',
     modelValue: 0,
     required: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/switch/RuiSwitch.stories.ts
+++ b/packages/ui-library/src/components/forms/switch/RuiSwitch.stories.ts
@@ -1,29 +1,31 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiSwitch, { type Props } from '@/components/forms/switch/RuiSwitch.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiSwitch from '@/components/forms/switch/RuiSwitch.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type PropsAndLabel = Props & { label: string };
+function render(args: ComponentPropsAndSlots<typeof RuiSwitch>) {
+  return {
+    components: { RuiSwitch },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-const render: StoryFn<PropsAndLabel> = args => ({
-  components: { RuiSwitch },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+      return { args, modelValue };
+    },
+    template: `<RuiSwitch v-bind="args" v-model="modelValue">
+      {{ args.label }}
+    </RuiSwitch>`,
+  };
+}
 
-    return { args, modelValue };
-  },
-  template: `<RuiSwitch v-bind="args" v-model="modelValue">
-    {{ args.label }}
-  </RuiSwitch>`,
-});
-
-const meta: Meta<PropsAndLabel> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
     successMessages: [],
@@ -49,76 +51,74 @@ const meta: Meta<PropsAndLabel> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/Switch',
-};
+});
 
-type Story = StoryObj<PropsAndLabel>;
-
-export const Checked: Story = {
+export const Checked = meta.story({
   args: {
     modelValue: true,
   },
-};
+});
 
-export const Small: Story = {
+export const Small = meta.story({
   args: {
     label: 'asdfa',
     size: 'sm',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
   },
-};
+});
 
-export const WithLabel: Story = {
+export const WithLabel = meta.story({
   args: {
     label: 'With Label',
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
     label: 'Disabled',
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
     label: 'Label',
   },
-};
+});
 
-export const WithSuccessMessage: Story = {
+export const WithSuccessMessage = meta.story({
   args: {
     label: 'Label',
     successMessages: ['With success messages'],
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
     label: 'Label',
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
     label: 'Label',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Required Switch',
     required: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/text-area/RuiTextArea.stories.ts
+++ b/packages/ui-library/src/components/forms/text-area/RuiTextArea.stories.ts
@@ -1,28 +1,32 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiTextArea, { type Props } from '@/components/forms/text-area/RuiTextArea.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiTextArea from '@/components/forms/text-area/RuiTextArea.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type RuiTextAreaProps = Props & { modelValue: string };
-const render: StoryFn<RuiTextAreaProps> = args => ({
-  components: { RuiTextArea },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiTextArea>) {
+  return {
+    components: { RuiTextArea },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `<RuiTextArea v-model="modelValue" v-bind="args" />`,
-});
+      return { args, modelValue };
+    },
+    template: `<RuiTextArea v-model="modelValue" v-bind="args" />`,
+  };
+}
 
-const meta: Meta<RuiTextAreaProps> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
+    modelValue: undefined,
     successMessages: [],
   },
   argTypes: {
@@ -68,88 +72,86 @@ const meta: Meta<RuiTextAreaProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/TextArea',
-};
+});
 
-type Story = StoryObj<RuiTextAreaProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
   },
-};
+});
 
-export const Filled: Story = {
+export const Filled = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'filled',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Dense: Story = {
+export const Dense = meta.story({
   args: {
     dense: true,
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const WithSuccessMessage: Story = {
+export const WithSuccessMessage = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     successMessages: ['With success messages'],
     variant: 'outlined',
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
@@ -157,27 +159,27 @@ export const HideDetails: Story = {
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const WithPrependIcon: Story = {
+export const WithPrependIcon = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     prependIcon: 'heart-fill',
     variant: 'outlined',
   },
-};
+});
 
-export const WithAppendIcon: Story = {
+export const WithAppendIcon = meta.story({
   args: {
     appendIcon: 'heart-fill',
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Readonly: Story = {
+export const Readonly = meta.story({
   args: {
     label: 'Label',
     modelValue: 'Readonly text',
@@ -185,9 +187,9 @@ export const Readonly: Story = {
     readonly: true,
     variant: 'outlined',
   },
-};
+});
 
-export const Clearable: Story = {
+export const Clearable = meta.story({
   args: {
     clearable: true,
     label: 'Label',
@@ -195,15 +197,15 @@ export const Clearable: Story = {
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     required: true,
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/forms/text-field/RuiTextField.stories.ts
+++ b/packages/ui-library/src/components/forms/text-field/RuiTextField.stories.ts
@@ -1,29 +1,32 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiTextField, { type TextFieldProps } from '@/components/forms/text-field/RuiTextField.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiTextField from '@/components/forms/text-field/RuiTextField.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type Props = TextFieldProps & { modelValue: string };
+function render(args: ComponentPropsAndSlots<typeof RuiTextField>) {
+  return {
+    components: { RuiTextField },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiTextField },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+      return { args, modelValue };
+    },
+    template: `<RuiTextField v-model="modelValue" v-bind="args" />`,
+  };
+}
 
-    return { args, modelValue };
-  },
-  template: `<RuiTextField v-model="modelValue" v-bind="args" />`,
-});
-
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     errorMessages: [],
+    modelValue: undefined,
     successMessages: [],
   },
   argTypes: {
@@ -65,61 +68,59 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Forms/TextField',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
   },
-};
+});
 
-export const Filled: Story = {
+export const Filled = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'filled',
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Dense: Story = {
+export const Dense = meta.story({
   args: {
     dense: true,
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Readonly: Story = {
+export const Readonly = meta.story({
   args: {
     label: 'Label',
     modelValue: 'Readonly text',
@@ -127,36 +128,36 @@ export const Readonly: Story = {
     readonly: true,
     variant: 'outlined',
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     errorMessages: ['With error messages'],
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const WithSuccessMessage: Story = {
+export const WithSuccessMessage = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     successMessages: ['With success messages'],
     variant: 'outlined',
   },
-};
+});
 
-export const WithHint: Story = {
+export const WithHint = meta.story({
   args: {
     hint: 'With hint',
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const HideDetails: Story = {
+export const HideDetails = meta.story({
   args: {
     hideDetails: true,
     hint: 'Hint (should be invisible)',
@@ -164,49 +165,49 @@ export const HideDetails: Story = {
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const WithPrependIcon: Story = {
+export const WithPrependIcon = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     prependIcon: 'heart-fill',
     variant: 'outlined',
   },
-};
+});
 
-export const WithAppendIcon: Story = {
+export const WithAppendIcon = meta.story({
   args: {
     appendIcon: 'heart-fill',
     label: 'Label',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedWithNoLabel: Story = {
+export const OutlinedWithNoLabel = meta.story({
   args: {
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const OutlinedWithVeryLongLabel: Story = {
+export const OutlinedWithVeryLongLabel = meta.story({
   args: {
     label:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     placeholder: 'Placeholder',
     variant: 'outlined',
   },
-};
+});
 
-export const Required: Story = {
+export const Required = meta.story({
   args: {
     label: 'Label',
     placeholder: 'Placeholder',
     required: true,
     variant: 'outlined',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/icons/RuiIcon.stories.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.stories.ts
@@ -1,17 +1,20 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiIcon, { type Props } from '@/components/icons/RuiIcon.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { contextColors } from '@/consts/colors';
 import { RuiIcons } from '@/icons';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiIcon },
-  setup() {
-    return { args };
-  },
-  template: '<RuiIcon v-bind="args" />',
-});
+function render(args: ComponentPropsAndSlots<typeof RuiIcon>) {
+  return {
+    components: { RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: '<RuiIcon v-bind="args" />',
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     color: { control: 'select', options: contextColors },
     name: {
@@ -34,32 +37,30 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Icon',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
     name: 'lu-arrow-down',
     size: 24,
   },
-};
+});
 
-export const Secondary: Story = {
+export const Secondary = meta.story({
   args: {
     color: 'secondary',
     name: 'lu-arrow-down',
     size: 24,
   },
-};
+});
 
-export const PrimaryLarge: Story = {
+export const PrimaryLarge = meta.story({
   args: {
     color: 'primary',
     name: 'lu-arrow-down',
     size: 48,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/loaders/RuiSkeletonLoader.stories.ts
+++ b/packages/ui-library/src/components/loaders/RuiSkeletonLoader.stories.ts
@@ -1,19 +1,18 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiSkeletonLoader, { type Props as SkeletonProps } from '@/components/loaders/RuiSkeletonLoader.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiSkeletonLoader from '@/components/loaders/RuiSkeletonLoader.vue';
+import preview from '~/.storybook/preview';
 
-type Props = SkeletonProps & {
-  class: string;
-};
+function render(args: ComponentPropsAndSlots<typeof RuiSkeletonLoader>) {
+  return {
+    components: { RuiSkeletonLoader },
+    setup() {
+      return { args };
+    },
+    template: '<RuiSkeletonLoader v-bind="args" />',
+  };
+}
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiSkeletonLoader },
-  setup() {
-    return { args };
-  },
-  template: '<RuiSkeletonLoader v-bind="args" />',
-});
-
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     type: 'text',
   },
@@ -50,48 +49,46 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Loaders/Skeleton',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Paragraph: Story = {
+export const Paragraph = meta.story({
   args: { type: 'paragraph' },
-};
+});
 
-export const Heading: Story = {
+export const Heading = meta.story({
   args: { type: 'heading' },
-};
+});
 
-export const Article: Story = {
+export const Article = meta.story({
   args: { type: 'article' },
-};
+});
 
-export const Button: Story = {
+export const Button = meta.story({
   args: { type: 'button' },
-};
+});
 
-export const Icon: Story = {
+export const Icon = meta.story({
   args: { type: 'icon' },
-};
+});
 
-export const Avatar: Story = {
+export const Avatar = meta.story({
   args: { type: 'avatar' },
-};
+});
 
-export const Thumbnail: Story = {
+export const Thumbnail = meta.story({
   args: { type: 'thumbnail' },
-};
+});
 
-export const Custom: Story = {
+export const Custom = meta.story({
   args: { class: 'w-20 h-20', rounded: 'lg', type: 'custom' },
-};
+});
 
-export const CustomFullRound: Story = {
+export const CustomFullRound = meta.story({
   args: { class: 'w-20 h-20', rounded: 'full', type: 'custom' },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/logos/RuiLogo.stories.ts
+++ b/packages/ui-library/src/components/logos/RuiLogo.stories.ts
@@ -1,15 +1,18 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiLogo, { type Props } from '@/components/logos/RuiLogo.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiLogo from '@/components/logos/RuiLogo.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiLogo },
-  setup() {
-    return { args };
-  },
-  template: `<RuiLogo v-bind="args" />`,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiLogo>) {
+  return {
+    components: { RuiLogo },
+    setup() {
+      return { args };
+    },
+    template: `<RuiLogo v-bind="args" />`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     branch: { control: 'text' },
     logo: { control: 'text' },
@@ -20,30 +23,28 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Logo',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const WithText: Story = {
+export const WithText = meta.story({
   args: {
     text: true,
   },
-};
+});
 
-export const WithCustomSrc: Story = {
+export const WithCustomSrc = meta.story({
   args: {
     logo: 'drawer_logo',
   },
-};
+});
 
-export const WithCustomSrcAndFallback: Story = {
+export const WithCustomSrcAndFallback = meta.story({
   args: {
     logo: 'notfoundkey',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/badge/RuiBadge.stories.ts
+++ b/packages/ui-library/src/components/overlays/badge/RuiBadge.stories.ts
@@ -1,45 +1,49 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import { objectOmit } from '@vueuse/shared';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
-import RuiBadge, { type Props as BadgeProps } from '@/components/overlays/badge/RuiBadge.vue';
+import RuiBadge from '@/components/overlays/badge/RuiBadge.vue';
 import { contextColors } from '@/consts/colors';
 import { RuiIcons } from '@/icons';
+import preview from '~/.storybook/preview';
 
-type Props = BadgeProps & {
+type BadgeStoryArgs = ComponentPropsAndSlots<typeof RuiBadge> & {
   buttonText?: string | null;
 };
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiBadge, RuiButton, RuiIcon },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: BadgeStoryArgs) {
+  return {
+    components: { RuiBadge, RuiButton, RuiIcon },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    const badgeArgs = computed(() => objectOmit(args, ['buttonText']));
+      const badgeArgs = computed(() => objectOmit(args, ['buttonText']));
 
-    return { args, badgeArgs, modelValue };
-  },
-  template: `
-    <div class="text-center p-4">
-      <RuiBadge v-bind="badgeArgs" v-model="modelValue">
-        <template v-if="args.text" #badge>
-          {{ args.text }}
-        </template>
-        <RuiButton @click="modelValue = !modelValue">
-          {{ args.buttonText }}
-        </RuiButton>
-      </RuiBadge>
-    </div>`,
-});
+      return { args, badgeArgs, modelValue };
+    },
+    template: `
+      <div class="text-center p-4">
+        <RuiBadge v-bind="badgeArgs" v-model="modelValue">
+          <template v-if="args.text" #badge>
+            {{ args.text }}
+          </template>
+          <RuiButton @click="modelValue = !modelValue">
+            {{ args.buttonText }}
+          </RuiButton>
+        </RuiBadge>
+      </div>`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     buttonText: 'Badge',
     color: 'primary',
@@ -72,7 +76,6 @@ const meta: Meta<Props> = {
       control: 'text',
     },
   },
-  component: RuiBadge,
   parameters: {
     docs: {
       controls: { exclude: ['default', 'badge'] },
@@ -81,82 +84,80 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/Badge',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Left: Story = {
+export const Left = meta.story({
   args: {
     left: true,
   },
-};
+});
 
-export const Center: Story = {
+export const Center = meta.story({
   args: {
     placement: 'center',
   },
-};
+});
 
-export const CenterLeft: Story = {
+export const CenterLeft = meta.story({
   args: {
     left: true,
     placement: 'center',
   },
-};
+});
 
-export const Bottom: Story = {
+export const Bottom = meta.story({
   args: {
     placement: 'bottom',
   },
-};
+});
 
-export const BottomLeft: Story = {
+export const BottomLeft = meta.story({
   args: {
     left: true,
     placement: 'bottom',
   },
-};
+});
 
-export const Dot: Story = {
+export const Dot = meta.story({
   args: { dot: true },
-};
+});
 
-export const DotLeft: Story = {
+export const DotLeft = meta.story({
   args: { dot: true, left: true },
-};
+});
 
-export const DotCenter: Story = {
+export const DotCenter = meta.story({
   args: {
     dot: true,
     placement: 'center',
   },
-};
+});
 
-export const DotCenterLeft: Story = {
+export const DotCenterLeft = meta.story({
   args: {
     dot: true,
     left: true,
     placement: 'center',
   },
-};
+});
 
-export const DotBottom: Story = {
+export const DotBottom = meta.story({
   args: {
     dot: true,
     placement: 'bottom',
   },
-};
+});
 
-export const DotBottomLeft: Story = {
+export const DotBottomLeft = meta.story({
   args: {
     dot: true,
     left: true,
     placement: 'bottom',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/bottom-sheet/RuiBottomSheet.stories.ts
+++ b/packages/ui-library/src/components/overlays/bottom-sheet/RuiBottomSheet.stories.ts
@@ -1,56 +1,59 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiCard from '@/components/cards/RuiCard.vue';
-import RuiBottomSheet, { type BottomSheetProps } from '@/components/overlays/bottom-sheet/RuiBottomSheet.vue';
+import RuiBottomSheet from '@/components/overlays/bottom-sheet/RuiBottomSheet.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<BottomSheetProps> = args => ({
-  components: { RuiBottomSheet, RuiButton, RuiCard },
-  setup() {
-    return { args };
-  },
-  template: `
-    <RuiBottomSheet
-      v-bind="args"
-      width="900px"
-    >
-      <template #activator="{ attrs }">
-        <RuiButton v-bind="attrs">
-          Click me!
-        </RuiButton>
-      </template>
-      <template #default="{ close }">
-        <RuiCard no-padding>
-          <template #header>
-            Header
-          </template>
-          <template #subheader>
-            Subheader
-          </template>
-  
-          <div class="p-4 pb-0">
-            <div class="h-[500px]">
-              Contents
-            </div>
-  
-            <div class="border-t border-default py-4">
-              <div class="flex gap-2 w-full justify-end">
-                <RuiButton
-                  variant="outlined"
-                  color="primary"
-                  @click="close()"
-                >
-                  Close
-                </RuiButton>
+function render(args: ComponentPropsAndSlots<typeof RuiBottomSheet>) {
+  return {
+    components: { RuiBottomSheet, RuiButton, RuiCard },
+    setup() {
+      return { args };
+    },
+    template: `
+      <RuiBottomSheet
+        v-bind="args"
+        width="900px"
+      >
+        <template #activator="{ attrs }">
+          <RuiButton v-bind="attrs">
+            Click me!
+          </RuiButton>
+        </template>
+        <template #default="{ close }">
+          <RuiCard no-padding>
+            <template #header>
+              Header
+            </template>
+            <template #subheader>
+              Subheader
+            </template>
+
+            <div class="p-4 pb-0">
+              <div class="h-[500px]">
+                Contents
+              </div>
+
+              <div class="border-t border-default py-4">
+                <div class="flex gap-2 w-full justify-end">
+                  <RuiButton
+                    variant="outlined"
+                    color="primary"
+                    @click="close()"
+                  >
+                    Close
+                  </RuiButton>
+                </div>
               </div>
             </div>
-          </div>
-        </RuiCard>
-      </template>
-    </RuiBottomSheet>
-  `,
-});
+          </RuiCard>
+        </template>
+      </RuiBottomSheet>
+    `,
+  };
+}
 
-const meta: Meta<BottomSheetProps> = {
+const meta = preview.meta({
   args: {
     maxWidth: '500px',
     persistent: false,
@@ -70,24 +73,22 @@ const meta: Meta<BottomSheetProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/BottomSheet',
-};
+});
 
-type Story = StoryObj<BottomSheetProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Persistent: Story = {
+export const Persistent = meta.story({
   args: {
     persistent: true,
   },
-};
+});
 
-export const CustomMaxWidth: Story = {
+export const CustomMaxWidth = meta.story({
   args: {
     maxWidth: '1000px',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/dialog/RuiDialog.stories.ts
+++ b/packages/ui-library/src/components/overlays/dialog/RuiDialog.stories.ts
@@ -1,56 +1,59 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiCard from '@/components/cards/RuiCard.vue';
-import RuiDialog, { type DialogProps } from '@/components/overlays/dialog/RuiDialog.vue';
+import RuiDialog from '@/components/overlays/dialog/RuiDialog.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<DialogProps> = args => ({
-  components: { RuiButton, RuiCard, RuiDialog },
-  setup() {
-    return { args };
-  },
-  template: `
-    <RuiDialog
-      v-bind="args"
-      width="900px"
-    >
-      <template #activator="{ attrs }">
-        <RuiButton v-bind="attrs">
-          Click me!
-        </RuiButton>
-      </template>
-      <template #default="{ close }">
-        <RuiCard no-padding>
-          <template #header>
-            Header
-          </template>
-          <template #subheader>
-            Subheader
-          </template>
+function render(args: ComponentPropsAndSlots<typeof RuiDialog>) {
+  return {
+    components: { RuiButton, RuiCard, RuiDialog },
+    setup() {
+      return { args };
+    },
+    template: `
+      <RuiDialog
+        v-bind="args"
+        width="900px"
+      >
+        <template #activator="{ attrs }">
+          <RuiButton v-bind="attrs">
+            Click me!
+          </RuiButton>
+        </template>
+        <template #default="{ close }">
+          <RuiCard no-padding>
+            <template #header>
+              Header
+            </template>
+            <template #subheader>
+              Subheader
+            </template>
 
-          <div class="p-4 pb-0">
-            <div class="h-[300px]">
-              Contents
-            </div>
+            <div class="p-4 pb-0">
+              <div class="h-[300px]">
+                Contents
+              </div>
 
-            <div class="border-t border-default py-4">
-              <div class="flex gap-2 w-full justify-end">
-                <RuiButton
-                  variant="outlined"
-                  color="primary"
-                  @click="close()"
-                >
-                  Close
-                </RuiButton>
+              <div class="border-t border-default py-4">
+                <div class="flex gap-2 w-full justify-end">
+                  <RuiButton
+                    variant="outlined"
+                    color="primary"
+                    @click="close()"
+                  >
+                    Close
+                  </RuiButton>
+                </div>
               </div>
             </div>
-          </div>
-        </RuiCard>
-      </template>
-    </RuiDialog>
-  `,
-});
+          </RuiCard>
+        </template>
+      </RuiDialog>
+    `,
+  };
+}
 
-const meta: Meta<DialogProps> = {
+const meta = preview.meta({
   args: {
     maxWidth: '500px',
     persistent: false,
@@ -70,24 +73,22 @@ const meta: Meta<DialogProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/Dialog',
-};
+});
 
-type Story = StoryObj<DialogProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Persistent: Story = {
+export const Persistent = meta.story({
   args: {
     persistent: true,
   },
-};
+});
 
-export const CustomMaxWidth: Story = {
+export const CustomMaxWidth = meta.story({
   args: {
     maxWidth: '1000px',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.stories.ts
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.stories.ts
@@ -1,27 +1,30 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
-import RuiMenu, { type MenuProps } from '@/components/overlays/menu/RuiMenu.vue';
+import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
 import { DEFAULT_POPPER_OPTIONS } from '@/composables/popper';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<MenuProps> = args => ({
-  components: { RuiButton, RuiMenu },
-  setup() {
-    return { args };
-  },
-  template: `
-    <div class="text-center p-4">
-      <RuiMenu v-bind="args">
-        <template #activator="{ attrs }">
-          <RuiButton v-bind='attrs'>Click Me!</RuiButton>
-        </template>
-        <div class="px-4 py-3">
-          This is menu
-        </div>
-      </RuiMenu>
-    </div>`,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiMenu>) {
+  return {
+    components: { RuiButton, RuiMenu },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="text-center p-4">
+        <RuiMenu v-bind="args">
+          <template #activator="{ attrs }">
+            <RuiButton v-bind='attrs'>Click Me!</RuiButton>
+          </template>
+          <div class="px-4 py-3">
+            This is menu
+          </div>
+        </RuiMenu>
+      </div>`,
+  };
+}
 
-const meta: Meta<MenuProps> = {
+const meta = preview.meta({
   args: {
     closeDelay: 0,
     closeOnContentClick: false,
@@ -54,61 +57,59 @@ const meta: Meta<MenuProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/Menu',
-};
+});
 
-type Story = StoryObj<MenuProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const OpenOnHover: Story = {
+export const OpenOnHover = meta.story({
   args: {
     closeDelay: 200,
     openOnHover: true,
   },
-};
+});
 
-export const CloseOnContentClick: Story = {
+export const CloseOnContentClick = meta.story({
   args: {
     closeOnContentClick: true,
   },
-};
+});
 
-export const Top: Story = {
+export const Top = meta.story({
   args: {
     popper: {
       placement: 'top',
     },
   },
-};
+});
 
-export const Right: Story = {
+export const Right = meta.story({
   args: {
     popper: {
       placement: 'right',
     },
   },
-};
+});
 
-export const Left: Story = {
+export const Left = meta.story({
   args: {
     popper: {
       placement: 'left',
     },
   },
-};
+});
 
-export const MenuDisabled: Story = {
+export const MenuDisabled = meta.story({
   args: {
     disabled: true,
   },
-};
+});
 
-export const PersistentMenu: Story = {
+export const PersistentMenu = meta.story({
   args: {
     persistent: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.stories.ts
+++ b/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.stories.ts
@@ -1,36 +1,40 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
-import RuiNavigationDrawer, { type NavigationDrawerProps } from '@/components/overlays/navigation-drawer/RuiNavigationDrawer.vue';
+import RuiNavigationDrawer from '@/components/overlays/navigation-drawer/RuiNavigationDrawer.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<NavigationDrawerProps> = args => ({
-  components: { RuiButton, RuiNavigationDrawer },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiNavigationDrawer>) {
+  return {
+    components: { RuiButton, RuiNavigationDrawer },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `
-    <RuiNavigationDrawer v-bind="args" v-model='modelValue'>
-      <template #activator="{ attrs }">
-        <RuiButton v-bind="attrs">
-          Click me!
-        </RuiButton>
-      </template>
-      <div class="p-4">
-        Navigation Drawer
-      </div>
-    </RuiNavigationDrawer>
-  `,
-});
+      return { args, modelValue };
+    },
+    template: `
+      <RuiNavigationDrawer v-bind="args" v-model='modelValue'>
+        <template #activator="{ attrs }">
+          <RuiButton v-bind="attrs">
+            Click me!
+          </RuiButton>
+        </template>
+        <div class="p-4">
+          Navigation Drawer
+        </div>
+      </RuiNavigationDrawer>
+    `,
+  };
+}
 
-const meta: Meta<NavigationDrawerProps> = {
+const meta = preview.meta({
   args: {
     modelValue: false,
   },
@@ -52,25 +56,23 @@ const meta: Meta<NavigationDrawerProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/NavigationDrawer',
-};
+});
 
-type Story = StoryObj<NavigationDrawerProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     temporary: true,
   },
-};
+});
 
-export const Right: Story = {
+export const Right = meta.story({
   args: {
     position: 'right',
     temporary: true,
   },
-};
+});
 
-export const Persistent: Story = {
+export const Persistent = meta.story({
   args: {},
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/notification/RuiNotification.stories.ts
+++ b/packages/ui-library/src/components/overlays/notification/RuiNotification.stories.ts
@@ -1,32 +1,36 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
-import RuiNotification, { type NotificationProps } from '@/components/overlays/notification/RuiNotification.vue';
+import RuiNotification from '@/components/overlays/notification/RuiNotification.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<NotificationProps> = args => ({
-  components: { RuiButton, RuiNotification },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiNotification>) {
+  return {
+    components: { RuiButton, RuiNotification },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `
-    <div>
-      <RuiButton @click="modelValue = !modelValue"> Click </RuiButton>
-      <RuiNotification v-bind="args" v-model='modelValue'>
-        <div class='m-4'>I am a notification</div>
-      </RuiNotification>
-    </div>
-  `,
-});
+      return { args, modelValue };
+    },
+    template: `
+      <div>
+        <RuiButton @click="modelValue = !modelValue"> Click </RuiButton>
+        <RuiNotification v-bind="args" v-model='modelValue'>
+          <div class='m-4'>I am a notification</div>
+        </RuiNotification>
+      </div>
+    `,
+  };
+}
 
-const meta: Meta<NotificationProps> = {
+const meta = preview.meta({
   args: {
     timeout: 0,
   },
@@ -47,45 +51,43 @@ const meta: Meta<NotificationProps> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/Notification',
-};
+});
 
-type Story = StoryObj<NotificationProps>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     modelValue: false,
     timeout: 0,
   },
-};
+});
 
-export const NonPersistent: Story = {
+export const NonPersistent = meta.story({
   args: {
     modelValue: false,
     timeout: 5000,
   },
-};
+});
 
-export const Light: Story = {
+export const Light = meta.story({
   args: {
     modelValue: false,
     theme: 'light',
     timeout: 5000,
   },
-};
+});
 
-export const Dark: Story = {
+export const Dark = meta.story({
   args: {
     modelValue: false,
     theme: 'dark',
     timeout: 5000,
   },
-};
+});
 
-export const Persistent: Story = {
+export const Persistent = meta.story({
   args: {
     modelValue: false,
     timeout: -1,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.stories.ts
+++ b/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.stories.ts
@@ -1,24 +1,27 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiTooltip, { type Props } from '@/components/overlays/tooltip/RuiTooltip.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiTooltip from '@/components/overlays/tooltip/RuiTooltip.vue';
 import { DEFAULT_POPPER_OPTIONS } from '@/composables/popper';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiTooltip },
-  setup() {
-    return { args };
-  },
-  template: `
-    <div class="text-center p-4">
-      <RuiTooltip v-bind="args">
-        <template #activator>
-          <span class="text-rui-primary"> Tooltip </span>
-        </template>
-        {{ args.text }}
-      </RuiTooltip>
-    </div>`,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiTooltip>) {
+  return {
+    components: { RuiTooltip },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="text-center p-4">
+        <RuiTooltip v-bind="args">
+          <template #activator>
+            <span class="text-rui-primary"> Tooltip </span>
+          </template>
+          {{ args.text }}
+        </RuiTooltip>
+      </div>`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     closeDelay: 500,
     disabled: false,
@@ -51,82 +54,80 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Overlays/Tooltip',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Top: Story = {
+export const Top = meta.story({
   args: {
     popper: {
       placement: 'top',
     },
   },
-};
+});
 
-export const Right: Story = {
+export const Right = meta.story({
   args: {
     popper: {
       placement: 'right',
     },
   },
-};
+});
 
-export const Left: Story = {
+export const Left = meta.story({
   args: {
     popper: {
       placement: 'left',
     },
   },
-};
+});
 
-export const NoArrow: Story = {
+export const NoArrow = meta.story({
   args: {
     hideArrow: true,
   },
-};
+});
 
-export const NoArrowTop: Story = {
+export const NoArrowTop = meta.story({
   args: {
     hideArrow: true,
     popper: {
       placement: 'top',
     },
   },
-};
+});
 
-export const NoArrowRight: Story = {
+export const NoArrowRight = meta.story({
   args: {
     hideArrow: true,
     popper: {
       placement: 'right',
     },
   },
-};
+});
 
-export const NoArrowLeft: Story = {
+export const NoArrowLeft = meta.story({
   args: {
     hideArrow: true,
     popper: {
       placement: 'left',
     },
   },
-};
+});
 
-export const WithCustomSizeFromTooltipClass: Story = {
+export const WithCustomSizeFromTooltipClass = meta.story({
   args: {
     text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
     tooltipClass: 'max-w-[20rem]',
   },
-};
+});
 
-export const TooltipDisabled: Story = {
+export const TooltipDisabled = meta.story({
   args: {
     disabled: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/progress/RuiProgress.stories.ts
+++ b/packages/ui-library/src/components/progress/RuiProgress.stories.ts
@@ -1,17 +1,20 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiProgress, { type Props } from '@/components/progress/RuiProgress.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiProgress from '@/components/progress/RuiProgress.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { Progress: RuiProgress },
-  setup() {
-    return { args };
-  },
-  template:
-    '<div class="text-black dark:text-white"><Progress v-bind="args" /></div>',
-});
+function render(args: ComponentPropsAndSlots<typeof RuiProgress>) {
+  return {
+    components: { Progress: RuiProgress },
+    setup() {
+      return { args };
+    },
+    template:
+      '<div class="text-black dark:text-white"><Progress v-bind="args" /></div>',
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   args: {
     size: 32,
     thickness: 4,
@@ -46,11 +49,9 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Progress',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     bufferValue: 60,
     circular: false,
@@ -58,9 +59,9 @@ export const Default: Story = {
     value: 50,
     variant: 'determinate',
   },
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     bufferValue: 60,
     circular: false,
@@ -69,76 +70,76 @@ export const Primary: Story = {
     value: 50,
     variant: 'determinate',
   },
-};
+});
 
-export const WithLabel: Story = {
+export const WithLabel = meta.story({
   args: {
     showLabel: true,
     value: 50,
   },
-};
+});
 
-export const Secondary: Story = {
+export const Secondary = meta.story({
   args: {
     color: 'secondary',
     value: 50,
   },
-};
+});
 
-export const Indeterminate: Story = {
+export const Indeterminate = meta.story({
   args: {
     value: 50,
     variant: 'indeterminate',
   },
-};
+});
 
-export const Buffer: Story = {
+export const Buffer = meta.story({
   args: {
     bufferValue: 70,
     value: 50,
     variant: 'buffer',
   },
-};
+});
 
-export const BufferWithLabel: Story = {
+export const BufferWithLabel = meta.story({
   args: {
     bufferValue: 70,
     showLabel: true,
     value: 50,
     variant: 'buffer',
   },
-};
+});
 
-export const Circular: Story = {
+export const Circular = meta.story({
   args: {
     circular: true,
     value: 50,
   },
-};
+});
 
-export const CircularPrimary: Story = {
+export const CircularPrimary = meta.story({
   args: {
     circular: true,
     color: 'primary',
     value: 50,
   },
-};
+});
 
-export const CircularIndeterminate: Story = {
+export const CircularIndeterminate = meta.story({
   args: {
     circular: true,
     value: 50,
     variant: 'indeterminate',
   },
-};
+});
 
-export const CircularWithLabel: Story = {
+export const CircularWithLabel = meta.story({
   args: {
     circular: true,
     showLabel: true,
     value: 100,
     variant: 'determinate',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/steppers/RuiFooterStepper.stories.ts
+++ b/packages/ui-library/src/components/steppers/RuiFooterStepper.stories.ts
@@ -1,24 +1,28 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiFooterStepper, { type Props } from '@/components/steppers/RuiFooterStepper.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiFooterStepper from '@/components/steppers/RuiFooterStepper.vue';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiFooterStepper },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
+function render(args: ComponentPropsAndSlots<typeof RuiFooterStepper>) {
+  return {
+    components: { RuiFooterStepper },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-    return { args, modelValue };
-  },
-  template: `<RuiFooterStepper v-model="modelValue" v-bind="args" />`,
-});
+      return { args, modelValue };
+    },
+    template: `<RuiFooterStepper v-model="modelValue" v-bind="args" />`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     arrowButtons: { control: 'boolean', table: { category: 'State' } },
     hideButtons: { control: 'boolean', table: { category: 'State' } },
@@ -42,20 +46,18 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/FooterStepper',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     arrowButtons: false,
     modelValue: 1,
     pages: 5,
     variant: 'numeric',
   },
-};
+});
 
-export const DefaultWithoutButtons: Story = {
+export const DefaultWithoutButtons = meta.story({
   args: {
     arrowButtons: false,
     hideButtons: false,
@@ -63,18 +65,18 @@ export const DefaultWithoutButtons: Story = {
     pages: 5,
     variant: 'numeric',
   },
-};
+});
 
-export const Bullet: Story = {
+export const Bullet = meta.story({
   args: {
     arrowButtons: false,
     modelValue: 1,
     pages: 5,
     variant: 'bullet',
   },
-};
+});
 
-export const BulletWithoutButtons: Story = {
+export const BulletWithoutButtons = meta.story({
   args: {
     arrowButtons: false,
     hideButtons: true,
@@ -82,18 +84,18 @@ export const BulletWithoutButtons: Story = {
     pages: 5,
     variant: 'bullet',
   },
-};
+});
 
-export const Progress: Story = {
+export const Progress = meta.story({
   args: {
     arrowButtons: false,
     modelValue: 1,
     pages: 5,
     variant: 'progress',
   },
-};
+});
 
-export const ProgressWithoutButtons: Story = {
+export const ProgressWithoutButtons = meta.story({
   args: {
     arrowButtons: false,
     hideButtons: true,
@@ -101,42 +103,42 @@ export const ProgressWithoutButtons: Story = {
     pages: 5,
     variant: 'progress',
   },
-};
+});
 
-export const Pills: Story = {
+export const Pills = meta.story({
   args: {
     arrowButtons: false,
     modelValue: 1,
     pages: 5,
     variant: 'pill',
   },
-};
+});
 
-export const ArrowButtons: Story = {
+export const ArrowButtons = meta.story({
   args: {
     arrowButtons: true,
     modelValue: 1,
     pages: 5,
     variant: 'numeric',
   },
-};
+});
 
-export const BulletWithArrows: Story = {
+export const BulletWithArrows = meta.story({
   args: {
     arrowButtons: true,
     modelValue: 1,
     pages: 5,
     variant: 'bullet',
   },
-};
+});
 
-export const ProgressWithArrows: Story = {
+export const ProgressWithArrows = meta.story({
   args: {
     arrowButtons: true,
     modelValue: 1,
     pages: 5,
     variant: 'progress',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/steppers/RuiStepper.stories.ts
+++ b/packages/ui-library/src/components/steppers/RuiStepper.stories.ts
@@ -1,16 +1,19 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
-import RuiStepper, { type Props } from '@/components/steppers/RuiStepper.vue';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiStepper from '@/components/steppers/RuiStepper.vue';
 import { StepperOrientation, StepperState } from '@/types/stepper';
+import preview from '~/.storybook/preview';
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiStepper },
-  setup() {
-    return { args };
-  },
-  template: `<RuiStepper v-bind="args" />`,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiStepper>) {
+  return {
+    components: { RuiStepper },
+    setup() {
+      return { args };
+    },
+    template: `<RuiStepper v-bind="args" />`,
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     custom: { control: 'boolean', table: { category: 'State' } },
     iconTop: { control: 'boolean', table: { category: 'State' } },
@@ -31,11 +34,9 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Stepper',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     steps: [
       {
@@ -75,9 +76,9 @@ export const Default: Story = {
       },
     ],
   },
-};
+});
 
-export const VerticalOrientation: Story = {
+export const VerticalOrientation = meta.story({
   args: {
     orientation: StepperOrientation.vertical,
     steps: [
@@ -118,9 +119,9 @@ export const VerticalOrientation: Story = {
       },
     ],
   },
-};
+});
 
-export const TitleOnly: Story = {
+export const TitleOnly = meta.story({
   args: {
     steps: [
       { state: StepperState.done, title: 'Step' },
@@ -129,9 +130,9 @@ export const TitleOnly: Story = {
       { state: StepperState.inactive, title: 'Step' },
     ],
   },
-};
+});
 
-export const Loading: Story = {
+export const Loading = meta.story({
   args: {
     steps: [
       { state: StepperState.done, title: 'Step' },
@@ -140,9 +141,9 @@ export const Loading: Story = {
       { state: StepperState.inactive, title: 'Step' },
     ],
   },
-};
+});
 
-export const TitleOnlyAndVertical: Story = {
+export const TitleOnlyAndVertical = meta.story({
   args: {
     orientation: StepperOrientation.vertical,
     steps: [
@@ -152,9 +153,9 @@ export const TitleOnlyAndVertical: Story = {
       { state: StepperState.inactive, title: 'Step' },
     ],
   },
-};
+});
 
-export const DescriptionOnly: Story = {
+export const DescriptionOnly = meta.story({
   args: {
     steps: [
       { description: 'Lorem ipsum', state: StepperState.done },
@@ -163,9 +164,9 @@ export const DescriptionOnly: Story = {
       { description: 'Lorem ipsum', state: StepperState.inactive },
     ],
   },
-};
+});
 
-export const DescriptionOnlyAndVertical: Story = {
+export const DescriptionOnlyAndVertical = meta.story({
   args: {
     orientation: StepperOrientation.vertical,
     steps: [
@@ -175,9 +176,9 @@ export const DescriptionOnlyAndVertical: Story = {
       { description: 'Lorem ipsum', state: StepperState.inactive },
     ],
   },
-};
+});
 
-export const StepOnly: Story = {
+export const StepOnly = meta.story({
   args: {
     steps: [
       { state: StepperState.done },
@@ -186,9 +187,9 @@ export const StepOnly: Story = {
       { state: StepperState.inactive },
     ],
   },
-};
+});
 
-export const StepOnlyAndVertical: Story = {
+export const StepOnlyAndVertical = meta.story({
   args: {
     orientation: StepperOrientation.vertical,
     steps: [
@@ -198,9 +199,9 @@ export const StepOnlyAndVertical: Story = {
       { state: StepperState.inactive },
     ],
   },
-};
+});
 
-export const Custom: Story = {
+export const Custom = meta.story({
   args: {
     custom: true,
     step: 1,
@@ -220,9 +221,9 @@ export const Custom: Story = {
       },
     ],
   },
-};
+});
 
-export const CustomVertical: Story = {
+export const CustomVertical = meta.story({
   args: {
     custom: true,
     orientation: StepperOrientation.vertical,
@@ -243,9 +244,9 @@ export const CustomVertical: Story = {
       },
     ],
   },
-};
+});
 
-export const CustomWithColor: Story = {
+export const CustomWithColor = meta.story({
   args: {
     custom: true,
     step: 1,
@@ -267,6 +268,6 @@ export const CustomWithColor: Story = {
     subtitleClass: 'text-rui-primary/80',
     titleClass: 'text-rui-primary',
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
@@ -1,12 +1,13 @@
 /* eslint-disable max-lines */
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots, Decorator } from '@storybook/vue3-vite';
 import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
 import { objectOmit } from '@vueuse/shared';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiCard from '@/components/cards/RuiCard.vue';
 import RuiTextField from '@/components/forms/text-field/RuiTextField.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
-import RuiDataTable, { type Props as TableProps } from '@/components/tables/RuiDataTable.vue';
+import RuiDataTable from '@/components/tables/RuiDataTable.vue';
+import preview from '~/.storybook/preview';
 
 interface User {
   id: number;
@@ -17,81 +18,85 @@ interface User {
   date: string;
 }
 
-type Props = TableProps<User, 'id'>;
+type DataTableProps = ComponentPropsAndSlots<typeof RuiDataTable<User>>;
 
-const render: StoryFn<Props> = args => ({
-  components: { RuiButton, RuiCard, RuiDataTable: RuiDataTable<User>, RuiIcon, RuiTextField },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
-    const pagination = computed({
-      get() {
-        return args.pagination;
-      },
-      set(val) {
-        args.pagination = val;
-      },
-    });
-    const sort = computed({
-      get() {
-        return args.sort;
-      },
-      set(val) {
-        args.sort = val;
-      },
-    });
-    const search = computed({
-      get() {
-        return args.search;
-      },
-      set(val) {
-        args.search = val;
-      },
-    });
-    const expanded = computed({
-      get() {
-        return args.expanded;
-      },
-      set(val) {
-        args.expanded = val;
-      },
-    });
-    const group = computed({
-      get() {
-        return args.group;
-      },
-      set(val) {
-        args.group = val;
-      },
-    });
-    const collapsed = computed({
-      get() {
-        return args.collapsed;
-      },
-      set(val) {
-        args.collapsed = val;
-      },
-    });
+type DataTableMetaArgs = Required<Pick<DataTableProps, 'columnAttr' | 'dense' | 'loading' | 'outlined' | 'rounded' | 'rowAttr' | 'rows' | 'striped'>>
+  & Partial<Pick<DataTableProps, 'modelValue'>>;
 
-    return {
-      args,
-      collapsed,
-      expanded,
-      group,
-      modelValue,
-      objectOmit,
-      pagination,
-      search,
-      sort,
-    };
-  },
-  template: `
+function render(args: DataTableProps) {
+  return {
+    components: { RuiButton, RuiCard, RuiDataTable: RuiDataTable<User>, RuiIcon, RuiTextField },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          args.modelValue = val;
+        },
+      });
+      const pagination = computed({
+        get() {
+          return args.pagination;
+        },
+        set(val) {
+          args.pagination = val;
+        },
+      });
+      const sort = computed({
+        get() {
+          return args.sort;
+        },
+        set(val) {
+          args.sort = val;
+        },
+      });
+      const search = computed({
+        get() {
+          return args.search;
+        },
+        set(val) {
+          args.search = val;
+        },
+      });
+      const expanded = computed({
+        get() {
+          return args.expanded;
+        },
+        set(val) {
+          args.expanded = val;
+        },
+      });
+      const group = computed({
+        get() {
+          return args.group;
+        },
+        set(val) {
+          args.group = val;
+        },
+      });
+      const collapsed = computed({
+        get() {
+          return args.collapsed;
+        },
+        set(val) {
+          args.collapsed = val;
+        },
+      });
+
+      return {
+        args,
+        collapsed,
+        expanded,
+        group,
+        modelValue,
+        objectOmit,
+        pagination,
+        search,
+        sort,
+      };
+    },
+    template: `
     <div class="flex flex-col space-y-4">
       <div class="flex items-center space-x-4">
         <RuiTextField
@@ -153,7 +158,8 @@ const render: StoryFn<Props> = args => ({
         </template>
       </RuiDataTable>
     </div>`,
-});
+  };
+}
 
 const data: User[] = [
   {
@@ -254,7 +260,7 @@ const columns: TableColumn<User>[] = [
   },
 ];
 
-const meta: Meta<Props> = {
+const meta = preview.meta<typeof RuiDataTable<User>, Decorator, DataTableMetaArgs>({
   args: {
     columnAttr: 'label',
     dense: false,
@@ -272,7 +278,7 @@ const meta: Meta<Props> = {
       options: ['sm', 'md', 'lg'],
     },
   },
-  component: RuiDataTable as any,
+  component: RuiDataTable<User>,
   parameters: {
     docs: {
       controls: {
@@ -301,76 +307,74 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Tables/DataTable',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     cols: columns,
     pagination: { limit: 10, page: 1, total: 50 },
     rows: data,
     sort: [{ column: 'name', direction: 'asc' }],
   },
-};
+});
 
-export const Dense: Story = {
+export const Dense = meta.story({
   args: {
     dense: true,
     rows: data,
   },
-};
+});
 
-export const Loading: Story = {
+export const Loading = meta.story({
   args: {
     cols: columns,
     loading: true,
     rows: [],
   },
-};
+});
 
-export const WithColumnDefinitions: Story = {
+export const WithColumnDefinitions = meta.story({
   args: {
     cols: columns,
     rows: data,
   },
-};
+});
 
-export const Selectable: Story = {
+export const Selectable = meta.story({
   args: {
     cols: columns,
     modelValue: [],
     rows: data,
   },
-};
+});
 
-export const SelectableAndDense: Story = {
+export const SelectableAndDense = meta.story({
   args: {
     cols: columns,
     dense: true,
     modelValue: [],
     rows: data,
   },
-};
+});
 
-export const WithPagination: Story = {
+export const WithPagination = meta.story({
   args: {
     modelValue: [],
     pagination: { limit: 10, page: 1, total: 50 },
     rows: data,
   },
-};
+});
 
-export const ColumnsWithPagination: Story = {
+export const ColumnsWithPagination = meta.story({
   args: {
     cols: columns,
     modelValue: [],
     pagination: { limit: 10, page: 1, total: 50 },
     rows: data,
   },
-};
+});
 
-export const Outlined: Story = {
+export const Outlined = meta.story({
   args: {
     cols: columns,
     modelValue: [],
@@ -378,9 +382,9 @@ export const Outlined: Story = {
     pagination: { limit: 10, page: 1, total: 50 },
     rows: data,
   },
-};
+});
 
-export const Striped: Story = {
+export const Striped = meta.story({
   args: {
     cols: columns,
     modelValue: [],
@@ -388,9 +392,9 @@ export const Striped: Story = {
     rows: data,
     striped: true,
   },
-};
+});
 
-export const SingleSort: Story = {
+export const SingleSort = meta.story({
   args: {
     cols: columns,
     modelValue: [],
@@ -398,9 +402,9 @@ export const SingleSort: Story = {
     rows: data,
     sort: { column: 'name', direction: 'asc' },
   },
-};
+});
 
-export const MultipleSort: Story = {
+export const MultipleSort = meta.story({
   args: {
     cols: columns,
     modelValue: [],
@@ -411,9 +415,9 @@ export const MultipleSort: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
-export const LoadingWithData: Story = {
+export const LoadingWithData = meta.story({
   args: {
     cols: columns,
     loading: true,
@@ -426,9 +430,9 @@ export const LoadingWithData: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
-export const LoadingWithoutData: Story = {
+export const LoadingWithoutData = meta.story({
   args: {
     cols: columns,
     loading: true,
@@ -441,9 +445,9 @@ export const LoadingWithoutData: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
-export const EmptyState: Story = {
+export const EmptyState = meta.story({
   args: {
     cols: columns,
     empty: {
@@ -459,9 +463,9 @@ export const EmptyState: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
-export const Expandable: Story = {
+export const Expandable = meta.story({
   args: {
     cols: columns,
     expanded: [],
@@ -474,9 +478,9 @@ export const Expandable: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
-export const SingleExpandable: Story = {
+export const SingleExpandable = meta.story({
   args: {
     cols: columns,
     expanded: [],
@@ -490,9 +494,9 @@ export const SingleExpandable: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
-export const StickyHeader: Story = {
+export const StickyHeader = meta.story({
   args: {
     cols: columns,
     expanded: [],
@@ -508,9 +512,9 @@ export const StickyHeader: Story = {
     stickyHeader: true,
     stickyOffset: 40,
   },
-};
+});
 
-export const Grouped: Story = {
+export const Grouped = meta.story({
   args: {
     collapsed: [],
     cols: columns,
@@ -525,6 +529,6 @@ export const Grouped: Story = {
       { column: 'email', direction: 'asc' },
     ],
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/tabs/tabs/RuiTabs.stories.ts
+++ b/packages/ui-library/src/components/tabs/tabs/RuiTabs.stories.ts
@@ -1,36 +1,37 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import RuiCard from '@/components/cards/RuiCard.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiTabItem from '@/components/tabs/tab-item/RuiTabItem.vue';
 import RuiTabItems from '@/components/tabs/tab-items/RuiTabItems.vue';
 import RuiTab from '@/components/tabs/tab/RuiTab.vue';
-import RuiTabs, { type Props as TabsProps } from '@/components/tabs/tabs/RuiTabs.vue';
+import RuiTabs from '@/components/tabs/tabs/RuiTabs.vue';
 import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
 
-type Props = TabsProps & { class?: string };
+function render(args: ComponentPropsAndSlots<typeof RuiTabs>) {
+  return {
+    components: {
+      RuiCard,
+      RuiIcon,
+      RuiTab,
+      RuiTabItem,
+      RuiTabItems: RuiTabItems<number>,
+      RuiTabs,
+    },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
 
-const render: StoryFn<Props> = args => ({
-  components: {
-    RuiCard,
-    RuiIcon,
-    RuiTab,
-    RuiTabItem,
-    RuiTabItems: RuiTabItems as any,
-    RuiTabs,
-  },
-  setup() {
-    const modelValue = computed({
-      get() {
-        return args.modelValue;
-      },
-      set(val) {
-        args.modelValue = val;
-      },
-    });
-
-    return { args, modelValue };
-  },
-  template: `
+      return { args, modelValue };
+    },
+    template: `
     <div class="flex" :class="args.vertical ? 'flex-row gap-x-6' : 'flex-col'">
       <RuiTabs v-bind="args" v-model='modelValue'>
         <RuiTab>
@@ -71,9 +72,10 @@ const render: StoryFn<Props> = args => ({
       </RuiTabItems>
     </div>
   `,
-});
+  };
+}
 
-const meta: Meta<Props> = {
+const meta = preview.meta({
   argTypes: {
     align: { control: 'select', options: ['start', 'center', 'end'] },
     class: { control: 'text' },
@@ -92,65 +94,63 @@ const meta: Meta<Props> = {
   render,
   tags: ['autodocs'],
   title: 'Components/Tabs',
-};
+});
 
-type Story = StoryObj<Props>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {},
-};
+});
 
-export const Primary: Story = {
+export const Primary = meta.story({
   args: {
     color: 'primary',
   },
-};
+});
 
-export const Disabled: Story = {
+export const Disabled = meta.story({
   args: {
     disabled: true,
   },
-};
+});
 
-export const Grow: Story = {
+export const Grow = meta.story({
   args: {
     grow: true,
   },
-};
+});
 
-export const Vertical: Story = {
+export const Vertical = meta.story({
   args: {
     class: 'w-[200px]',
     vertical: true,
   },
-};
+});
 
-export const DefaultWithArrow: Story = {
+export const DefaultWithArrow = meta.story({
   args: {
     class: 'w-[500px]',
   },
-};
+});
 
-export const VerticalWithArrow: Story = {
+export const VerticalWithArrow = meta.story({
   args: {
     class: 'w-[200px] h-[300px]',
     vertical: true,
   },
-};
+});
 
-export const IndicatorPositionOnTop: Story = {
+export const IndicatorPositionOnTop = meta.story({
   args: {
     class: 'w-[200px] h-[300px]',
     indicatorPosition: 'start',
   },
-};
+});
 
-export const IndicatorPositionOnLeft: Story = {
+export const IndicatorPositionOnLeft = meta.story({
   args: {
     class: 'w-[200px] h-[300px]',
     indicatorPosition: 'start',
     vertical: true,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/components/time-picker/RuiTimePicker.stories.ts
+++ b/packages/ui-library/src/components/time-picker/RuiTimePicker.stories.ts
@@ -1,21 +1,24 @@
-import type { Meta, StoryFn, StoryObj } from '@storybook/vue3-vite';
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import { TimeAccuracy } from '@/consts/time-accuracy';
+import preview from '~/.storybook/preview';
 import RuiTimePicker from './RuiTimePicker.vue';
 
-const render: StoryFn<typeof RuiTimePicker> = args => ({
-  components: { RuiTimePicker },
-  setup() {
-    return { args };
-  },
-  template: `
-    <div class='flex gap-4'>
-      <RuiTimePicker v-bind="args" v-model='args.modelValue' />
-      <div class='text-rui-text'>{{ args.modelValue !== undefined ? new Date(args.modelValue).toISOString(): '-' }}</div>
-    </div>
-  `,
-});
+function render(args: ComponentPropsAndSlots<typeof RuiTimePicker>) {
+  return {
+    components: { RuiTimePicker },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class='flex gap-4'>
+        <RuiTimePicker v-bind="args" v-model='args.modelValue' />
+        <div class='text-rui-text'>{{ args.modelValue !== undefined ? new Date(args.modelValue).toISOString(): '-' }}</div>
+      </div>
+    `,
+  };
+}
 
-const meta: Meta<typeof RuiTimePicker> = {
+const meta = preview.meta({
   argTypes: {
     'accuracy': {
       control: 'select',
@@ -37,35 +40,33 @@ const meta: Meta<typeof RuiTimePicker> = {
   render,
   tags: ['autodocs'],
   title: 'Components/TimePicker',
-};
+});
 
-type Story = StoryObj<typeof RuiTimePicker>;
-
-export const Default: Story = {
+export const Default = meta.story({
   args: {
     accuracy: TimeAccuracy.MINUTE,
     modelValue: new Date(),
   },
-};
+});
 
-export const WithSecondsAccuracy: Story = {
+export const WithSecondsAccuracy = meta.story({
   args: {
     accuracy: TimeAccuracy.SECOND,
     modelValue: new Date(),
   },
-};
+});
 
-export const WithMillisecondsAccuracy: Story = {
+export const WithMillisecondsAccuracy = meta.story({
   args: {
     accuracy: TimeAccuracy.MILLISECOND,
     modelValue: new Date(),
   },
-};
+});
 
-export const WithEmptyValue: Story = {
+export const WithEmptyValue = meta.story({
   args: {
     modelValue: undefined,
   },
-};
+});
 
 export default meta;

--- a/packages/ui-library/src/stories/references/icons.stories.ts
+++ b/packages/ui-library/src/stories/references/icons.stories.ts
@@ -1,10 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import IconBrowser from '@/components/icons/IconBrowser.vue';
+import preview from '~/.storybook/preview';
 
-const meta: Meta<typeof IconBrowser> = {
+const meta = preview.meta({
   component: IconBrowser,
-  tags: ['autodocs'],
-  title: 'References/Icons',
   parameters: {
     docs: {
       description: {
@@ -12,10 +10,10 @@ const meta: Meta<typeof IconBrowser> = {
       },
     },
   },
-};
+  tags: ['autodocs'],
+  title: 'References/Icons',
+});
 
-type Story = StoryObj<typeof IconBrowser>;
-
-export const Default: Story = {};
+export const Default = meta.story({});
 
 export default meta;


### PR DESCRIPTION
## Summary

- Migrate all 38 story files from CSF3 (`Meta<T>`, `StoryObj<T>`, `StoryFn<T>`) to CSF Next (`preview.meta()` + `meta.story()`)
- Update the `new-story.ts` scaffold script to generate the new pattern
- Use `ComponentPropsAndSlots<typeof Component>` instead of importing `Props` types from component files

## Test plan

- [ ] `pnpm run typecheck` passes
- [ ] `pnpm run lint` passes (0 errors, only pre-existing warnings)
- [ ] `pnpm run build:storybook` builds successfully
- [ ] Storybook renders all stories correctly with autodocs