### PR TITLE
refactor(tables): extract RuiDataTable into focused composables

### DIFF
--- a/apps/example/e2e/data-table.spec.ts
+++ b/apps/example/e2e/data-table.spec.ts
@@ -10,11 +10,11 @@ test.describe('data tables - basic', () => {
     await expect(table).toBeVisible();
 
     await expect(
-      table.locator('thead th span[class*=_column__text_]').filter({ hasText: 'Street' }).first(),
+      table.locator('thead th span[data-id="column-text"]').filter({ hasText: 'Street' }).first(),
     ).toBeVisible();
 
     await expect(
-      table.locator('thead th span[class*=_column__text_]').getByText('address.street', { exact: true }),
+      table.locator('thead th span[data-id="column-text"]').getByText('address.street', { exact: true }),
     ).toHaveCount(0);
   });
 
@@ -23,7 +23,7 @@ test.describe('data tables - basic', () => {
     await expect(table).toBeVisible();
 
     await expect(
-      table.locator('thead th span[class*=_column__text_]').filter({ hasText: 'address.street' }).first(),
+      table.locator('thead th span[data-id="column-text"]').filter({ hasText: 'address.street' }).first(),
     ).toBeVisible();
   });
 
@@ -55,7 +55,7 @@ test.describe('data tables - sorting', () => {
     const table = page.locator('[data-cy=table-single-sort] [data-cy=table]');
     await expect(table).toBeVisible();
 
-    const sortButton = table.locator('thead th[class*=_sortable_] button').first();
+    const sortButton = table.locator('thead th[data-id="column-sortable"] button').first();
     await expect(sortButton).toBeVisible();
 
     // Get initial first row name
@@ -74,7 +74,7 @@ test.describe('data tables - sorting', () => {
     const table = page.locator('[data-cy=table-single-sort] [data-cy=table]');
     await expect(table).toBeVisible();
 
-    const sortButton = table.locator('thead th[class*=_sortable_] button').first();
+    const sortButton = table.locator('thead th[data-id="column-sortable"] button').first();
     const firstCell = table.locator('tbody tr:first-child td:nth-child(2)');
 
     // Get initial state (asc)
@@ -98,7 +98,7 @@ test.describe('data tables - sorting', () => {
     const table = page.locator('[data-cy=table-multi-sort] [data-cy=table]');
     await expect(table).toBeVisible();
 
-    const sortButtons = table.locator('thead th[class*=_sortable_] button');
+    const sortButtons = table.locator('thead th[data-id="column-sortable"] button');
     const secondSortButton = sortButtons.nth(1);
 
     // Click second sortable column to add to sort
@@ -161,7 +161,7 @@ test.describe('data tables - pagination', () => {
     await expect(table).toBeVisible();
 
     // Count initial rows
-    const initialRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const initialRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Open per-page dropdown and select different value
     const perPageSelect = container.locator('[data-cy=table-pagination-limit] [data-id=activator]').first();
@@ -172,7 +172,7 @@ test.describe('data tables - pagination', () => {
     await option.click();
 
     // Row count should change
-    const newRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const newRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
     expect(newRows).not.toEqual(initialRows);
   });
 
@@ -269,7 +269,7 @@ test.describe('data tables - search', () => {
     await expect(searchInput).toBeVisible();
 
     // Count initial rows
-    const initialRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const initialRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Type search query
     await searchInput.fill('Chelsey');
@@ -278,7 +278,7 @@ test.describe('data tables - search', () => {
     await page.waitForTimeout(100);
 
     // Row count should be reduced
-    const filteredRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const filteredRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
     expect(filteredRows).toBeLessThan(initialRows);
   });
 
@@ -290,13 +290,13 @@ test.describe('data tables - search', () => {
     await expect(table).toBeVisible();
 
     // Count initial rows
-    const initialRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const initialRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Search to filter
     await searchInput.fill('Chelsey');
     await page.waitForTimeout(100);
 
-    const filteredRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const filteredRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
     expect(filteredRows).toBeLessThan(initialRows);
 
     // Clear search
@@ -304,7 +304,7 @@ test.describe('data tables - search', () => {
     await page.waitForTimeout(100);
 
     // Rows should be restored
-    const restoredRows = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const restoredRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
     expect(restoredRows).toEqual(initialRows);
   });
 
@@ -319,13 +319,13 @@ test.describe('data tables - search', () => {
     await searchInput.fill('chelsey');
     await page.waitForTimeout(100);
 
-    const lowerCaseResults = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const lowerCaseResults = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Clear and search with uppercase
     await searchInput.fill('CHELSEY');
     await page.waitForTimeout(100);
 
-    const upperCaseResults = await table.locator('tbody tr:not([class*=_tr__empty_])').count();
+    const upperCaseResults = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Should find same results regardless of case
     expect(lowerCaseResults).toEqual(upperCaseResults);
@@ -346,7 +346,7 @@ test.describe('data tables - search', () => {
     await page.waitForTimeout(100);
 
     // Should show empty row
-    await expect(table.locator('tbody tr[class*=_tr__empty_]')).toBeVisible();
+    await expect(table.locator('tbody tr[data-id="row-empty"]')).toBeVisible();
   });
 
   test('should reset pagination when searching', async ({ page }) => {
@@ -619,7 +619,7 @@ test.describe('data tables - grouping', () => {
     await expect(table).toBeVisible();
 
     // Should have group header rows
-    const groupHeaders = table.locator('tbody tr[class*=_tr__group]');
+    const groupHeaders = table.locator('tbody tr[data-id="row-group"]');
     await expect(groupHeaders.first()).toBeVisible();
   });
 
@@ -628,21 +628,21 @@ test.describe('data tables - grouping', () => {
     const table = container.locator('[data-cy=table]');
     await expect(table).toBeVisible();
 
-    const groupExpandButton = table.locator('tr[class*=_tr__group] button[aria-expanded]').first();
+    const groupExpandButton = table.locator('tr[data-id="row-group"] button[aria-expanded]').first();
     await expect(groupExpandButton).toBeVisible();
 
     // Initially expanded
     await expect(groupExpandButton).toHaveAttribute('aria-expanded', 'true');
 
     // Count initial data rows
-    const initialDataRows = await table.locator('tbody tr:not([class*=_tr__group]):not([class*=_tr__empty_])').count();
+    const initialDataRows = await table.locator('tbody tr:not([data-id="row-group"]):not([data-id="row-empty"])').count();
 
     // Collapse first group
     await groupExpandButton.click();
     await expect(groupExpandButton).toHaveAttribute('aria-expanded', 'false');
 
     // Should have fewer visible data rows
-    const collapsedDataRows = await table.locator('tbody tr:not([class*=_tr__group]):not([class*=_tr__empty_]):not([hidden])').count();
+    const collapsedDataRows = await table.locator('tbody tr:not([data-id="row-group"]):not([data-id="row-empty"]):not([hidden])').count();
     expect(collapsedDataRows).toBeLessThan(initialDataRows);
   });
 
@@ -670,7 +670,7 @@ test.describe('data tables - grouping', () => {
     await expect(table).toBeVisible();
 
     // Get the first group header row
-    const groupRow = table.locator('tr[class*=_tr__group]').first();
+    const groupRow = table.locator('tr[data-id="row-group"]').first();
     const groupCell = groupRow.locator('td').first();
 
     // The expand button should be the last element in the flex container
@@ -694,8 +694,8 @@ test.describe('data tables - empty states', () => {
     const table = container.locator('[data-cy=table]');
     await expect(table).toBeVisible();
 
-    await expect(table.locator('tbody tr[class*=_tr__empty_] p[class*=_empty__label_]')).toBeVisible();
-    await expect(table.locator('tbody tr[class*=_tr__empty_] p[class*=_empty__description_]')).toBeVisible();
+    await expect(table.locator('tbody tr[data-id="row-empty"] p[data-id="empty-label"]')).toBeVisible();
+    await expect(table.locator('tbody tr[data-id="row-empty"] p[data-id="empty-description"]')).toBeVisible();
   });
 
   test('should render empty table with action slot', async ({ page }) => {
@@ -703,8 +703,8 @@ test.describe('data tables - empty states', () => {
     const table = container.locator('[data-cy=table]');
     await expect(table).toBeVisible();
 
-    await expect(table.locator('tbody tr[class*=_tr__empty_] p[class*=_empty__label_]')).toBeVisible();
-    await expect(table.locator('tbody tr[class*=_tr__empty_] button')).toBeVisible();
+    await expect(table.locator('tbody tr[data-id="row-empty"] p[data-id="empty-label"]')).toBeVisible();
+    await expect(table.locator('tbody tr[data-id="row-empty"] button')).toBeVisible();
   });
 
   test('should render loading state without data', async ({ page }) => {
@@ -714,7 +714,7 @@ test.describe('data tables - empty states', () => {
 
     // Table should have aria-busy attribute when loading
     await expect(table.locator('table')).toHaveAttribute('aria-busy', 'true');
-    await expect(table.locator('tbody td[class*=_tbody__loader_] div[class*=_circular_]')).toBeVisible();
+    await expect(table.locator('tbody td[data-id="tbody-loader"] div[class*=_circular_]')).toBeVisible();
   });
 
   test('should render loading state with data', async ({ page }) => {
@@ -726,11 +726,11 @@ test.describe('data tables - empty states', () => {
     await expect(table.locator('table')).toHaveAttribute('aria-busy', 'true');
 
     // Should show data rows
-    const rows = table.locator('tbody tr:not([class*=_tr__empty_])');
+    const rows = table.locator('tbody tr:not([data-id="row-empty"])');
     await expect(rows.first()).toBeVisible();
 
     // Should show progress bar in header
-    await expect(table.locator('thead tr[class*=_thead__loader_]')).toHaveCount(1);
+    await expect(table.locator('thead tr[data-id="thead-loader"]')).toHaveCount(1);
   });
 });
 

--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -111,12 +111,12 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(wrapper.find('div div[class*=_navigation_]').exists()).toBeTruthy();
     expect(wrapper.find('div div[class*=_navigation_] button[disabled]').exists()).toBeTruthy();
 
-    expect(wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').exists()).toBeTruthy();
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
 
-    await wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
-    expect(wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button_open]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
     expect(wrapper.find('div[data-cy=table-pagination] div[class*=limit]').exists()).toBeTruthy();
     expect(wrapper.find('div[data-cy=table-pagination] div[class*=ranges]').exists()).toBeTruthy();
@@ -143,16 +143,16 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(wrapper.props().expanded).toHaveLength(0);
     expect(wrapper.find('tbody tr[hidden]:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
 
-    await wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(1);
-    expect(wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button_open]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
 
-    await wrapper.find('tbody tr:nth-child(3) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(3) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(2);
-    expect(wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button_open]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
     expect(wrapper.find('tbody tr:nth-child(4) div[data-cy=expanded-content]').exists()).toBeTruthy();
   });
 
@@ -206,25 +206,25 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(wrapper.props().expanded).toHaveLength(0);
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
 
-    await wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(1);
-    expect(wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button_open]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
 
-    await wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(0);
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
 
-    await wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
 
-    await wrapper.find('tbody tr:nth-child(3) button[class*=_tr__expander_button]').trigger('click');
+    await wrapper.find('tbody tr:nth-child(3) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(1);
-    expect(wrapper.find('tbody tr:nth-child(1) button[class*=_tr__expander_button_open]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeFalsy();
     expect(wrapper.find('tbody tr:nth-child(4) div[data-cy=expanded-content]').exists()).toBeFalsy();
   });
 
@@ -319,7 +319,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__expanded_]):not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-expanded"]):not([data-id="row-empty"])');
       expect(rows).toHaveLength(5);
       expect(rows[0]?.find('td:nth-child(1)').text()).toBe('1');
     });
@@ -334,7 +334,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__expanded_]):not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-expanded"]):not([data-id="row-empty"])');
       expect(rows).toHaveLength(5);
       expect(rows[0]?.find('td:nth-child(1)').text()).toBe('6');
     });
@@ -349,7 +349,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__expanded_]):not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-expanded"]):not([data-id="row-empty"])');
       expect(rows).toHaveLength(5);
     });
   });
@@ -433,7 +433,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const sortButton = wrapper.find('thead th[class*=_sortable_] button');
+      const sortButton = wrapper.find('thead th[data-id="column-sortable"] button');
       await sortButton.trigger('click');
 
       expect(onUpdateSort).toHaveBeenCalledWith(
@@ -453,7 +453,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const sortButton = wrapper.find('thead th[class*=_sortable_] button');
+      const sortButton = wrapper.find('thead th[data-id="column-sortable"] button');
       await sortButton.trigger('click');
 
       expect(onUpdateSort).toHaveBeenCalledWith(
@@ -473,7 +473,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const sortButtons = wrapper.findAll('thead th[class*=_sortable_] button');
+      const sortButtons = wrapper.findAll('thead th[data-id="column-sortable"] button');
       const titleSortButton = sortButtons[1];
       await titleSortButton?.trigger('click');
 
@@ -500,7 +500,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const sortButton = wrapper.find('thead th[class*=_sortable_] button');
+      const sortButton = wrapper.find('thead th[data-id="column-sortable"] button');
       await sortButton.trigger('click');
 
       expect(onUpdateSort).toHaveBeenCalledWith([
@@ -526,7 +526,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows).toHaveLength(1);
       expect(rows[0]?.find('td:nth-child(2)').text()).toBe('Alice Smith');
     });
@@ -546,7 +546,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows).toHaveLength(1);
     });
 
@@ -566,7 +566,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows).toHaveLength(1);
       expect(rows[0]?.find('td:nth-child(2)').text()).toBe('Charlie Brown');
     });
@@ -586,7 +586,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const emptyRow = wrapper.find('tbody tr[class*=_tr__empty_]');
+      const emptyRow = wrapper.find('tbody tr[data-id="row-empty"]');
       expect(emptyRow.exists()).toBeTruthy();
     });
 
@@ -605,11 +605,11 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      expect(wrapper.findAll('tbody tr:not([class*=_tr__empty_])')).toHaveLength(1);
+      expect(wrapper.findAll('tbody tr:not([data-id="row-empty"])')).toHaveLength(1);
 
       await wrapper.setProps({ search: 'bob' });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows).toHaveLength(1);
       expect(rows[0]?.find('td:nth-child(2)').text()).toBe('Bob Jones');
     });
@@ -634,7 +634,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows).toHaveLength(5);
     });
 
@@ -655,7 +655,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows).toHaveLength(2);
       expect(rows[0]?.find('td:nth-child(2)').text()).toBe('Alice Dev');
       expect(rows[1]?.find('td:nth-child(2)').text()).toBe('Zack Dev');
@@ -708,7 +708,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const headers = wrapper.findAll('thead th span[class*=_column__text_]');
+      const headers = wrapper.findAll('thead th span[data-id="column-text"]');
       const headerTexts = headers.map(h => h.text());
 
       expect(headerTexts).toContain('id');
@@ -794,14 +794,14 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const ungroupButton = wrapper.find('tr[class*=_tr__group] button:has([class*=lu-trash])');
+      const ungroupButton = wrapper.find('tr[data-id="row-group"] button:has([class*=lu-trash])');
       if (ungroupButton.exists()) {
         await ungroupButton.trigger('click');
         expect(onUpdateGroup).toHaveBeenCalledWith(undefined);
         expect(onUpdateCollapsed).toHaveBeenCalledWith([]);
       }
       else {
-        const buttons = wrapper.findAll('tr[class*=_tr__group] button');
+        const buttons = wrapper.findAll('tr[data-id="row-group"] button');
         for (const btn of buttons) {
           if (btn.html().includes('trash')) {
             await btn.trigger('click');
@@ -1035,9 +1035,9 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(paginate).toHaveLength(1);
 
     // Verify pagination is after the scroller (footer position)
-    const wrapperEl = wrapper.find('[class*=_wrapper]').element;
+    const wrapperEl = wrapper.find('[data-id="table-wrapper"]').element;
     const pagination = wrapper.find('[data-cy="table-pagination"]').element;
-    const scroller = wrapper.find('[class*=_scroller]').element;
+    const scroller = wrapper.find('[data-id="table-scroller"]').element;
     const children = Array.from(wrapperEl.children);
     expect(children.indexOf(pagination)).toBeGreaterThan(children.indexOf(scroller));
   });
@@ -1056,9 +1056,9 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(paginate).toHaveLength(1);
 
     // Verify pagination is before the scroller (header position)
-    const wrapperEl = wrapper.find('[class*=_wrapper]').element;
+    const wrapperEl = wrapper.find('[data-id="table-wrapper"]').element;
     const pagination = wrapper.find('[data-cy="table-pagination"]').element;
-    const scroller = wrapper.find('[class*=_scroller]').element;
+    const scroller = wrapper.find('[data-id="table-scroller"]').element;
     const children = Array.from(wrapperEl.children);
     expect(children.indexOf(pagination)).toBeLessThan(children.indexOf(scroller));
   });
@@ -1076,7 +1076,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const groupHeaders = wrapper.findAll('tr[class*=_tr__group]');
+      const groupHeaders = wrapper.findAll('tr[data-id="row-group"]');
       expect(groupHeaders.length).toBeGreaterThan(0);
     });
 
@@ -1092,7 +1092,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const groupExpandButton = wrapper.find('tr[class*=_tr__group] button[class*=_tr__expander_button]');
+      const groupExpandButton = wrapper.find('tr[data-id="row-group"] button[data-id="expand-button"]');
       expect(groupExpandButton.exists()).toBeTruthy();
 
       await groupExpandButton.trigger('click');
@@ -1113,7 +1113,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const groupExpandButton = wrapper.find('tr[class*=_tr__group] button[class*=_tr__expander_button]');
+      const groupExpandButton = wrapper.find('tr[data-id="row-group"] button[data-id="expand-button"]');
       await groupExpandButton.trigger('click');
 
       expect(onUpdateCollapsed).toHaveBeenCalled();
@@ -1130,10 +1130,10 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const groupHeader = wrapper.find('tr[class*=_tr__group]');
+      const groupHeader = wrapper.find('tr[data-id="row-group"]');
       expect(groupHeader.exists()).toBeTruthy();
 
-      const expandButton = groupHeader.find('button[class*=_tr__expander_button]');
+      const expandButton = groupHeader.find('button[data-id="expand-button"]');
       expect(expandButton.exists()).toBeTruthy();
     });
 
@@ -1149,10 +1149,10 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const groupHeader = wrapper.find('tr[class*=_tr__group]');
+      const groupHeader = wrapper.find('tr[data-id="row-group"]');
       expect(groupHeader.exists()).toBeTruthy();
 
-      const expandButton = groupHeader.find('button[class*=_tr__expander_button]');
+      const expandButton = groupHeader.find('button[data-id="expand-button"]');
       expect(expandButton.exists()).toBeTruthy();
     });
 
@@ -1169,13 +1169,13 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const copyButton = wrapper.find('tr[class*=_tr__group] button:has([class*=lu-copy])');
+      const copyButton = wrapper.find('tr[data-id="row-group"] button:has([class*=lu-copy])');
       if (copyButton.exists()) {
         await copyButton.trigger('click');
         expect(onCopyGroup).toHaveBeenCalled();
       }
       else {
-        const buttons = wrapper.findAll('tr[class*=_tr__group] button');
+        const buttons = wrapper.findAll('tr[data-id="row-group"] button');
         const copyBtn = buttons[1];
         if (copyBtn) {
           await copyBtn.trigger('click');
@@ -1291,7 +1291,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const tbodyRows = wrapper.findAll('tbody tr:not([class*=_tr__expanded_])');
+      const tbodyRows = wrapper.findAll('tbody tr:not([data-id="row-expanded"])');
       expect(tbodyRows).toHaveLength(5);
     });
 
@@ -1461,8 +1461,8 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const emptyLabel = wrapper.find('p[class*=_empty__label_]');
-      const emptyDescription = wrapper.find('p[class*=_empty__description_]');
+      const emptyLabel = wrapper.find('p[data-id="empty-label"]');
+      const emptyDescription = wrapper.find('p[data-id="empty-description"]');
 
       expect(emptyLabel.exists()).toBeTruthy();
       expect(emptyLabel.text()).toBe('No results found');
@@ -1556,7 +1556,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__expanded_]):not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-expanded"]):not([data-id="row-empty"])');
       rows.forEach((row) => {
         expect(row.classes()).toContain('custom-row-class');
       });
@@ -1606,7 +1606,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const loader = wrapper.find('td[class*=_tbody__loader_]');
+      const loader = wrapper.find('td[data-id="tbody-loader"]');
       expect(loader.exists()).toBeTruthy();
     });
 
@@ -1620,10 +1620,10 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-empty"])');
       expect(rows.length).toBeGreaterThan(0);
 
-      const circularLoader = wrapper.find('td[class*=_tbody__loader_]');
+      const circularLoader = wrapper.find('td[data-id="tbody-loader"]');
       expect(circularLoader.exists()).toBeFalsy();
 
       const progressBar = wrapper.findComponent({ name: 'RuiProgress' });
@@ -1640,7 +1640,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const circularLoader = wrapper.find('td[class*=_tbody__loader_]');
+      const circularLoader = wrapper.find('td[data-id="tbody-loader"]');
       expect(circularLoader.exists()).toBeFalsy();
     });
   });
@@ -1665,7 +1665,7 @@ describe('components/tables/RuiDataTable.vue', () => {
       });
 
       // Group headers should be rendered
-      const groupHeaders = wrapper.findAll('tr[class*=_tr__group]');
+      const groupHeaders = wrapper.findAll('tr[data-id="row-group"]');
       expect(groupHeaders.length).toBeGreaterThan(0);
     });
   });
@@ -1759,7 +1759,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const sortableButton = wrapper.find('thead th[class*=_sortable_] button');
+      const sortableButton = wrapper.find('thead th[data-id="column-sortable"] button');
       await sortableButton.trigger('click');
 
       expect(onUpdateSort).toHaveBeenCalled();
@@ -1777,7 +1777,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const sortableButton = wrapper.find('thead th[class*=_sortable_] button');
+      const sortableButton = wrapper.find('thead th[data-id="column-sortable"] button');
       await sortableButton.trigger('click');
 
       expect(onUpdateOptions).toHaveBeenCalledWith(
@@ -1822,7 +1822,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const rows = wrapper.findAll('tbody tr:not([class*=_tr__expanded_]):not([class*=_tr__empty_])');
+      const rows = wrapper.findAll('tbody tr:not([data-id="row-expanded"]):not([data-id="row-empty"])');
       expect(rows).toHaveLength(5);
     });
   });
@@ -1929,7 +1929,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const headers = wrapper.findAll('thead th span[class*=_column__text_]');
+      const headers = wrapper.findAll('thead th span[data-id="column-text"]');
       expect(headers[0]?.text()).toBe('Custom ID');
       expect(headers[1]?.text()).toBe('Custom Name');
     });
@@ -2011,10 +2011,10 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const emptyRow = wrapper.find('tr[class*=_tr__empty_]');
+      const emptyRow = wrapper.find('tr[data-id="row-empty"]');
       expect(emptyRow.exists()).toBeTruthy();
 
-      const emptyLabel = wrapper.find('p[class*=_empty__label_]');
+      const emptyLabel = wrapper.find('p[data-id="empty-label"]');
       expect(emptyLabel.text()).toBe('No data available');
     });
   });
@@ -2037,7 +2037,7 @@ describe('components/tables/RuiDataTable.vue', () => {
       expect(wrapper.props().modelValue).toHaveLength(3);
 
       // Click sort button
-      const sortButton = wrapper.find('thead th[class*=_sortable_] button');
+      const sortButton = wrapper.find('thead th[data-id="column-sortable"] button');
       await sortButton.trigger('click');
 
       // Selection should be cleared

--- a/packages/ui-library/src/components/tables/RuiExpandButton.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiExpandButton.spec.ts
@@ -16,9 +16,7 @@ describe('components/tables/RuiExpandButton.vue', () => {
       },
     });
 
-    expect(wrapper.find('button').exists()).toBeTruthy();
-    const buttonClasses = wrapper.find('button').classes();
-    expect(buttonClasses.some(c => c.includes('_tr__expander_button'))).toBeTruthy();
+    expect(wrapper.find('button[data-id="expand-button"]').exists()).toBeTruthy();
   });
 
   it('should apply open class when expanded is true', () => {
@@ -28,8 +26,8 @@ describe('components/tables/RuiExpandButton.vue', () => {
       },
     });
 
-    const button = wrapper.find('button');
-    expect(button.classes().some(c => c.includes('_tr__expander_button_open'))).toBeTruthy();
+    const button = wrapper.find('button[data-id="expand-button"]');
+    expect(button.attributes('aria-expanded')).toBe('true');
   });
 
   it('should not apply open class when expanded is false', () => {
@@ -39,8 +37,8 @@ describe('components/tables/RuiExpandButton.vue', () => {
       },
     });
 
-    const button = wrapper.find('button');
-    expect(button.classes().some(c => c.includes('_tr__expander_button_open'))).toBeFalsy();
+    const button = wrapper.find('button[data-id="expand-button"]');
+    expect(button.attributes('aria-expanded')).toBe('false');
   });
 
   it('should emit click event when clicked', async () => {

--- a/packages/ui-library/src/components/tables/RuiExpandButton.vue
+++ b/packages/ui-library/src/components/tables/RuiExpandButton.vue
@@ -24,6 +24,7 @@ const { expanded, icon = 'lu-chevron-down' } = defineProps<Props>();
       },
     ]"
     :aria-expanded="expanded"
+    data-id="expand-button"
     icon
     size="sm"
     variant="text"

--- a/packages/ui-library/src/components/tables/RuiTableHead.vue
+++ b/packages/ui-library/src/components/tables/RuiTableHead.vue
@@ -178,6 +178,7 @@ function getSortDirection(key: TableColumn<T>['key']): 'asc' | 'desc' | undefine
         scope="col"
         :colspan="column.colspan ?? 1"
         :rowspan="column.rowspan ?? 1"
+        :data-id="column.sortable ? 'column-sortable' : undefined"
       >
         <slot
           :column="column"
@@ -203,7 +204,10 @@ function getSortDirection(key: TableColumn<T>['key']): 'asc' | 'desc' | undefine
               variant="text"
               @click="onSort(column)"
             >
-              <span :class="$style.column__text">
+              <span
+                :class="$style.column__text"
+                data-id="column-text"
+              >
                 <slot
                   :name="`header.text.${column.key.toString()}`"
                   :column="column"
@@ -236,6 +240,7 @@ function getSortDirection(key: TableColumn<T>['key']): 'asc' | 'desc' | undefine
           <span
             v-else
             :class="$style.column__text"
+            data-id="column-text"
           >
             <slot
               :name="`header.text.${column.key.toString()}`"
@@ -250,6 +255,7 @@ function getSortDirection(key: TableColumn<T>['key']): 'asc' | 'desc' | undefine
     <tr
       v-if="loading"
       :class="[$style.thead__loader, $style.thead__loader_linear]"
+      data-id="thead-loader"
     >
       <th
         :class="$style.progress"

--- a/packages/ui-library/src/composables/tables/data-table/columns.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/columns.spec.ts
@@ -1,0 +1,157 @@
+import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+import { useTableColumns } from '@/composables/tables/data-table/columns';
+
+interface TestItem {
+  id: number;
+  name: string;
+  title: string;
+}
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent);
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/tables/data-table/columns', () => {
+  let unmount: () => void;
+
+  const cols: TableColumn<TestItem>[] = [
+    { key: 'id', label: 'ID' },
+    { key: 'name', label: 'Name', sortable: true },
+    { key: 'title', label: 'Title' },
+  ];
+
+  const rows: TestItem[] = [{ id: 1, name: 'Alice', title: 'Developer' }];
+
+  afterEach(() => {
+    unmount?.();
+  });
+
+  it('should use provided cols', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => cols,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => false),
+        groupKeys: computed(() => []),
+        selectedData: ref(undefined),
+        slots: {},
+      }),
+    );
+    unmount = u;
+    expect(get(result.columns)).toHaveLength(3);
+  });
+
+  it('should auto-generate columns from first row when cols is undefined', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => undefined,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => false),
+        groupKeys: computed(() => []),
+        selectedData: ref(undefined),
+        slots: {},
+      }),
+    );
+    unmount = u;
+    expect(get(result.columns)).toHaveLength(3);
+    expect(get(result.columns).map(c => c.key)).toContain('id');
+    expect(get(result.columns).map(c => c.key)).toContain('name');
+    expect(get(result.columns).map(c => c.key)).toContain('title');
+  });
+
+  it('should add expand column when expandable', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => cols,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => true),
+        groupKeys: computed(() => []),
+        selectedData: ref(undefined),
+        slots: {},
+      }),
+    );
+    unmount = u;
+    expect(get(result.columns)).toHaveLength(4);
+    expect(get(result.columns).at(-1)?.key).toBe('expand');
+  });
+
+  it('should filter out grouped columns', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => cols,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => false),
+        groupKeys: computed(() => ['title']),
+        selectedData: ref(undefined),
+        slots: {},
+      }),
+    );
+    unmount = u;
+    expect(get(result.columns)).toHaveLength(2);
+    expect(get(result.columns).map(c => c.key)).not.toContain('title');
+  });
+
+  it('should compute colspan including selection column', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => cols,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => false),
+        groupKeys: computed(() => []),
+        selectedData: ref([]),
+        slots: {},
+      }),
+    );
+    unmount = u;
+    expect(get(result.colspan)).toBe(4);
+  });
+
+  it('should extract header slots', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => cols,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => false),
+        groupKeys: computed(() => []),
+        selectedData: ref(undefined),
+        slots: { 'header.name': () => null, 'item.name': () => null },
+      }),
+    );
+    unmount = u;
+    expect(get(result.headerSlots)).toEqual(['header.name']);
+  });
+
+  it('should return cell value', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableColumns<TestItem, 'id'>({
+        cols: () => cols,
+        columnAttr: 'label',
+        rows: () => rows,
+        expandable: computed<boolean>(() => false),
+        groupKeys: computed(() => []),
+        selectedData: ref(undefined),
+        slots: {},
+      }),
+    );
+    unmount = u;
+    expect(result.cellValue(rows[0]!, 'name')).toBe('Alice');
+  });
+});

--- a/packages/ui-library/src/composables/tables/data-table/columns.ts
+++ b/packages/ui-library/src/composables/tables/data-table/columns.ts
@@ -1,0 +1,89 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type {
+  NoneSortableTableColumn,
+  TableColumn,
+  TableRowKey,
+} from '@/components/tables/RuiTableHead.vue';
+import { isHeaderSlot } from '@/composables/tables/data-table/types';
+
+export interface UseTableColumnsOptions<T extends object, IdType extends keyof T> {
+  cols: MaybeRefOrGetter<TableColumn<T>[] | undefined>;
+  columnAttr: keyof TableColumn<T>;
+  rows: MaybeRefOrGetter<T[]>;
+  expandable: ComputedRef<boolean>;
+  groupKeys: ComputedRef<TableRowKey<T>[]>;
+  selectedData: Ref<T[IdType][] | undefined>;
+  slots: Record<string, any>;
+}
+
+export interface UseTableColumnsReturn<T extends object> {
+  columns: ComputedRef<TableColumn<T>[]>;
+  colspan: ComputedRef<number>;
+  headerSlots: ComputedRef<`header.${string}`[]>;
+  cellValue: (row: T, key: TableColumn<T>['key']) => T[TableRowKey<T>];
+}
+
+export function useTableColumns<T extends object, IdType extends keyof T>(
+  options: UseTableColumnsOptions<T, IdType>,
+): UseTableColumnsReturn<T> {
+  const { columnAttr, expandable, groupKeys, selectedData, slots } = options;
+
+  const getKeys = <O extends object>(t: O): TableRowKey<O>[] => Object.keys(t) as TableRowKey<O>[];
+
+  const columns = computed<TableColumn<T>[]>(() => {
+    const currentCols = toValue(options.cols);
+    const currentRows = toValue(options.rows);
+    const data =
+      currentCols ??
+      getKeys(currentRows[0] ?? {}).map(
+        key =>
+          ({
+            key,
+            [columnAttr]: String(key),
+          }) satisfies NoneSortableTableColumn<T>,
+      );
+
+    const hasExpandColumn = data.some(row => row.key === 'expand');
+
+    if (get(expandable) && !hasExpandColumn) {
+      return [
+        ...data,
+        {
+          key: 'expand' as TableRowKey<T>,
+          sortable: false,
+          class: 'w-16',
+          cellClass: '!py-0 w-16',
+          align: 'end',
+        } satisfies NoneSortableTableColumn<T>,
+      ];
+    }
+
+    const groupByKeys = get(groupKeys);
+
+    if (groupByKeys.length === 0)
+      return data;
+
+    return data.filter(column => !groupByKeys.includes(column.key as TableRowKey<T>));
+  });
+
+  const colspan = computed<number>(() => {
+    let columnLength = get(columns).length;
+    if (get(selectedData))
+      columnLength++;
+
+    return columnLength;
+  });
+
+  const headerSlots = computed<`header.${string}`[]>(() => Object.keys(slots).filter(isHeaderSlot));
+
+  function cellValue(row: T, key: TableColumn<T>['key']): T[TableRowKey<T>] {
+    return row[key as TableRowKey<T>];
+  }
+
+  return {
+    columns,
+    colspan,
+    headerSlots,
+    cellValue,
+  };
+}

--- a/packages/ui-library/src/composables/tables/data-table/expansion.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/expansion.spec.ts
@@ -1,0 +1,153 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+import { useTableExpansion } from '@/composables/tables/data-table/expansion';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent);
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/tables/data-table/expansion', () => {
+  let unmount: () => void;
+
+  afterEach(() => {
+    unmount?.();
+  });
+
+  it('should return expandable as false when expanded is undefined', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: false },
+        { expanded: ref(undefined), hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+    expect(get(result.expandable)).toBe(false);
+  });
+
+  it('should return expandable as false when no expanded-item slot', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: false },
+        { expanded: ref([]), hasExpandedItemSlot: ref(false) },
+      ),
+    );
+    unmount = u;
+    expect(get(result.expandable)).toBe(false);
+  });
+
+  it('should return expandable as true when both expanded and slot exist', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: false },
+        { expanded: ref([]), hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+    expect(get(result.expandable)).toBe(true);
+  });
+
+  it('should toggle expansion for a row', () => {
+    const expanded = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: false },
+        { expanded, hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+
+    const row: TestItem = { id: 1, name: 'Alice' };
+    expect(result.isExpanded(1)).toBe(false);
+
+    result.onToggleExpand(row);
+    expect(result.isExpanded(1)).toBe(true);
+
+    result.onToggleExpand(row);
+    expect(result.isExpanded(1)).toBe(false);
+  });
+
+  it('should support single expand mode', () => {
+    const expanded = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: true },
+        { expanded, hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+
+    const row1: TestItem = { id: 1, name: 'Alice' };
+    const row2: TestItem = { id: 2, name: 'Bob' };
+
+    result.onToggleExpand(row1);
+    expect(result.isExpanded(1)).toBe(true);
+
+    result.onToggleExpand(row2);
+    expect(result.isExpanded(1)).toBe(false);
+    expect(result.isExpanded(2)).toBe(true);
+  });
+
+  it('should not toggle expand when expanded is undefined', () => {
+    const expanded = ref<TestItem[] | undefined>(undefined);
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: false },
+        { expanded: expanded as any, hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleExpand({ id: 1, name: 'Alice' });
+    expect(get(expanded)).toBeUndefined();
+  });
+
+  it('should collapse single-expand row when toggling the same row', () => {
+    const expanded = ref<TestItem[]>([{ id: 1, name: 'Alice' }]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: true },
+        { expanded, hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isExpanded(1)).toBe(true);
+    result.onToggleExpand({ id: 1, name: 'Alice' });
+    expect(result.isExpanded(1)).toBe(false);
+    expect(get(expanded)).toEqual([]);
+  });
+
+  it('should support multiple expand mode', () => {
+    const expanded = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableExpansion<TestItem, 'id'>(
+        { rowAttr: 'id', singleExpand: false },
+        { expanded, hasExpandedItemSlot: ref(true) },
+      ),
+    );
+    unmount = u;
+
+    const row1: TestItem = { id: 1, name: 'Alice' };
+    const row2: TestItem = { id: 2, name: 'Bob' };
+
+    result.onToggleExpand(row1);
+    result.onToggleExpand(row2);
+    expect(result.isExpanded(1)).toBe(true);
+    expect(result.isExpanded(2)).toBe(true);
+  });
+});

--- a/packages/ui-library/src/composables/tables/data-table/expansion.ts
+++ b/packages/ui-library/src/composables/tables/data-table/expansion.ts
@@ -1,0 +1,61 @@
+import type { ComputedRef, Ref } from 'vue';
+
+export interface UseTableExpansionOptions<T extends object, IdType extends keyof T> {
+  rowAttr: IdType;
+  singleExpand: boolean;
+}
+
+export interface UseTableExpansionDeps<T extends object> {
+  expanded: Ref<T[] | undefined>;
+  hasExpandedItemSlot: Ref<boolean>;
+}
+
+export interface UseTableExpansionReturn<T extends object, IdType extends keyof T> {
+  expandable: ComputedRef<boolean>;
+  isExpanded: (identifier: T[IdType]) => boolean;
+  onToggleExpand: (row: T) => void;
+}
+
+export function useTableExpansion<T extends object, IdType extends keyof T>(
+  options: UseTableExpansionOptions<T, IdType>,
+  deps: UseTableExpansionDeps<T>,
+): UseTableExpansionReturn<T, IdType> {
+  const { rowAttr, singleExpand } = options;
+  const { expanded, hasExpandedItemSlot } = deps;
+
+  const expandable = computed<boolean>(() => !!get(expanded) && get(hasExpandedItemSlot));
+
+  const expandedSet = computed<Set<T[IdType]>>(() => {
+    const expandedVal = get(expanded);
+    if (!expandedVal?.length)
+      return new Set<T[IdType]>();
+    return new Set<T[IdType]>(expandedVal.map(row => row[rowAttr]));
+  });
+
+  function isExpanded(identifier: T[IdType]): boolean {
+    return get(expandedSet).has(identifier);
+  }
+
+  function onToggleExpand(row: T): void {
+    const expandedVal = get(expanded);
+    if (!expandedVal)
+      return;
+
+    const key = rowAttr;
+    const rowExpanded = isExpanded(row[key]);
+
+    if (singleExpand)
+      return set(expanded, rowExpanded ? [] : [row]);
+
+    return set(
+      expanded,
+      rowExpanded ? expandedVal.filter(item => item[key] !== row[key]) : [...expandedVal, row],
+    );
+  }
+
+  return {
+    expandable,
+    isExpanded,
+    onToggleExpand,
+  };
+}

--- a/packages/ui-library/src/composables/tables/data-table/grouping.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/grouping.spec.ts
@@ -1,0 +1,423 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { useTableGrouping } from '@/composables/tables/data-table/grouping';
+
+interface TestItem {
+  id: number;
+  name: string;
+  title: string;
+}
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent);
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/tables/data-table/grouping', () => {
+  let unmount: () => void;
+
+  const rows: TestItem[] = [
+    { id: 1, name: 'Alice', title: 'Developer' },
+    { id: 2, name: 'Bob', title: 'Developer' },
+    { id: 3, name: 'Charlie', title: 'Manager' },
+  ];
+
+  afterEach(() => {
+    unmount?.();
+  });
+
+  it('should return empty groupKeys when group is undefined', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(undefined),
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.groupKeys)).toEqual([]);
+    expect(get(result.isGrouped)).toBe(false);
+  });
+
+  it('should support single group key', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.groupKeys)).toEqual(['title']);
+    expect(get(result.isGrouped)).toBe(true);
+    expect(get(result.groupKey)).toBe('title');
+  });
+
+  it('should create grouped data with headers', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const grouped = get(result.grouped);
+    expect(grouped.length).toBe(5);
+
+    const headers = grouped.filter(item => '__header__' in item);
+    expect(headers).toHaveLength(2);
+  });
+
+  it('should toggle group collapse', () => {
+    const collapsed = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed,
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isExpandedGroup({ title: 'Developer' })).toBe(true);
+
+    result.onToggleExpandGroup({ title: 'Developer' }, 'Developer');
+
+    expect(result.isExpandedGroup({ title: 'Developer' })).toBe(false);
+    expect(get(collapsed)).toHaveLength(2);
+
+    result.onToggleExpandGroup({ title: 'Developer' }, 'Developer');
+
+    expect(result.isExpandedGroup({ title: 'Developer' })).toBe(true);
+    expect(get(collapsed)).toHaveLength(0);
+  });
+
+  it('should ungroup', () => {
+    const group = ref<string | undefined>('title');
+    const collapsed = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: group as any,
+          collapsed,
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onUngroup();
+    expect(get(group)).toBeUndefined();
+    expect(get(collapsed)).toEqual([]);
+  });
+
+  it('should call emitCopyGroup on copy', () => {
+    const emitCopyGroup = vi.fn();
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onCopyGroup({ key: 'title', value: { title: 'Developer' } });
+    expect(emitCopyGroup).toHaveBeenCalledWith({ key: 'title', value: { title: 'Developer' } });
+  });
+
+  it('should support array group keys', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(['name', 'title']) as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.groupKeys)).toEqual(['name', 'title']);
+    expect(get(result.isGrouped)).toBe(true);
+    expect(get(result.groupKey)).toBe('name:title');
+  });
+
+  it('should correctly identify hidden rows when group is collapsed', () => {
+    const collapsed = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed,
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    // Initially no rows hidden
+    expect(result.isHiddenRow(rows[0]!)).toBe(false);
+
+    // Collapse the Developer group
+    result.onToggleExpandGroup({ title: 'Developer' }, 'Developer');
+
+    // Rows in the Developer group should be hidden
+    expect(result.isHiddenRow(rows[0]!)).toBe(true);
+    expect(result.isHiddenRow(rows[1]!)).toBe(true);
+
+    // Row in the Manager group should not be hidden
+    expect(result.isHiddenRow(rows[2]!)).toBe(false);
+  });
+
+  it('should not hide rows when not grouped', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(undefined),
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isHiddenRow(rows[0]!)).toBe(false);
+  });
+
+  it('should not treat group headers as hidden rows', () => {
+    const collapsed = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed,
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const header = {
+      __header__: true as const,
+      group: { title: 'Developer' },
+      identifier: 'Developer',
+    };
+    expect(result.isHiddenRow(header)).toBe(false);
+  });
+
+  it('should return group rows via getGroupRows', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const devRows = result.getGroupRows('Developer');
+    expect(devRows).toHaveLength(2);
+    expect(devRows.map(r => r.name)).toEqual(['Alice', 'Bob']);
+
+    const mgrRows = result.getGroupRows('Manager');
+    expect(mgrRows).toHaveLength(1);
+    expect(mgrRows[0]?.name).toBe('Charlie');
+  });
+
+  it('should return empty array from getGroupRows when not grouped', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(undefined),
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.getGroupRows('Developer')).toEqual([]);
+  });
+
+  it('should compare groups using compareGroupsFn', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.compareGroupsFn(rows[0]!, { title: 'Developer' })).toBe(true);
+    expect(result.compareGroupsFn(rows[0]!, { title: 'Manager' })).toBe(false);
+    expect(result.compareGroupsFn(rows[2]!, { title: 'Manager' })).toBe(true);
+  });
+
+  it('should return false from compareGroupsFn when no group keys', () => {
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(undefined),
+          collapsed: ref(undefined),
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.compareGroupsFn(rows[0]!, { title: 'Developer' })).toBe(false);
+  });
+
+  it('should not toggle expand when value is undefined', () => {
+    const collapsed = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed,
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleExpandGroup({ title: 'Developer' }, undefined);
+    // Should remain expanded since the call was a no-op
+    expect(result.isExpandedGroup({ title: 'Developer' })).toBe(true);
+    expect(get(collapsed)).toHaveLength(0);
+  });
+
+  it('should ungroup array group to empty array', () => {
+    const group = ref<string[]>(['title']);
+    const collapsed = ref<TestItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: group as any,
+          collapsed,
+          sorted: computed(() => rows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onUngroup();
+    expect(get(group)).toEqual([]);
+  });
+
+  it('should skip rows with empty identifier in mappedGroups', () => {
+    const rowsWithEmpty = [
+      { id: 1, name: 'Alice', title: 'Developer' },
+      { id: '' as any, name: 'Unknown', title: 'None' },
+      { id: 3, name: 'Charlie', title: 'Developer' },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => rowsWithEmpty),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const groups = get(result.mappedGroups);
+    // "None" group should not exist since its row has empty id
+    const noneGroup = groups.None;
+    expect(noneGroup).toBeUndefined();
+  });
+
+  it('should create correct groups with multi-key grouping', () => {
+    const multiRows: TestItem[] = [
+      { id: 1, name: 'Alice', title: 'Developer' },
+      { id: 2, name: 'Alice', title: 'Manager' },
+      { id: 3, name: 'Bob', title: 'Developer' },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<TestItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(['name', 'title']) as any,
+          collapsed: ref(undefined),
+          sorted: computed(() => multiRows),
+          emitCopyGroup: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const groups = get(result.mappedGroups);
+    // 3 unique name+title combos
+    expect(Object.keys(groups)).toHaveLength(3);
+
+    const grouped = get(result.grouped);
+    // 3 headers + 3 rows
+    expect(grouped).toHaveLength(6);
+  });
+});

--- a/packages/ui-library/src/composables/tables/data-table/grouping.ts
+++ b/packages/ui-library/src/composables/tables/data-table/grouping.ts
@@ -1,0 +1,206 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { GroupData, TableRowKey, TableRowKeyData } from '@/components/tables/RuiTableHead.vue';
+import {
+  type GroupedTableRow,
+  type GroupHeader,
+  isRow,
+} from '@/composables/tables/data-table/types';
+import { assert } from '@/utils/assert';
+
+export interface UseTableGroupingOptions<T extends object, IdType extends keyof T> {
+  rowAttr: IdType;
+}
+
+export interface UseTableGroupingDeps<T extends object> {
+  group: Ref<TableRowKeyData<T>>;
+  collapsed: Ref<T[] | undefined>;
+  sorted: ComputedRef<T[]>;
+  emitCopyGroup: (value: GroupData<T>) => void;
+}
+
+export interface UseTableGroupingReturn<T extends object> {
+  groupKeys: ComputedRef<TableRowKey<T>[]>;
+  groupKey: ComputedRef<string>;
+  isGrouped: ComputedRef<boolean>;
+  mappedGroups: ComputedRef<Record<string, GroupedTableRow<T>[]>>;
+  grouped: ComputedRef<GroupedTableRow<T>[]>;
+  getRowGroup: (row: T) => Partial<T>;
+  getGroupRows: (groupVal: string) => T[];
+  compareGroupsFn: (a: T, b: Partial<T>) => boolean;
+  isExpandedGroup: (value: Partial<T>) => boolean;
+  isHiddenRow: (row: GroupedTableRow<T>) => boolean;
+  onToggleExpandGroup: (group: Partial<T>, value?: string) => void;
+  onUngroup: () => void;
+  onCopyGroup: (value: GroupData<T>) => void;
+}
+
+// Null character separator prevents false collisions when group values contain commas
+const GROUP_KEY_SEPARATOR = '\0';
+
+export function useTableGrouping<T extends object, IdType extends keyof T>(
+  options: UseTableGroupingOptions<T, IdType>,
+  deps: UseTableGroupingDeps<T>,
+): UseTableGroupingReturn<T> {
+  const { rowAttr } = options;
+  const { group, collapsed, sorted, emitCopyGroup } = deps;
+
+  const collapsedRows: Ref<T[]> = ref([]);
+
+  watch(collapsed, value => set(collapsedRows, value ?? []), { immediate: true });
+
+  const groupKeys: ComputedRef<TableRowKey<T>[]> = computed(() => {
+    const groupBy = get(group);
+
+    if (!groupBy)
+      return [];
+
+    if (!Array.isArray(groupBy))
+      return [groupBy];
+
+    return groupBy;
+  });
+
+  const groupKey = computed<string>(() => get(groupKeys).join(':'));
+
+  const isGrouped = computed<boolean>(() => !!get(groupKey));
+
+  const collapsedIdentifierSet = computed<Set<T[IdType]>>(
+    () => new Set(get(collapsedRows).map(row => row[rowAttr])),
+  );
+
+  const collapsedGroupKeySet = computed<Set<string>>(() => {
+    const grouping = get(groupKeys);
+    if (grouping.length === 0)
+      return new Set<string>();
+
+    const seen = new Set<string>();
+    for (const row of get(collapsedRows)) {
+      const groupVal = grouping
+        .map(key => row[key])
+        .filter(isDefined)
+        .join(GROUP_KEY_SEPARATOR);
+      seen.add(groupVal);
+    }
+    return seen;
+  });
+
+  function getRowGroup(row: T): Partial<T> {
+    return get(groupKeys).reduce((acc, key) => ({ ...acc, [key]: row[key] }), {});
+  }
+
+  function compareGroupsFn(a: T, b: Partial<T>): boolean {
+    const grouping = get(groupKeys);
+    if (grouping.length === 0)
+      return false;
+
+    return grouping.every(key => a[key] === b[key]);
+  }
+
+  function isExpandedGroup(value: Partial<T>): boolean {
+    const groupVal = Object.values(value).filter(isDefined).join(GROUP_KEY_SEPARATOR);
+    return !get(collapsedGroupKeySet).has(groupVal);
+  }
+
+  function isHiddenRow(row: GroupedTableRow<T>): boolean {
+    if (!get(isGrouped))
+      return false;
+    if (!isRow(row))
+      return false;
+    return get(collapsedIdentifierSet).has(row[rowAttr]);
+  }
+
+  const mappedGroups = computed<Record<string, GroupedTableRow<T>[]>>(() => {
+    if (!get(isGrouped))
+      return {};
+
+    const result = get(sorted);
+    const identifier = rowAttr;
+
+    return result.reduce((acc: Record<string, GroupedTableRow<T>[]>, row) => {
+      if (!isDefined(row[identifier]) || row[identifier] === '')
+        return acc;
+
+      const rowGroup = getRowGroup(row);
+      const groupVal = Object.values(rowGroup).filter(isDefined).join(GROUP_KEY_SEPARATOR);
+      if (!acc[groupVal]) {
+        acc[groupVal] = [
+          {
+            __header__: true,
+            group: rowGroup,
+            identifier: groupVal,
+          } satisfies GroupHeader<T>,
+        ];
+      }
+
+      acc[groupVal].push(row);
+
+      return acc;
+    }, {});
+  });
+
+  const grouped = computed<GroupedTableRow<T>[]>(() => {
+    const result = get(sorted);
+    const groupByKey = get(groupKey);
+
+    if (!groupByKey)
+      return result;
+
+    return Object.values(get(mappedGroups)).flat();
+  });
+
+  function getGroupRows(groupVal: string): T[] {
+    if (!get(isGrouped))
+      return [];
+
+    const groupRows = get(mappedGroups)[groupVal];
+    assert(groupRows);
+    return groupRows.filter(isRow);
+  }
+
+  function onToggleExpandGroup(groupPartial: Partial<T>, value?: string): void {
+    if (!value)
+      return;
+
+    const currentCollapsed = get(collapsedRows);
+
+    const groupExpanded = isExpandedGroup(groupPartial);
+
+    const groupRows = getGroupRows(value);
+
+    set(
+      collapsedRows,
+      groupExpanded
+        ? [...currentCollapsed, ...groupRows]
+        : currentCollapsed.filter(row => !compareGroupsFn(row, groupPartial)),
+    );
+
+    set(collapsed, get(collapsedRows));
+  }
+
+  function onUngroup(): void {
+    set(collapsedRows, []);
+
+    set(collapsed, []);
+    set(group, Array.isArray(get(group)) ? [] : undefined);
+  }
+
+  function onCopyGroup(value: GroupData<T>): void {
+    emitCopyGroup(value);
+  }
+
+  return {
+    groupKeys,
+    groupKey,
+    isGrouped,
+    mappedGroups,
+    grouped,
+    getRowGroup,
+    getGroupRows,
+    compareGroupsFn,
+    isExpandedGroup,
+    isHiddenRow,
+    onToggleExpandGroup,
+    onUngroup,
+    onCopyGroup,
+  };
+}

--- a/packages/ui-library/src/composables/tables/data-table/pagination.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/pagination.spec.ts
@@ -1,0 +1,435 @@
+import type { GroupedTableRow } from '@/composables/tables/data-table/types';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { createTableDefaults, TableSymbol } from '@/composables/defaults/table';
+import { useTablePagination } from '@/composables/tables/data-table/pagination';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent, {
+    global: {
+      provide: {
+        [TableSymbol.valueOf()]: createTableDefaults({
+          limits: [5, 10, 25],
+        }),
+      },
+    },
+  });
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/tables/data-table/pagination', () => {
+  let unmount: () => void;
+
+  const rows: TestItem[] = Array.from({ length: 25 }, (_, i) => ({
+    id: i + 1,
+    name: `User ${i + 1}`,
+  }));
+
+  afterEach(() => {
+    unmount?.();
+  });
+
+  it('should create default pagination when no external pagination', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination: ref(undefined),
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    const pagination = get(result.paginationData);
+    expect(pagination.limit).toBe(10);
+    expect(pagination.page).toBe(1);
+  });
+
+  it('should paginate data internally', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 5,
+      page: 1,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 5, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+
+    expect(get(result.filtered)).toHaveLength(5);
+    expect((get(result.filtered)[0] as TestItem).id).toBe(1);
+  });
+
+  it('should show second page', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 5,
+      page: 2,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 5, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+
+    expect(get(result.filtered)).toHaveLength(5);
+    expect((get(result.filtered)[0] as TestItem).id).toBe(6);
+  });
+
+  it('should not paginate when paginationModifiersExternal is true', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 5,
+      page: 1,
+      total: 100,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 5, paginationModifiersExternal: true, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.filtered)).toHaveLength(25);
+    expect(get(result.paginationData).total).toBe(100);
+  });
+
+  it('should set internal total', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination: ref(undefined),
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+    expect(get(result.itemsLength)).toBe(25);
+  });
+
+  it('should emit update:options on pagination set', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const emitUpdateOptions = vi.fn();
+    const pagination = ref({ limit: 10, page: 1, total: 25 });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions,
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    set(result.paginationData, { limit: 5, page: 1, total: 25 });
+    expect(emitUpdateOptions).toHaveBeenCalled();
+  });
+
+  it('should auto-adjust page when current page exceeds max', async () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 5,
+      page: 5,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 5, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+
+    // Set to page 10 which exceeds max (25/5=5)
+    set(result.paginationData, { limit: 5, page: 10, total: 25 });
+
+    await nextTick();
+
+    expect(get(result.paginationData).page).toBe(5);
+  });
+
+  it('should sync pagination limit to global defaults when globalItemsPerPage is true', async () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 10,
+      page: 1,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: false, globalItemsPerPage: true },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    // Change pagination limit
+    set(result.paginationData, { limit: 25, page: 1, total: 25 });
+
+    await nextTick();
+
+    // Should sync to global defaults
+    expect(get(tableDefaults.itemsPerPage)).toBe(25);
+  });
+
+  it('should sync global defaults to pagination limit when globalItemsPerPage is true', async () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 10,
+      page: 1,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: false, globalItemsPerPage: true },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+
+    // Change global default
+    set(tableDefaults.itemsPerPage, 5);
+
+    await nextTick();
+
+    expect(get(result.paginationData).limit).toBe(5);
+  });
+
+  it('should not sync to global defaults when globalItemsPerPage is false', async () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 10,
+      page: 1,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: false, globalItemsPerPage: false },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+
+    set(tableDefaults.itemsPerPage, 5);
+
+    await nextTick();
+
+    // Should NOT sync since globalItemsPerPage is false
+    expect(get(result.paginationData).limit).toBe(10);
+  });
+
+  it('should handle pagination with group headers', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const groupedData: GroupedTableRow<TestItem>[] = [
+      { __header__: true, group: { name: 'A' }, identifier: 'A' },
+      { id: 1, name: 'A' },
+      { id: 2, name: 'A' },
+      { __header__: true, group: { name: 'B' }, identifier: 'B' },
+      { id: 3, name: 'B' },
+    ];
+
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 3,
+      page: 1,
+      total: 3,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 3, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => groupedData),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(groupedData);
+
+    const filtered = get(result.filtered);
+    // Should include group headers alongside data rows
+    expect(filtered.length).toBeGreaterThan(0);
+  });
+
+  it('should return empty filtered when page is beyond data', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 5,
+      page: 100,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 5, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+
+    expect(get(result.filtered)).toHaveLength(0);
+  });
+
+  it('should filter hidden rows in external pagination mode', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+      limit: 25,
+      page: 1,
+      total: 25,
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 25, paginationModifiersExternal: true, globalItemsPerPage: undefined },
+        {
+          pagination,
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: (row) => {
+            if ('id' in row)
+              return (row as TestItem).id <= 5;
+            return false;
+          },
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    // 25 rows, first 5 hidden
+    expect(get(result.filtered)).toHaveLength(20);
+  });
+
+  it('should not set internal total when paginationModifiersExternal is true', () => {
+    const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+    const { result, unmount: u } = withSetup(() =>
+      useTablePagination<TestItem>(
+        { itemsPerPage: 10, paginationModifiersExternal: true, globalItemsPerPage: undefined },
+        {
+          pagination: ref(undefined),
+          grouped: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          isHiddenRow: () => false,
+          sort: ref(undefined),
+          emitUpdateOptions: () => {},
+          tableDefaults,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.setInternalTotal(rows);
+    expect(get(result.itemsLength)).toBe(0);
+  });
+});

--- a/packages/ui-library/src/composables/tables/data-table/pagination.ts
+++ b/packages/ui-library/src/composables/tables/data-table/pagination.ts
@@ -1,0 +1,173 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { TableSortData } from '@/components/tables/RuiTableHead.vue';
+import type { TablePaginationData } from '@/components/tables/RuiTablePagination.vue';
+import type { TableOptions as TableDefaultOptions } from '@/composables/defaults/table';
+import { type GroupedTableRow, isRow } from '@/composables/tables/data-table/types';
+import { assert } from '@/utils/assert';
+
+export interface UseTablePaginationOptions {
+  itemsPerPage: number;
+  paginationModifiersExternal: boolean | undefined;
+  globalItemsPerPage: boolean | undefined;
+}
+
+export interface UseTablePaginationDeps<T extends object> {
+  pagination: Ref<TablePaginationData | undefined>;
+  grouped: ComputedRef<GroupedTableRow<T>[]>;
+  isHiddenRow: (row: GroupedTableRow<T>) => boolean;
+  sort: Ref<TableSortData<T>>;
+  emitUpdateOptions: (options: {
+    sort?: TableSortData<T>;
+    pagination?: TablePaginationData;
+  }) => void;
+  tableDefaults: TableDefaultOptions;
+}
+
+export interface UseTablePaginationReturn<T extends object> {
+  paginationData: Ref<TablePaginationData>;
+  filtered: ComputedRef<GroupedTableRow<T>[]>;
+  itemsLength: Ref<number>;
+  globalItemsPerPageSettings: ComputedRef<boolean>;
+  setInternalTotal: (items: GroupedTableRow<T>[]) => void;
+  resetPagination: () => void;
+}
+
+export function useTablePagination<T extends object>(
+  options: UseTablePaginationOptions,
+  deps: UseTablePaginationDeps<T>,
+): UseTablePaginationReturn<T> {
+  const { itemsPerPage, paginationModifiersExternal, globalItemsPerPage } = options;
+  const { pagination, grouped, isHiddenRow, sort, emitUpdateOptions, tableDefaults } = deps;
+
+  const itemsLength = ref<number>(0);
+  const internalPaginationState: Ref<TablePaginationData | undefined> = ref();
+
+  const globalItemsPerPageSettings = computed<boolean>(() => {
+    if (globalItemsPerPage !== undefined)
+      return globalItemsPerPage;
+
+    return get(tableDefaults.globalItemsPerPage);
+  });
+
+  const paginationData: Ref<TablePaginationData> = computed({
+    get(): TablePaginationData {
+      const paginated = get(internalPaginationState);
+      if (!paginated) {
+        return {
+          total: get(itemsLength),
+          limit: itemsPerPage,
+          page: 1,
+        };
+      }
+
+      if (paginationModifiersExternal)
+        return paginated;
+
+      return {
+        total: get(itemsLength),
+        limit: paginated.limit,
+        page: paginated.page,
+        limits: paginated.limits,
+      };
+    },
+    set(value: TablePaginationData) {
+      set(internalPaginationState, value);
+      set(pagination, value);
+      emitUpdateOptions({
+        pagination: value,
+        sort: get(sort),
+      });
+    },
+  });
+
+  const filtered = computed<GroupedTableRow<T>[]>(() => {
+    const result = get(grouped);
+
+    const paginated = get(paginationData);
+    const limit = paginated.limit;
+    if (!paginationModifiersExternal) {
+      const start = (paginated.page - 1) * limit;
+      const end = start + limit;
+      const preGroups = result.slice(0, start + 1).filter(item => !isRow(item));
+      const postGroups = result
+        .slice(start + 1, end + preGroups.length)
+        .filter(item => !isRow(item));
+      const data = result.slice(
+        start + preGroups.length,
+        end + preGroups.length + postGroups.length,
+      );
+      const nearestGroup = preGroups.at(-1);
+      if (data.length > 0) {
+        const firstItem = data[0];
+        assert(firstItem);
+        if (isRow(firstItem) && nearestGroup)
+          data.unshift(nearestGroup);
+        const lastItem = data.at(-1);
+        if (lastItem && !isRow(lastItem))
+          data.pop();
+      }
+
+      return data.filter(row => !isHiddenRow(row));
+    }
+
+    return result.filter(row => !isHiddenRow(row));
+  });
+
+  function setInternalTotal(items: GroupedTableRow<T>[]): void {
+    if (!paginationModifiersExternal)
+      set(itemsLength, items.filter(isRow).length);
+  }
+
+  function resetPagination(): void {
+    set(paginationData, {
+      ...get(paginationData),
+      page: 1,
+    });
+  }
+
+  // Sync external pagination model to internal state
+  watch(pagination, val => set(internalPaginationState, val), { immediate: true });
+
+  // Sync pagination limit to global table defaults
+  watch(internalPaginationState, (paginationState) => {
+    if (paginationState?.limit && get(globalItemsPerPageSettings))
+      set(tableDefaults.itemsPerPage, paginationState.limit);
+  });
+
+  // Sync global table defaults to pagination limit
+  watch(
+    tableDefaults.itemsPerPage,
+    (perPage) => {
+      if (!get(globalItemsPerPageSettings))
+        return;
+
+      set(paginationData, {
+        ...get(paginationData),
+        limit: perPage,
+      });
+    },
+    { immediate: true },
+  );
+
+  // Auto-adjust page when current page exceeds max available pages
+  watch(paginationData, (paginationState) => {
+    const { total, limit, page } = paginationState;
+    const maxPages = Math.ceil(total / limit);
+
+    if (maxPages > 0 && page > maxPages) {
+      set(paginationData, {
+        ...paginationState,
+        page: maxPages,
+      });
+    }
+  });
+
+  return {
+    paginationData,
+    filtered,
+    itemsLength,
+    globalItemsPerPageSettings,
+    setInternalTotal,
+    resetPagination,
+  };
+}

--- a/packages/ui-library/src/composables/tables/data-table/selection.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/selection.spec.ts
@@ -1,0 +1,494 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+import { useTableSelection } from '@/composables/tables/data-table/selection';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent);
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/tables/data-table/selection', () => {
+  let unmount: () => void;
+
+  const rows: TestItem[] = [
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' },
+    { id: 3, name: 'Charlie' },
+  ];
+
+  afterEach(() => {
+    unmount?.();
+  });
+
+  it('should track selected state with Set-based lookup', () => {
+    const selectedData = ref<number[]>([1, 2]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isSelected(1)).toBe(true);
+    expect(result.isSelected(3)).toBe(false);
+  });
+
+  it('should compute isAllSelected correctly', () => {
+    const selectedData = ref<number[]>([1, 2, 3]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.isAllSelected)).toBe(true);
+    expect(get(result.indeterminate)).toBe(false);
+  });
+
+  it('should compute indeterminate when partially selected', () => {
+    const selectedData = ref<number[]>([1]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.isAllSelected)).toBe(false);
+    expect(get(result.indeterminate)).toBe(true);
+  });
+
+  it('should toggle all on', () => {
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleAll(true);
+    expect(get(selectedData)).toHaveLength(3);
+  });
+
+  it('should toggle all off', () => {
+    const selectedData = ref<number[]>([1, 2, 3]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleAll(false);
+    expect(get(selectedData)).toHaveLength(0);
+  });
+
+  it('should detect disabled rows', () => {
+    const disabledRow: TestItem = { id: 1, name: 'Alice' };
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isDisabledRow(1)).toBe(true);
+    expect(result.isDisabledRow(2)).toBe(false);
+  });
+
+  it('should exclude disabled rows from toggle all', () => {
+    const disabledRow: TestItem = { id: 1, name: 'Alice' };
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleAll(true);
+    expect(get(selectedData)).toHaveLength(2);
+    expect(get(selectedData)).not.toContain(1);
+  });
+
+  it('should support multi-page selection', () => {
+    const selectedData = ref<number[]>([1]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: true, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows.slice(1)),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleAll(true);
+    expect(get(selectedData)).toHaveLength(3);
+    expect(get(selectedData)).toContain(1);
+  });
+
+  it('should deselect removed rows', () => {
+    const visibleRows = ref<TestItem[]>(rows);
+    const selectedData = ref<number[]>([1, 2, 3]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => get(visibleRows)),
+        },
+      ),
+    );
+    unmount = u;
+
+    set(visibleRows, [rows[0]!]);
+    result.deselectRemovedRows();
+    expect(get(selectedData)).toHaveLength(1);
+    expect(get(selectedData)).toContain(1);
+  });
+
+  it('should select a row via onSelect', () => {
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSelect(true, 2, true);
+    expect(get(selectedData)).toContain(2);
+  });
+
+  it('should deselect a row via onSelect', () => {
+    const selectedData = ref<number[]>([1, 2]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSelect(false, 2, true);
+    expect(get(selectedData)).not.toContain(2);
+    expect(get(selectedData)).toContain(1);
+  });
+
+  it('should not duplicate when selecting already selected row', () => {
+    const selectedData = ref<number[]>([1]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSelect(true, 1, true);
+    expect(get(selectedData)).toEqual([1]);
+  });
+
+  it('should compute isSelectable correctly', () => {
+    const disabledRow: TestItem = { id: 1, name: 'Alice' };
+    const selectedData = ref<number[]>([1]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Disabled but selected → selectable (can be shown as checked)
+    expect(result.isSelectable(1)).toBe(true);
+    // Not disabled → selectable
+    expect(result.isSelectable(2)).toBe(true);
+  });
+
+  it('should compute isSelectable as false for disabled unselected row', () => {
+    const disabledRow: TestItem = { id: 1, name: 'Alice' };
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Disabled and not selected → not selectable
+    expect(result.isSelectable(1)).toBe(false);
+  });
+
+  it('should compute mustSelect correctly', () => {
+    const disabledRow: TestItem = { id: 1, name: 'Alice' };
+    const selectedData = ref<number[]>([1]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Selected + disabled → must stay selected
+    expect(result.mustSelect(1)).toBe(true);
+    // Selected but not disabled → can be deselected
+    expect(result.mustSelect(2)).toBe(false);
+    // Not selected → false
+    expect(result.mustSelect(3)).toBe(false);
+  });
+
+  it('should keep mustSelect rows when toggling all off', () => {
+    const disabledRow: TestItem = { id: 1, name: 'Alice' };
+    const selectedData = ref<number[]>([1, 2, 3]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleAll(false);
+    // Only the must-select row should remain
+    expect(get(selectedData)).toEqual([1]);
+  });
+
+  it('should reset checkbox shift state', () => {
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Should not throw
+    result.resetCheckboxShiftState();
+  });
+
+  it('should deselect on other pages when multi-page toggle off', () => {
+    // Page 1 has rows 2,3. Row 1 is from another page.
+    const selectedData = ref<number[]>([1, 2, 3]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: true, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows.slice(1)), // only Bob(2), Charlie(3) visible
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onToggleAll(false);
+    // Row 1 from other page should remain
+    expect(get(selectedData)).toEqual([1]);
+  });
+
+  it('should not deselect when selectedData is undefined', () => {
+    const selectedData = ref<number[] | undefined>(undefined);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData: selectedData as any,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Should not throw
+    result.onToggleAll(true);
+    expect(get(selectedData)).toBeUndefined();
+  });
+
+  it('should skip onSelect when shiftClicked and userAction', () => {
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Simulate internal shiftClicked state by calling resetCheckboxShiftState
+    // then select normally to verify the baseline works
+    result.onSelect(true, 1, true);
+    expect(get(selectedData)).toContain(1);
+
+    // The shiftClicked flag is internal — we can't set it directly,
+    // but we test that normal userAction select works
+    result.onSelect(true, 2, true);
+    expect(get(selectedData)).toContain(2);
+  });
+
+  it('should not select when internalSelectedData is falsy', () => {
+    const selectedData = ref<number[] | undefined>(undefined);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData: selectedData as any,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Should not throw when selectedData is undefined
+    result.onSelect(true, 1, false);
+    expect(get(selectedData)).toBeUndefined();
+  });
+
+  it('should not deselect a row that is not selected via onSelect', () => {
+    const selectedData = ref<number[]>([1]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // Deselect id 2 which is not selected — should be a no-op
+    result.onSelect(false, 2, true);
+    expect(get(selectedData)).toEqual([1]);
+  });
+
+  it('should compute indeterminate as false when selectedData is undefined', () => {
+    const selectedData = ref<number[] | undefined>(undefined);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData: selectedData as any,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.indeterminate)).toBe(false);
+  });
+
+  it('should return empty disabledRowKeySet when disabledRows is undefined', () => {
+    const selectedData = ref<number[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // No rows should be disabled
+    expect(result.isDisabledRow(1)).toBe(false);
+    expect(result.isDisabledRow(2)).toBe(false);
+    expect(result.isDisabledRow(3)).toBe(false);
+  });
+
+  it('should not modify selection when deselectRemovedRows has nothing to remove', () => {
+    const selectedData = ref<number[]>([1, 2, 3]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSelection<TestItem, 'id'>(
+        { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+        {
+          selectedData,
+          filtered: computed(() => rows),
+        },
+      ),
+    );
+    unmount = u;
+
+    result.deselectRemovedRows();
+    // All visible, nothing removed
+    expect(get(selectedData)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/ui-library/src/composables/tables/data-table/selection.ts
+++ b/packages/ui-library/src/composables/tables/data-table/selection.ts
@@ -1,0 +1,228 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { type GroupedTableRow, isRow } from '@/composables/tables/data-table/types';
+import { assert } from '@/utils/assert';
+
+export interface UseTableSelectionOptions<T extends object, IdType extends keyof T> {
+  rowAttr: IdType;
+  multiPageSelect: boolean;
+  disabledRows: MaybeRefOrGetter<T[] | undefined>;
+}
+
+export interface UseTableSelectionDeps<T extends object, IdType extends keyof T> {
+  selectedData: Ref<T[IdType][] | undefined>;
+  filtered: ComputedRef<GroupedTableRow<T>[]>;
+}
+
+export interface UseTableSelectionReturn<T extends object, IdType extends keyof T> {
+  visibleIdentifiers: ComputedRef<T[IdType][]>;
+  isAllSelected: ComputedRef<boolean>;
+  indeterminate: ComputedRef<boolean>;
+  isSelected: (identifier: T[IdType]) => boolean;
+  isDisabledRow: (rowKey: T[IdType]) => boolean;
+  isSelectable: (rowKey: T[IdType]) => boolean;
+  mustSelect: (rowKey: T[IdType]) => boolean;
+  onToggleAll: (checked: boolean) => void;
+  onSelect: (checked: boolean, value: T[IdType], userAction?: boolean) => void;
+  onCheckboxClick: (event: MouseEvent, value: T[IdType], index: number) => void;
+  deselectRemovedRows: () => void;
+  resetCheckboxShiftState: () => void;
+}
+
+export function useTableSelection<T extends object, IdType extends keyof T>(
+  options: UseTableSelectionOptions<T, IdType>,
+  deps: UseTableSelectionDeps<T, IdType>,
+): UseTableSelectionReturn<T, IdType> {
+  const { rowAttr, multiPageSelect } = options;
+  const { selectedData, filtered } = deps;
+
+  const shiftClicked: Ref<boolean> = ref(false);
+  const lastSelectedIndex: Ref<number> = ref(-1);
+  const internalSelectedData: Ref<T[IdType][]> = ref([]);
+
+  // Sync external selection model to internal state
+  watch(selectedData, val => set(internalSelectedData, val), { immediate: true });
+
+  const visibleIdentifiers = computed<T[IdType][]>(() =>
+    get(filtered)
+      .filter(isRow)
+      .map(row => row[rowAttr]),
+  );
+
+  const selectedSet = computed<Set<T[IdType]>>(() => new Set(get(selectedData) ?? []));
+
+  const disabledRowKeySet = computed<Set<T[IdType]>>(() => {
+    const currentDisabledRows = toValue(options.disabledRows);
+    if (!currentDisabledRows || !rowAttr)
+      return new Set<T[IdType]>();
+    return new Set<T[IdType]>(currentDisabledRows.map((row: T) => row[rowAttr]));
+  });
+
+  const isAllSelected = computed<boolean>(() => {
+    const selectedRows = get(selectedData);
+    if (!selectedRows || selectedRows.length === 0)
+      return false;
+
+    const selected = get(selectedSet);
+    return get(visibleIdentifiers).every(id => selected.has(id));
+  });
+
+  const indeterminate = computed<boolean>(() => {
+    const selectedRows = get(selectedData);
+    if (!selectedRows)
+      return false;
+
+    return selectedRows.length > 0 && !get(isAllSelected);
+  });
+
+  function isSelected(identifier: T[IdType]): boolean {
+    return get(selectedSet).has(identifier);
+  }
+
+  function isDisabledRow(rowKey: T[IdType]): boolean {
+    return get(disabledRowKeySet).has(rowKey);
+  }
+
+  function isSelectable(rowKey: T[IdType]): boolean {
+    return isSelected(rowKey) || !isDisabledRow(rowKey);
+  }
+
+  function mustSelect(rowKey: T[IdType]): boolean {
+    return isSelected(rowKey) && isDisabledRow(rowKey);
+  }
+
+  function resetCheckboxShiftState(): void {
+    set(shiftClicked, false);
+    set(lastSelectedIndex, -1);
+  }
+
+  function onToggleAll(checked: boolean): void {
+    const selectedRows = get(selectedData);
+
+    if (!isDefined(selectedRows))
+      return;
+
+    if (!multiPageSelect) {
+      if (checked)
+        set(selectedData, get(visibleIdentifiers).filter(isSelectable));
+      else set(selectedData, get(visibleIdentifiers).filter(mustSelect));
+    }
+    else {
+      if (checked) {
+        set(
+          selectedData,
+          Array.from(new Set([...selectedRows, ...get(visibleIdentifiers).filter(isSelectable)])),
+        );
+      }
+      else {
+        const visibleSet = new Set(get(visibleIdentifiers));
+        const mustSelectSet = new Set(get(visibleIdentifiers).filter(mustSelect));
+        set(
+          selectedData,
+          selectedRows.filter(rowKey => !visibleSet.has(rowKey) || mustSelectSet.has(rowKey)),
+        );
+      }
+    }
+  }
+
+  function onSelect(checked: boolean, value: T[IdType], userAction: boolean = false): void {
+    if (get(shiftClicked) && userAction)
+      return;
+
+    const selectedRows = get(internalSelectedData);
+    if (!selectedRows)
+      return;
+
+    const selected = isSelected(value);
+
+    if (checked && !selected) {
+      set(internalSelectedData, [...selectedRows, value]);
+    }
+    else if (!checked && selected) {
+      set(
+        internalSelectedData,
+        [...selectedRows].filter(r => r !== value),
+      );
+    }
+
+    if (userAction)
+      set(selectedData, get(internalSelectedData));
+  }
+
+  function onCheckboxClick(event: MouseEvent, value: T[IdType], index: number): void {
+    const currentTarget = event.currentTarget;
+    if (!(currentTarget instanceof HTMLElement))
+      return;
+
+    const input = currentTarget.querySelector('input');
+    const target = event.target;
+    const nodeName = target instanceof HTMLElement ? target.nodeName : undefined;
+
+    const shiftKey = event.shiftKey;
+    set(shiftClicked, shiftKey);
+
+    if (input && nodeName !== 'INPUT') {
+      if (shiftKey) {
+        setTimeout(() => {
+          let lastIndex = get(lastSelectedIndex);
+          if (lastIndex === -1)
+            lastIndex = index;
+          const tableData = get(filtered);
+          const lastSelectedData = tableData[lastIndex];
+          assert(lastSelectedData);
+
+          if (isRow(lastSelectedData)) {
+            const valueToApply = isSelected(lastSelectedData[rowAttr]);
+
+            if (lastIndex === index) {
+              onSelect(!valueToApply, value);
+            }
+            else {
+              const from = Math.min(lastIndex, index);
+              const to = Math.max(lastIndex, index);
+
+              for (let i = from; i <= to; i++) {
+                const currSelectedData = tableData[i];
+                assert(currSelectedData);
+                if (isRow(currSelectedData) && !isDisabledRow(currSelectedData[rowAttr]))
+                  onSelect(valueToApply, currSelectedData[rowAttr]);
+              }
+            }
+
+            set(lastSelectedIndex, index);
+            set(selectedData, get(internalSelectedData));
+          }
+        }, 1);
+      }
+      else {
+        set(lastSelectedIndex, index);
+      }
+    }
+  }
+
+  function deselectRemovedRows(): void {
+    const currentSelected = get(selectedData);
+    if (!currentSelected)
+      return;
+
+    const visibleSet = new Set(get(visibleIdentifiers));
+    const remaining = currentSelected.filter(key => visibleSet.has(key));
+
+    if (remaining.length !== currentSelected.length)
+      set(selectedData, remaining);
+  }
+
+  return {
+    visibleIdentifiers,
+    isAllSelected,
+    indeterminate,
+    isSelected,
+    isDisabledRow,
+    isSelectable,
+    mustSelect,
+    onToggleAll,
+    onSelect,
+    onCheckboxClick,
+    deselectRemovedRows,
+    resetCheckboxShiftState,
+  };
+}

--- a/packages/ui-library/src/composables/tables/data-table/sort.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/sort.spec.ts
@@ -1,0 +1,473 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { useTableSort } from '@/composables/tables/data-table/sort';
+
+interface TestItem {
+  id: number;
+  name: string;
+  title: string;
+}
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent);
+  return { result, unmount: () => wrapper.unmount() };
+}
+
+describe('composables/tables/data-table/sort', () => {
+  let unmount: () => void;
+
+  const rows: TestItem[] = [
+    { id: 3, name: 'Charlie', title: 'Manager' },
+    { id: 1, name: 'Alice', title: 'Developer' },
+    { id: 2, name: 'Bob', title: 'Designer' },
+  ];
+
+  afterEach(() => {
+    unmount?.();
+  });
+
+  it('should filter rows based on search query', () => {
+    const sort = ref<{ column?: string; direction: 'asc' | 'desc' } | undefined>({
+      column: undefined,
+      direction: 'asc',
+    });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => 'alice', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.searchData)).toHaveLength(1);
+    expect(get(result.searchData)[0]?.name).toBe('Alice');
+  });
+
+  it('should sort rows ascending', () => {
+    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    expect(sorted[0]?.name).toBe('Alice');
+    expect(sorted[1]?.name).toBe('Bob');
+    expect(sorted[2]?.name).toBe('Charlie');
+  });
+
+  it('should sort rows descending', () => {
+    const sort = ref({ column: 'name', direction: 'desc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    expect(sorted[0]?.name).toBe('Charlie');
+    expect(sorted[2]?.name).toBe('Alice');
+  });
+
+  it('should sort numeric values correctly', () => {
+    const sort = ref({ column: 'id', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    expect(sorted[0]?.id).toBe(1);
+    expect(sorted[1]?.id).toBe(2);
+    expect(sorted[2]?.id).toBe(3);
+  });
+
+  it('should not sort when sortModifiersExternal is true', () => {
+    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: true },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    expect(sorted[0]?.name).toBe('Charlie');
+  });
+
+  it('should build sortedMap from single sort', () => {
+    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isSortedBy('name')).toBe(true);
+    expect(result.isSortedBy('id')).toBe(false);
+  });
+
+  it('should emit update:options when sort changes via onSort', () => {
+    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const emitUpdateOptions = vi.fn();
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSort({ key: 'name' });
+    expect(emitUpdateOptions).toHaveBeenCalled();
+  });
+
+  it('should toggle single sort direction on same column', () => {
+    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    // asc → desc
+    result.onSort({ key: 'name' });
+    expect(get(result.sortData)).toEqual({ column: 'name', direction: 'desc' });
+  });
+
+  it('should clear single sort when toggling past desc', () => {
+    const sort = ref({ column: 'name', direction: 'desc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    // desc → clear (column=undefined, direction=asc)
+    result.onSort({ key: 'name' });
+    expect(get(result.sortData)).toEqual({ column: undefined, direction: 'asc' });
+  });
+
+  it('should set new column when sorting unsorted column in single mode', () => {
+    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSort({ key: 'title' });
+    expect(get(result.sortData)).toEqual({ column: 'title', direction: 'asc' });
+  });
+
+  it('should support explicit direction in onSort', () => {
+    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSort({ key: 'name', direction: 'desc' });
+    expect(get(result.sortData)).toEqual({ column: 'name', direction: 'desc' });
+  });
+
+  it('should add column in multi-sort mode', () => {
+    const sort = ref([{ column: 'name', direction: 'asc' as const }]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSort({ key: 'title' });
+    const sortVal = get(result.sortData);
+    expect(Array.isArray(sortVal)).toBe(true);
+    expect(sortVal).toHaveLength(2);
+  });
+
+  it('should toggle direction in multi-sort mode', () => {
+    const sort = ref([{ column: 'name', direction: 'asc' as const }]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    // asc → desc
+    result.onSort({ key: 'name' });
+    const sortVal = get(result.sortData) as Array<{ column: string; direction: string }>;
+    expect(sortVal).toHaveLength(1);
+    expect(sortVal[0]?.direction).toBe('desc');
+  });
+
+  it('should remove column in multi-sort when toggling past desc', () => {
+    const sort = ref([
+      { column: 'name', direction: 'desc' as const },
+      { column: 'title', direction: 'asc' as const },
+    ]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    // desc → remove
+    result.onSort({ key: 'name' });
+    const sortVal = get(result.sortData) as Array<{ column: string; direction: string }>;
+    expect(sortVal).toHaveLength(1);
+    expect(sortVal[0]?.column).toBe('title');
+  });
+
+  it('should return sort index for multi-sort', () => {
+    const sort = ref([
+      { column: 'name', direction: 'asc' as const },
+      { column: 'title', direction: 'asc' as const },
+    ]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.getSortIndex('name')).toBe(0);
+    expect(result.getSortIndex('title')).toBe(1);
+    expect(result.getSortIndex('id')).toBe(-1);
+  });
+
+  it('should return -1 for getSortIndex in single sort mode', () => {
+    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.getSortIndex('name')).toBe(-1);
+  });
+
+  it('should build sortedMap from multi-sort array', () => {
+    const sort = ref([
+      { column: 'name', direction: 'asc' as const },
+      { column: 'id', direction: 'desc' as const },
+    ]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isSortedBy('name')).toBe(true);
+    expect(result.isSortedBy('id')).toBe(true);
+    expect(result.isSortedBy('title')).toBe(false);
+  });
+
+  it('should return empty sortedMap when single sort column is undefined', () => {
+    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isSortedBy('name')).toBe(false);
+    expect(result.isSortedBy('id')).toBe(false);
+  });
+
+  it('should skip entries with falsy column in multi-sort sortedMap', () => {
+    const sort = ref([
+      { column: 'name', direction: 'asc' as const },
+      { column: undefined, direction: 'asc' as const },
+    ]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(result.isSortedBy('name')).toBe(true);
+    // The undefined column entry should be skipped
+    expect(Object.keys(get(result.sortedMap))).toHaveLength(1);
+  });
+
+  it('should preserve row order when sort column is undefined', () => {
+    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    // Original order preserved since column is undefined
+    expect(sorted[0]?.name).toBe('Charlie');
+    expect(sorted[1]?.name).toBe('Alice');
+    expect(sorted[2]?.name).toBe('Bob');
+  });
+
+  it('should support explicit direction in multi-sort onSort', () => {
+    const sort = ref([{ column: 'name', direction: 'asc' as const }]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSort({ key: 'title', direction: 'desc' });
+    const sortVal = get(result.sortData) as Array<{ column: string; direction: string }>;
+    expect(sortVal).toHaveLength(2);
+    expect(sortVal[1]?.column).toBe('title');
+    expect(sortVal[1]?.direction).toBe('desc');
+  });
+
+  it('should do nothing when onSort is called with undefined sortData', () => {
+    const sort = ref(undefined);
+    const emitUpdateOptions = vi.fn();
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => rows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: sort as any,
+          pagination: ref(undefined),
+          emitUpdateOptions,
+        },
+      ),
+    );
+    unmount = u;
+
+    result.onSort({ key: 'name' });
+    expect(emitUpdateOptions).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-library/src/composables/tables/data-table/sort.ts
+++ b/packages/ui-library/src/composables/tables/data-table/sort.ts
@@ -1,0 +1,194 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { SortColumn, TableRowKey, TableSortData } from '@/components/tables/RuiTableHead.vue';
+import type { TablePaginationData } from '@/components/tables/RuiTablePagination.vue';
+import { assert } from '@/utils/assert';
+
+const SORT_COLLATOR_OPTIONS: Intl.CollatorOptions = { sensitivity: 'accent', usage: 'sort' };
+
+export interface UseTableSortOptions<T extends object> {
+  rows: MaybeRefOrGetter<T[]>;
+  search: MaybeRefOrGetter<string>;
+  sortModifiersExternal: boolean | undefined;
+}
+
+export interface UseTableSortDeps<T extends object> {
+  sort: Ref<TableSortData<T>>;
+  pagination: Ref<TablePaginationData | undefined>;
+  emitUpdateOptions: (options: {
+    sort?: TableSortData<T>;
+    pagination?: TablePaginationData;
+  }) => void;
+}
+
+export interface UseTableSortReturn<T extends object> {
+  sortData: ComputedRef<TableSortData<T>>;
+  sortedMap: ComputedRef<Partial<Record<TableRowKey<T>, SortColumn<T>>>>;
+  searchData: ComputedRef<T[]>;
+  sorted: ComputedRef<T[]>;
+  isSortedBy: (key: TableRowKey<T>) => boolean;
+  getSortIndex: (key: TableRowKey<T>) => number;
+  onSort: (payload: { key: TableRowKey<T>; direction?: 'asc' | 'desc' }) => void;
+}
+
+export function useTableSort<T extends object>(
+  options: UseTableSortOptions<T>,
+  deps: UseTableSortDeps<T>,
+): UseTableSortReturn<T> {
+  const { sortModifiersExternal } = options;
+  const { sort, pagination, emitUpdateOptions } = deps;
+
+  const getKeys = <O extends object>(t: O): TableRowKey<O>[] => Object.keys(t) as TableRowKey<O>[];
+
+  const sortData = computed<TableSortData<T>>({
+    get(): TableSortData<T> {
+      return get(sort);
+    },
+    set(value: TableSortData<T>) {
+      set(sort, value);
+      emitUpdateOptions({
+        sort: value,
+        pagination: get(pagination),
+      });
+    },
+  });
+
+  const sortedMap = computed<Partial<Record<TableRowKey<T>, SortColumn<T>>>>(() => {
+    const mapped: Partial<Record<TableRowKey<T>, SortColumn<T>>> = {};
+    const sortBy = get(sortData);
+    if (!sortBy)
+      return mapped;
+
+    if (!Array.isArray(sortBy)) {
+      if (sortBy.column)
+        mapped[sortBy.column] = sortBy;
+
+      return mapped;
+    }
+
+    return sortBy.reduce((acc, curr) => {
+      if (!curr.column)
+        return acc;
+
+      acc[curr.column] = curr;
+      return acc;
+    }, mapped);
+  });
+
+  const searchData = computed<T[]>(() => {
+    const currentRows = toValue(options.rows);
+    const query = toValue(options.search)?.toLocaleLowerCase();
+    if (!query)
+      return currentRows;
+
+    return currentRows.filter(row =>
+      getKeys(row).some(key => `${row[key]}`.toLocaleLowerCase().includes(query)),
+    );
+  });
+
+  const sorted: ComputedRef<T[]> = computed(() => {
+    const sortBy = get(sortData);
+    const data = [...get(searchData)];
+    if (!sortBy || sortModifiersExternal)
+      return data;
+
+    const sortFn = (by: SortColumn<T>): void => {
+      data.sort((a, b) => {
+        const column = by.column;
+        if (!column)
+          return 0;
+
+        let [aValue, bValue] = [a[column], b[column]];
+        if (by.direction === 'desc')
+          [aValue, bValue] = [bValue, aValue];
+
+        const aNumber = Number(aValue);
+        const bNumber = Number(bValue);
+        if (!isNaN(aNumber) && !isNaN(bNumber))
+          return aNumber - bNumber;
+
+        return `${aValue}`.localeCompare(`${bValue}`, undefined, SORT_COLLATOR_OPTIONS);
+      });
+    };
+
+    if (!Array.isArray(sortBy))
+      sortFn(sortBy);
+    else [...sortBy].reverse().forEach(sortFn);
+
+    return data;
+  });
+
+  function isSortedBy(key: TableRowKey<T>): boolean {
+    return key in get(sortedMap);
+  }
+
+  function getSortIndex(key: TableRowKey<T>): number {
+    const sortBy = get(sortData);
+
+    if (!sortBy || !Array.isArray(sortBy) || !isSortedBy(key))
+      return -1;
+
+    return sortBy.findIndex(s => s.column === key);
+  }
+
+  function onSort({ key, direction }: { key: TableRowKey<T>; direction?: 'asc' | 'desc' }): void {
+    const sortBy = get(sortData);
+    if (!sortBy)
+      return;
+
+    if (!Array.isArray(sortBy)) {
+      if (isSortedBy(key)) {
+        const newDirection = !direction || direction === 'asc' ? 'desc' : 'asc';
+
+        if (sortBy.direction === newDirection) {
+          set(sortData, { ...sortBy, column: undefined, direction: 'asc' });
+        }
+        else {
+          set(sortData, {
+            ...sortBy,
+            direction: sortBy.direction === 'asc' ? 'desc' : 'asc',
+          });
+        }
+      }
+      else {
+        set(sortData, { column: key, direction: direction || 'asc' });
+      }
+      return;
+    }
+
+    if (isSortedBy(key)) {
+      const newDirection = !direction || direction === 'asc' ? 'desc' : 'asc';
+
+      const index = getSortIndex(key);
+      const sortByCol = sortBy[index];
+      assert(sortByCol);
+
+      if (sortByCol.direction === newDirection) {
+        set(
+          sortData,
+          sortBy.filter((_, i) => i !== index),
+        );
+      }
+      else {
+        set(
+          sortData,
+          sortBy.map((col, i) =>
+            i === index ? { ...col, direction: col.direction === 'asc' ? 'desc' : 'asc' } : col,
+          ),
+        );
+      }
+    }
+    else {
+      set(sortData, [...sortBy, { column: key, direction: direction || 'asc' }]);
+    }
+  }
+
+  return {
+    sortData,
+    sortedMap,
+    searchData,
+    sorted,
+    isSortedBy,
+    getSortIndex,
+    onSort,
+  };
+}

--- a/packages/ui-library/src/composables/tables/data-table/types.ts
+++ b/packages/ui-library/src/composables/tables/data-table/types.ts
@@ -1,0 +1,23 @@
+import type { TableSortData } from '@/components/tables/RuiTableHead.vue';
+import type { TablePaginationData } from '@/components/tables/RuiTablePagination.vue';
+
+export interface TableOptions<T> {
+  pagination?: TablePaginationData;
+  sort?: TableSortData<T>;
+}
+
+export interface GroupHeader<T> {
+  __header__: true;
+  identifier: string;
+  group: Partial<T>;
+}
+
+export type GroupedTableRow<T> = T | GroupHeader<T>;
+
+export function isRow<T extends object>(item: GroupedTableRow<T>): item is T {
+  return !('__header__' in item);
+}
+
+export function isHeaderSlot(slotName: string): slotName is `header.${string}` {
+  return slotName.startsWith('header.');
+}

--- a/packages/ui-library/vitest.config.ts
+++ b/packages/ui-library/vitest.config.ts
@@ -19,8 +19,8 @@ const vitestConfig = defineConfig({
       provider: 'v8',
       reportsDirectory: 'tests/coverage',
       reporter: ['html', 'json'],
-      include: ['src/*'],
-      exclude: ['node_modules', 'tests/', '**/*.d.ts', 'src/**/*.stories.ts'],
+      include: ['src/**'],
+      exclude: ['node_modules', 'tests/', '**/*.d.ts', 'src/**/*.stories.ts', 'src/**/__test__/**'],
     },
     projects: [
       {


### PR DESCRIPTION
## Summary

- Extract RuiDataTable (~970 line script) into 6 focused composables: columns, expansion, grouping, pagination, selection, and sort
- Eliminate circular dependency between sort and selection via component-level wrapper
- Add Set-based O(1) lookups for selection, expansion, and grouping state
- Optimize sticky header: rAF-throttled scroll/resize, fix resize observer leak, use `useTemplateRef`
- Remove dead code (unused scroller prop, redundant rowIdentifier wrapper, stale CSS)
- Match loading/empty state heights to prevent layout shift
- Add 77 unit tests covering all composable logic

## Test plan

- [x] All 77 composable unit tests pass
- [x] All 89 RuiDataTable integration tests pass
- [x] TypeScript compiles cleanly (library + example app)
- [x] ESLint passes on all changed files
- [ ] Verify sticky header behavior in example app
- [ ] Verify selection, pagination, grouping, and sort in example app
- [ ] Run e2e tests against production build