### PR TITLE
refactor(autocomplete): fix bugs, improve performance, and add storybook coverage

### DIFF
--- a/apps/example/src/pages/auto-completes/advanced.vue
+++ b/apps/example/src/pages/auto-completes/advanced.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import AutoCompleteAdvancedView from '@/views/auto-completes/AutoCompleteAdvancedView.vue';
+</script>
+
+<template>
+  <AutoCompleteAdvancedView />
+</template>

--- a/apps/example/src/pages/auto-completes/keyboard.vue
+++ b/apps/example/src/pages/auto-completes/keyboard.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import AutoCompleteKeyboardView from '@/views/auto-completes/AutoCompleteKeyboardView.vue';
+</script>
+
+<template>
+  <AutoCompleteKeyboardView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -54,6 +54,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/auto-completes/advanced': RouteRecordInfo<
+      '/auto-completes/advanced',
+      '/auto-completes/advanced',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/auto-completes/basic': RouteRecordInfo<
       '/auto-completes/basic',
       '/auto-completes/basic',
@@ -64,6 +71,13 @@ declare module 'vue-router/auto-routes' {
     '/auto-completes/custom': RouteRecordInfo<
       '/auto-completes/custom',
       '/auto-completes/custom',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
+    '/auto-completes/keyboard': RouteRecordInfo<
+      '/auto-completes/keyboard',
+      '/auto-completes/keyboard',
       Record<never, never>,
       Record<never, never>,
       | never
@@ -420,6 +434,12 @@ declare module 'vue-router/auto-routes' {
       views:
         | never
     }
+    'src/pages/auto-completes/advanced.vue': {
+      routes:
+        | '/auto-completes/advanced'
+      views:
+        | never
+    }
     'src/pages/auto-completes/basic.vue': {
       routes:
         | '/auto-completes/basic'
@@ -429,6 +449,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/auto-completes/custom.vue': {
       routes:
         | '/auto-completes/custom'
+      views:
+        | never
+    }
+    'src/pages/auto-completes/keyboard.vue': {
+      routes:
+        | '/auto-completes/keyboard'
       views:
         | never
     }

--- a/apps/example/src/views/auto-completes/AutoCompleteAdvancedView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteAdvancedView.vue
@@ -1,0 +1,134 @@
+<script lang="ts" setup>
+import { RuiAutoComplete } from '@rotki/ui-library/components';
+import { createOptions, type SelectOption } from '@/data/options';
+
+const objectOptions = createOptions();
+const primitiveOptions: string[] = ['Lorem', 'Ipsum', 'Dolor', 'Sit amet', 'Consecteur'];
+
+// Options with id starting at 0 for falsy value testing
+const numericOptions: SelectOption[] = [
+  { id: 0, label: 'Zero' },
+  { id: 1, label: 'One' },
+  { id: 2, label: 'Two' },
+  { id: 3, label: 'Three' },
+];
+
+const returnObjectValue = ref<SelectOption>();
+const returnObjectPreselected = ref<SelectOption>({ id: 1, label: 'Germany' });
+const filledValue = ref<string>();
+const filledOutlinedValue = ref<string>();
+const falsyValue = ref<number>(0);
+const searchInputValue = ref<string>();
+const searchInputText = ref<string>('');
+
+const multiClearValue = ref<string[]>(['Lorem', 'Ipsum', 'Dolor']);
+const customBlurValue = ref<string>();
+</script>
+
+<template>
+  <div data-cy="auto-completes-advanced">
+    <h2 class="text-2xl font-bold mb-6">
+      Advanced
+    </h2>
+
+    <div class="grid gap-6 grid-cols-2">
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="returnObjectValue"
+          return-object
+          :options="objectOptions"
+          key-attr="id"
+          text-attr="label"
+          label="Return Object"
+          data-cy="ac-adv-return-object"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="returnObjectPreselected"
+          return-object
+          :options="objectOptions"
+          key-attr="id"
+          text-attr="label"
+          label="Return Object (pre-selected)"
+          data-cy="ac-adv-return-object-pre"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="filledValue"
+          variant="filled"
+          :options="primitiveOptions"
+          label="Filled Variant"
+          data-cy="ac-adv-filled"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="filledOutlinedValue"
+          variant="outlined"
+          :options="primitiveOptions"
+          label="Outlined (comparison)"
+          data-cy="ac-adv-outlined"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="falsyValue"
+          :options="numericOptions"
+          key-attr="id"
+          text-attr="label"
+          label="Falsy Value (0)"
+          data-cy="ac-adv-falsy"
+        />
+        <div
+          data-cy="ac-adv-falsy-display"
+          class="mt-2 text-sm"
+        >
+          Model: {{ falsyValue === undefined ? 'undefined' : falsyValue }}
+        </div>
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="searchInputValue"
+          v-model:search-input="searchInputText"
+          :options="primitiveOptions"
+          label="Search Input Model"
+          data-cy="ac-adv-search-input"
+        />
+        <div
+          data-cy="ac-adv-search-display"
+          class="mt-2 text-sm"
+        >
+          Search: "{{ searchInputText }}"
+        </div>
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="multiClearValue"
+          chips
+          clearable
+          :options="primitiveOptions"
+          label="Multi Clear"
+          data-cy="ac-adv-multi-clear"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="customBlurValue"
+          custom-value
+          :options="primitiveOptions"
+          label="Custom Value on Blur"
+          data-cy="ac-adv-custom-blur"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/example/src/views/auto-completes/AutoCompleteKeyboardView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteKeyboardView.vue
@@ -1,0 +1,95 @@
+<script lang="ts" setup>
+import { RuiAutoComplete } from '@rotki/ui-library/components';
+
+const primitiveOptions: string[] = ['Lorem', 'Ipsum', 'Dolor', 'Sit amet', 'Consecteur'];
+
+const multiNonChipsValue = ref<string[]>(['Lorem', 'Ipsum', 'Dolor']);
+const multiChipsValue = ref<string[]>(['Lorem', 'Ipsum', 'Dolor']);
+const chipNavValue = ref<string[]>(['Lorem', 'Ipsum', 'Dolor', 'Sit amet']);
+const escapeValue = ref<string>();
+const formValue = ref<string>('Lorem');
+const formSubmitted = ref<boolean>(false);
+const reopenValue = ref<string>();
+
+function onFormSubmit(): void {
+  formSubmitted.value = true;
+}
+</script>
+
+<template>
+  <div data-cy="auto-completes-keyboard">
+    <h2 class="text-2xl font-bold mb-6">
+      Keyboard
+    </h2>
+
+    <div class="grid gap-6 grid-cols-2">
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="multiNonChipsValue"
+          :options="primitiveOptions"
+          label="Multi Non-Chips (Backspace)"
+          data-cy="ac-kb-multi-no-chips"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="multiChipsValue"
+          chips
+          :options="primitiveOptions"
+          label="Multi Chips (Backspace)"
+          data-cy="ac-kb-multi-chips"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="chipNavValue"
+          chips
+          :options="primitiveOptions"
+          label="Chip Navigation (Arrows)"
+          data-cy="ac-kb-chip-nav"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="escapeValue"
+          :options="primitiveOptions"
+          label="Escape to Close"
+          data-cy="ac-kb-escape"
+        />
+      </div>
+
+      <div class="py-4">
+        <form
+          data-cy="ac-kb-form"
+          @submit.prevent="onFormSubmit()"
+        >
+          <RuiAutoComplete
+            v-model="formValue"
+            :options="primitiveOptions"
+            label="Form Submit (Enter)"
+            data-cy="ac-kb-form-submit"
+          />
+          <div
+            v-if="formSubmitted"
+            data-cy="form-submitted"
+            class="mt-2 text-green-600"
+          >
+            Form submitted!
+          </div>
+        </form>
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="reopenValue"
+          :options="primitiveOptions"
+          label="Re-open Highlight"
+          data-cy="ac-kb-reopen"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/example/src/views/auto-completes/index.vue
+++ b/apps/example/src/views/auto-completes/index.vue
@@ -33,6 +33,18 @@ const sections = [
     route: '/auto-completes/custom',
     icon: 'lu-blocks',
   },
+  {
+    title: 'Keyboard',
+    description: 'Keyboard navigation, Backspace, Escape, Enter, chip arrows',
+    route: '/auto-completes/keyboard',
+    icon: 'lu-keyboard',
+  },
+  {
+    title: 'Advanced',
+    description: 'Return object, filled variant, falsy values, search model',
+    route: '/auto-completes/advanced',
+    icon: 'lu-settings',
+  },
 ];
 </script>
 

--- a/packages/ui-library/.storybook/main.ts
+++ b/packages/ui-library/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from '@storybook/vue3-vite';
-import vueDevTools from 'vite-plugin-vue-devtools';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
@@ -21,13 +20,6 @@ const config: StorybookConfig = {
   },
   typescript: {
     check: true,
-  },
-  async viteFinal(config) {
-    const { mergeConfig } = await import('vite');
-
-    return mergeConfig(config, {
-      plugins: [vueDevTools()],
-    });
   },
 };
 

--- a/packages/ui-library/src/composables/forms/auto-complete/search.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/search.ts
@@ -60,12 +60,12 @@ export function useAutoCompleteSearch<TItem>(
       if (!item)
         return false;
 
-      const keywords: string[] = [keyAttr ? getCachedTextToken((item as any)[keyAttr]) : item.toString()];
+      const keywords: string[] = [getCachedTextToken(keyAttr ? String((item as any)[keyAttr]) : item.toString())];
 
       if (textAttr && typeof item === 'object')
-        keywords.push(getCachedTextToken((item as any)[textAttr]));
+        keywords.push(getCachedTextToken(String((item as any)[textAttr])));
 
-      return keywords.some(keyword => getCachedTextToken(keyword).includes(searchToken));
+      return keywords.some(keyword => keyword.includes(searchToken));
     });
 
     const filtered = optionsValue.filter(item => usedFilter(item, search));


### PR DESCRIPTION
## Summary

- **Fix falsy value handling** across `value.ts`, `dropdown-menu.ts`, and `keyboard-navigation.ts` — values like `0` or `''` were silently dropped by JavaScript truthiness checks (`!!val`, `if(val)`, `val ? x : y`), replaced with explicit `=== null || === undefined` checks
- **Fix `onClick.stop` in chipAttrs** — Vue event modifiers don't work in `v-bind` objects, so `setValueFocus()` was never called on chip clicks; replaced with explicit `stopPropagation()` call
- **Fix Backspace in non-chips multi-value mode** — directly removes last item instead of trying to focus non-existent chip elements
- **Add `stopPropagation` to chip keyboard delete** to prevent browser back-navigation in Storybook
- **Remove side effects from `value` computed getter** — moved search text sync to a dedicated watcher
- **Eliminate `tempIsOpen`/`syncRef` workaround** by creating `isOpen` ref upfront and passing to both composables
- **O(1) `isActiveItem` via Set lookup** instead of O(n) `findIndex` per call
- **Replace `menuMinHeight` DOM-measuring watcher** with a simple computed based on item count × item height
- **Fix `applyHighlighted`** — replaced `.find()` linear scan with direct index access
- **Remove redundant double-tokenization** in search filter — keywords are now tokenized once at creation
- **Deduplicate `multiple` computed** between component and value composable
- **Fix `getText` usage in `onEnter`** instead of hardcoded `.label`/`.value` property names
- **Reorder script setup** to place reactive state before computed properties per project conventions
- **Add 16 new storybook stories** with interaction tests (chips deletion, multi-value deletion, hide-selected, no-filter, auto-select-first, custom value, read-only, loading, placeholders, hints, errors, success messages, hide-details, required)
- **Add 4 unit tests** for falsy value handling, chip keyboard propagation, non-chips multi-value deletion, and chip click focus

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test:run` — 937 unit tests pass
- [x] `pnpm run test:storybook` — 358 storybook tests pass (all 24 AutoComplete stories)