### PR TITLE
fix(theme): move adaptive CSS variables to Tailwind plugin

### DIFF
--- a/apps/example/e2e/theme.spec.ts
+++ b/apps/example/e2e/theme.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+
+function getAdaptiveVariable(variableName: string): (page: import('@playwright/test').Page) => Promise<string> {
+  return async (page) => {
+    const raw = await page.evaluate((name) => {
+      const style = getComputedStyle(document.documentElement);
+      return style.getPropertyValue(name).trim();
+    }, variableName);
+    // Normalize leading zeros in decimal values (e.g. ".87" → "0.87")
+    // Chromium versions differ on whether they include the leading zero.
+    return raw.replace(/(?<!\d)\.(\d)/g, '0.$1');
+  };
+}
+
+test.describe('theme', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  test('should set adaptive CSS variables matching light theme defaults', async ({ page }) => {
+    // Ensure we're in light mode
+    const lightButton = page.locator('header button').first();
+    await lightButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+    const primaryMain = await getAdaptiveVariable('--rui-primary-main')(page);
+    expect(primaryMain).toBe('78, 91, 166');
+
+    const textPrimary = await getAdaptiveVariable('--rui-text-primary')(page);
+    expect(textPrimary).toBe('rgba(0, 0, 0, 0.87)');
+  });
+
+  test('should update adaptive CSS variables when switching to dark theme', async ({ page }) => {
+    // Switch to dark mode
+    const darkButton = page.locator('header button').nth(1);
+    await darkButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    const primaryMain = await getAdaptiveVariable('--rui-primary-main')(page);
+    expect(primaryMain).toBe('91, 104, 178');
+
+    const textPrimary = await getAdaptiveVariable('--rui-text-primary')(page);
+    expect(textPrimary).toBe('rgb(255, 255, 255)');
+  });
+
+  test('should switch adaptive CSS variables back when toggling light to dark to light', async ({ page }) => {
+    // Start in light mode
+    const lightButton = page.locator('header button').first();
+    const darkButton = page.locator('header button').nth(1);
+
+    await lightButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+    let primaryMain = await getAdaptiveVariable('--rui-primary-main')(page);
+    expect(primaryMain).toBe('78, 91, 166');
+
+    // Switch to dark
+    await darkButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    primaryMain = await getAdaptiveVariable('--rui-primary-main')(page);
+    expect(primaryMain).toBe('91, 104, 178');
+
+    // Switch back to light
+    await lightButton.click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+    primaryMain = await getAdaptiveVariable('--rui-primary-main')(page);
+    expect(primaryMain).toBe('78, 91, 166');
+  });
+});

--- a/packages/ui-library/src/composables/theme.ts
+++ b/packages/ui-library/src/composables/theme.ts
@@ -1,7 +1,6 @@
 import { defaultWindow, getSSRHandler, useColorMode } from '@vueuse/core';
 import { computed, type ComputedRef, type Ref, ref } from 'vue';
 import {
-  type ColorIntensity,
   defaultTheme,
   type InitThemeOptions,
   type ThemeConfig,
@@ -102,34 +101,6 @@ export const useRotkiTheme = createSharedComposable<() => ThemeContent>(() => {
   const init = (options: InitThemeOptions): void => {
     switchThemeScheme(options.mode ?? ThemeMode.auto);
     setThemeConfig(options.config ?? { ...defaultTheme });
-
-    const windowReference = defaultWindow;
-    if (windowReference) {
-      watch([isLight, theme], ([isLight, theme]) => {
-        const styleVariables = new Map();
-
-        // Compute context variables
-        Object.entries(theme).forEach(([context, contextObject]: [string, ColorIntensity]) => {
-          styleVariables.set(`--rui-${context}-darker`, contextObject.darker);
-          styleVariables.set(`--rui-${context}-lighter`, contextObject.lighter);
-          styleVariables.set(`--rui-${context}-main`, contextObject.DEFAULT);
-        });
-
-        // Determine the theme mode
-        const state = isLight ? ThemeMode.light : ThemeMode.dark;
-
-        // Add text color variables
-        styleVariables.set('--rui-text-disabled', `var(--rui-${state}-text-disabled)`);
-        styleVariables.set('--rui-text-primary', `var(--rui-${state}-text-primary)`);
-        styleVariables.set('--rui-text-secondary', `var(--rui-${state}-text-secondary)`);
-
-        // Apply all style variables in one operation
-        const rootStyle = windowReference.document.documentElement.style;
-        styleVariables.forEach((value, variableName) => {
-          rootStyle.setProperty(variableName, value);
-        });
-      }, { immediate: true });
-    }
   };
 
   return {

--- a/packages/ui-library/src/theme/index.ts
+++ b/packages/ui-library/src/theme/index.ts
@@ -70,7 +70,25 @@ const adaptiveTextColorsCombination = {
 };
 
 const themePlugin = plugin(
-  ({ addUtilities, addVariant, matchUtilities }) => {
+  ({ addBase, addUtilities, addVariant, matchUtilities }) => {
+    // Adaptive theme variable aliases
+    const themeVariables = (theme: 'light' | 'dark'): Record<string, string> =>
+      Object.fromEntries([
+        ...contextColors.flatMap(color => [
+          [`--rui-${color}-main`, `var(--rui-${theme}-${color}-main)`],
+          [`--rui-${color}-darker`, `var(--rui-${theme}-${color}-darker)`],
+          [`--rui-${color}-lighter`, `var(--rui-${theme}-${color}-lighter)`],
+        ]),
+        ['--rui-text-primary', `var(--rui-${theme}-text-primary)`],
+        ['--rui-text-secondary', `var(--rui-${theme}-text-secondary)`],
+        ['--rui-text-disabled', `var(--rui-${theme}-text-disabled)`],
+      ]);
+
+    addBase({
+      'html[data-theme="light"], html.light': themeVariables('light'),
+      'html[data-theme="dark"], html.dark': themeVariables('dark'),
+    });
+
     // Border utilities
     addUtilities({
       '.border-default': {


### PR DESCRIPTION
## Summary

- Move adaptive theme variable aliases (`--rui-primary-main`, `--rui-text-primary`, etc.) from runtime JS in `init()` to CSS rules via Tailwind's `addBase`
- Removes the imperative `watch` block that set CSS variables via `document.documentElement.style`
- Default theme colors now work without requiring `createRui()` plugin setup
- Adds e2e tests verifying CSS variables update correctly on theme toggle

Closes #391

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:run` — all 827 unit tests pass
- [x] `pnpm run test:e2e` — theme e2e tests verify CSS variables
- [x] Verify in Nuxt SSR app that theme colors work without `createRui()`