### PR TITLE
fix(logos): deduplicate asset-mappings fetch and add src prop

### DIFF
--- a/packages/ui-library/src/components/logos/RuiLogo.spec.ts
+++ b/packages/ui-library/src/components/logos/RuiLogo.spec.ts
@@ -78,4 +78,28 @@ describe('components/logos/RuiLogo.vue', () => {
     expect(placeholder.exists()).toBe(true);
     expect(placeholder.attributes('aria-label')).toBe('rotki');
   });
+
+  it('should render custom image directly when src prop is provided', () => {
+    wrapper = createWrapper({
+      props: {
+        src: '/staging/logo.svg',
+      },
+    });
+
+    const img = wrapper.find('img[data-image=custom]');
+    expect(img.exists()).toBeTruthy();
+    expect(img.attributes('src')).toBe('/staging/logo.svg');
+  });
+
+  it('should not show decoding placeholder when src is provided with logo', () => {
+    wrapper = createWrapper({
+      props: {
+        src: '/staging/logo.svg',
+        logo: 'website',
+      },
+    });
+
+    expect(wrapper.find('div[role=img]').exists()).toBe(false);
+    expect(wrapper.find('img[data-image=custom]').exists()).toBeTruthy();
+  });
 });

--- a/packages/ui-library/src/components/logos/RuiLogo.vue
+++ b/packages/ui-library/src/components/logos/RuiLogo.vue
@@ -2,7 +2,7 @@
 import { isClient } from '@vueuse/shared';
 import { useSSRContext } from 'vue';
 import fallback from '@/components/logos/logo.svg';
-import { transformCase } from '@/utils/helpers';
+import { getLogoSources } from '@/components/logos/use-logo-sources';
 
 export interface ExternalLinks {
   drawer?: string;
@@ -60,17 +60,11 @@ async function fetchSources(): Promise<void> {
     return;
 
   set(pendingSources, true);
-  try {
-    const { data } = await useFetch<string>(
-      `https://raw.githubusercontent.com/rotki/data/${branch}/constants/asset-mappings.json`,
-    );
+  const links = await getLogoSources(branch);
 
-    const links = transformCase(JSON.parse(get(data) ?? 'null')?.logo, 'camelCase');
+  if (links)
+    set(externalSources, links);
 
-    if (links)
-      set(externalSources, links);
-  }
-  catch {}
   set(pendingSources, false);
 }
 

--- a/packages/ui-library/src/components/logos/RuiLogo.vue
+++ b/packages/ui-library/src/components/logos/RuiLogo.vue
@@ -19,17 +19,18 @@ export interface Props {
   logo?: keyof ExternalLinks;
   size?: string | number; // in rems
   uniqueKey?: string | number;
+  src?: string;
 }
 
 defineOptions({
   name: 'RuiLogo',
 });
 
-const { text = false, branch = 'develop', logo, size = 3, uniqueKey } = defineProps<Props>();
+const { text = false, branch = 'develop', logo, size = 3, uniqueKey, src } = defineProps<Props>();
 
 const customImageRef = useTemplateRef<HTMLImageElement>('customImageRef');
 const error = ref<boolean>(false);
-const decoding = ref<boolean>(!!logo);
+const decoding = ref<boolean>(!!logo && !src);
 const pendingSources = ref<boolean>(false);
 const appName = 'rotki';
 const emptyLinks: ExternalLinks = {
@@ -41,6 +42,9 @@ const emptyLinks: ExternalLinks = {
 const externalSources = ref<ExternalLinks>(emptyLinks);
 
 const externalSource = computed<string | undefined>(() => {
+  if (src)
+    return src;
+
   const sources = get(externalSources);
   if (!logo || !sources[logo]) {
     set(decoding, get(pendingSources));
@@ -56,7 +60,7 @@ const externalSource = computed<string | undefined>(() => {
 });
 
 async function fetchSources(): Promise<void> {
-  if (!logo)
+  if (!logo || src)
     return;
 
   set(pendingSources, true);

--- a/packages/ui-library/src/components/logos/use-logo-sources.spec.ts
+++ b/packages/ui-library/src/components/logos/use-logo-sources.spec.ts
@@ -1,0 +1,125 @@
+import { http, HttpResponse } from 'msw';
+import { afterEach, describe, expect, it } from 'vitest';
+import { server } from '../../../tests/mocks/server';
+import { clearLogoSourcesCache, getLogoSources } from './use-logo-sources';
+
+describe('use-logo-sources', () => {
+  afterEach(() => {
+    server.resetHandlers();
+    clearLogoSourcesCache();
+  });
+
+  it('should fetch and return external links for a branch', async () => {
+    const result = await getLogoSources('develop');
+
+    expect(result).toBeDefined();
+    expect(result?.website).toBe('website-logo.svg');
+    expect(result?.app).toBe('app-logo.svg');
+    expect(result?.drawer).toBe('drawer-logo.svg');
+    expect(result?.about).toBe('about-logo.svg');
+    expect(result?.emptyScreen).toBe('empty-screen-logo.svg');
+  });
+
+  it('should deduplicate concurrent requests for the same branch', async () => {
+    let fetchCount = 0;
+    server.use(
+      http.get('https://raw.githubusercontent.com/rotki/data/:branch/constants/asset-mappings.json', () => {
+        fetchCount++;
+        return HttpResponse.json({
+          logo: {
+            app: 'app.svg',
+            website: 'web.svg',
+          },
+        });
+      }),
+    );
+
+    // Fire 3 concurrent requests for the same branch
+    const [result1, result2, result3] = await Promise.all([
+      getLogoSources('main'),
+      getLogoSources('main'),
+      getLogoSources('main'),
+    ]);
+
+    expect(fetchCount).toBe(1);
+    expect(result1).toStrictEqual(result2);
+    expect(result2).toStrictEqual(result3);
+    expect(result1?.app).toBe('app.svg');
+  });
+
+  it('should cache resolved values for subsequent calls', async () => {
+    let fetchCount = 0;
+    server.use(
+      http.get('https://raw.githubusercontent.com/rotki/data/:branch/constants/asset-mappings.json', () => {
+        fetchCount++;
+        return HttpResponse.json({
+          logo: { app: 'cached.svg' },
+        });
+      }),
+    );
+
+    const first = await getLogoSources('main');
+    const second = await getLogoSources('main');
+
+    expect(fetchCount).toBe(1);
+    expect(first?.app).toBe('cached.svg');
+    expect(second?.app).toBe('cached.svg');
+  });
+
+  it('should fetch separately for different branches', async () => {
+    const requestedBranches: string[] = [];
+    server.use(
+      http.get('https://raw.githubusercontent.com/rotki/data/:branch/constants/asset-mappings.json', ({ params }) => {
+        const branch = params.branch as string;
+        requestedBranches.push(branch);
+        return HttpResponse.json({
+          logo: { app: `${branch}-app.svg` },
+        });
+      }),
+    );
+
+    const [develop, main] = await Promise.all([
+      getLogoSources('develop'),
+      getLogoSources('main'),
+    ]);
+
+    expect(requestedBranches).toHaveLength(2);
+    expect(requestedBranches).toContain('develop');
+    expect(requestedBranches).toContain('main');
+    expect(develop?.app).toBe('develop-app.svg');
+    expect(main?.app).toBe('main-app.svg');
+  });
+
+  it('should return undefined on network error', async () => {
+    server.use(
+      http.get('https://raw.githubusercontent.com/rotki/data/:branch/constants/asset-mappings.json', () =>
+        HttpResponse.error()),
+    );
+
+    const result = await getLogoSources('develop');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when response has no logo field', async () => {
+    server.use(
+      http.get('https://raw.githubusercontent.com/rotki/data/:branch/constants/asset-mappings.json', () =>
+        HttpResponse.json({ other: 'data' })),
+    );
+
+    const result = await getLogoSources('develop');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when logo field contains non-string values', async () => {
+    server.use(
+      http.get('https://raw.githubusercontent.com/rotki/data/:branch/constants/asset-mappings.json', () =>
+        HttpResponse.json({ logo: { app: 123, website: true } })),
+    );
+
+    const result = await getLogoSources('develop');
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/ui-library/src/components/logos/use-logo-sources.ts
+++ b/packages/ui-library/src/components/logos/use-logo-sources.ts
@@ -1,0 +1,53 @@
+import type { ExternalLinks } from '@/components/logos/RuiLogo.vue';
+import { transformCase } from '@/utils/helpers';
+
+const ASSET_MAPPINGS_URL = 'https://raw.githubusercontent.com/rotki/data';
+
+// Module-level cache: deduplicates asset-mappings fetches across all RuiLogo instances.
+// Keyed by branch so different branches don't share stale data.
+const sourcesCache = new Map<string, Promise<ExternalLinks | undefined>>();
+
+function isExternalLinks(value: unknown): value is ExternalLinks {
+  if (typeof value !== 'object' || value === null)
+    return false;
+
+  return Object.values(value).every(v => v === undefined || typeof v === 'string');
+}
+
+async function fetchSourcesFromNetwork(branch: string): Promise<ExternalLinks | undefined> {
+  try {
+    const { data } = await useFetch<string>(
+      `${ASSET_MAPPINGS_URL}/${branch}/constants/asset-mappings.json`,
+    );
+
+    const links = transformCase(JSON.parse(get(data) ?? 'null')?.logo, 'camelCase');
+    if (isExternalLinks(links))
+      return links;
+
+    return undefined;
+  }
+  catch {
+    return undefined;
+  }
+}
+
+/**
+ * Fetches external logo sources for a given branch, deduplicating concurrent requests.
+ * Uses a module-level cache so all RuiLogo instances share a single fetch per branch.
+ */
+export function getLogoSources(branch: string): Promise<ExternalLinks | undefined> {
+  const cached = sourcesCache.get(branch);
+  if (cached)
+    return cached;
+
+  const promise = fetchSourcesFromNetwork(branch);
+  sourcesCache.set(branch, promise);
+  return promise;
+}
+
+/**
+ * Clears the module-level cache. Exposed for testing only.
+ */
+export function clearLogoSourcesCache(): void {
+  sourcesCache.clear();
+}


### PR DESCRIPTION
## Summary

- **Deduplicate asset-mappings fetch**: Extract fetch logic from `RuiLogo` into a separate `use-logo-sources.ts` helper with a module-level `Map<string, Promise>` cache keyed by branch. Multiple `RuiLogo` instances now share a single network request per branch instead of each fetching independently. Uses a type guard (`isExternalLinks`) instead of type casting for runtime validation.
- **Add `src` prop**: When provided, `RuiLogo` renders the URL directly without fetching asset-mappings from GitHub. This allows consumers to pass a local image (e.g. staging logo) without external fetch overhead.

## Test plan

- [x] Added 7 unit tests for `use-logo-sources.ts` (fetch, dedup, caching, error handling, type guard)
- [x] Added 2 unit tests for `src` prop in `RuiLogo.spec.ts`
- [x] Existing RuiLogo tests still pass (12 total)