### PR TITLE
refactor(tests): standardize on data-id and configure Playwright testIdAttribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,17 +162,16 @@ test.describe('component name', () => {
   });
 
   test('should do something', async ({ page }) => {
-    await expect(page.locator('[data-cy=element]')).toBeVisible();
+    await expect(page.getByTestId('element')).toBeVisible();
   });
 });
 ```
 
 **Locator Best Practices (in order of preference):**
 
-1. `[data-cy=...]` - Test-specific attributes (preferred)
+1. `page.getByTestId('...')` - Uses `data-id` attribute (preferred, configured via `testIdAttribute` in playwright config)
 2. `[role=...]` - ARIA roles for accessibility testing
-3. `[data-id=...]` - Component-specific identifiers
-4. `[class*=_component_]` - CSS module classes (last resort for internal state)
+3. `[class*=_component_]` - CSS module classes (last resort for internal state)
 
 **Avoid:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,14 +176,14 @@ test.describe('component name', () => {
   });
 
   test('should do something', async ({ page }) => {
-    await expect(page.locator('[data-cy=element]')).toBeVisible();
+    await expect(page.locator('[data-id=element]')).toBeVisible();
   });
 });
 ```
 
 **Locator strategy** (in order of preference):
 
-1. `[data-cy=...]` - Test-specific data attributes (preferred)
+1. `[data-id=...]` - Test-specific data attributes (preferred)
 2. `[role=...]` - ARIA roles for accessibility
 3. `[data-id=...]` - Component identifiers
 4. `[class*=_name_]` - CSS module classes (last resort)

--- a/apps/example/e2e/accordions.spec.ts
+++ b/apps/example/e2e/accordions.spec.ts
@@ -6,10 +6,10 @@ test.describe('accordions', () => {
   });
 
   test('should render accordions and handle expansion', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=accordions]')).toContainText('Accordions');
+    await expect(page.locator('h2[data-id=accordions]')).toContainText('Accordions');
 
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const accordions = wrapper.locator('[data-cy=accordions]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const accordions = wrapper.locator('[data-id=accordions]');
 
     await expect(accordions.locator('> *')).toHaveCount(2);
 
@@ -22,8 +22,8 @@ test.describe('accordions', () => {
   });
 
   test('should allow multiple accordions to be open when multiple prop is set', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-1]');
-    const accordions = wrapper.locator('[data-cy=accordions]');
+    const wrapper = page.locator('[data-id=wrapper-1]');
+    const accordions = wrapper.locator('[data-id=accordions]');
 
     await expect(accordions.locator('> *')).toHaveCount(2);
 
@@ -41,8 +41,8 @@ test.describe('accordions', () => {
   });
 
   test('should toggle aria-expanded on click', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const accordions = wrapper.locator('[data-cy=accordions]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const accordions = wrapper.locator('[data-id=accordions]');
     const trigger = accordions.locator('div:first-child [data-accordion-trigger]');
 
     await expect(trigger).toHaveAttribute('aria-expanded', 'false');
@@ -56,8 +56,8 @@ test.describe('accordions', () => {
   });
 
   test('should collapse accordion when clicking expanded header', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const accordions = wrapper.locator('[data-cy=accordions]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const accordions = wrapper.locator('[data-id=accordions]');
     const trigger = accordions.locator('div:first-child [data-accordion-trigger]');
 
     await trigger.click();
@@ -71,8 +71,8 @@ test.describe('accordions', () => {
   });
 
   test('should have data-state attribute on accordion', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const accordions = wrapper.locator('[data-cy=accordions]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const accordions = wrapper.locator('[data-id=accordions]');
     const accordion = accordions.locator('> [data-accordion]').first();
 
     await expect(accordion).toHaveAttribute('data-state', 'closed');
@@ -82,8 +82,8 @@ test.describe('accordions', () => {
   });
 
   test('should have role="button" and aria-controls on trigger', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const trigger = wrapper.locator('[data-cy=accordions] div:first-child [data-accordion-trigger]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const trigger = wrapper.locator('[data-id=accordions] div:first-child [data-accordion-trigger]');
 
     await expect(trigger).toHaveAttribute('role', 'button');
     await expect(trigger).toHaveAttribute('tabindex', '0');
@@ -91,8 +91,8 @@ test.describe('accordions', () => {
   });
 
   test('should have role="region" on content with aria-labelledby', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const accordions = wrapper.locator('[data-cy=accordions]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const accordions = wrapper.locator('[data-id=accordions]');
     const trigger = accordions.locator('div:first-child [data-accordion-trigger]');
 
     // Open accordion to reveal content

--- a/apps/example/e2e/alert.spec.ts
+++ b/apps/example/e2e/alert.spec.ts
@@ -6,7 +6,7 @@ test.describe('alerts', () => {
   });
 
   test('checks for alerts and alert text', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=alerts]')).toContainText('Alerts');
+    await expect(page.locator('h2[data-id=alerts]')).toContainText('Alerts');
 
     // Find alerts that have action buttons and close buttons using native locators
     // Instead of finding button first and traversing up with XPath, find alert first

--- a/apps/example/e2e/button.spec.ts
+++ b/apps/example/e2e/button.spec.ts
@@ -6,9 +6,9 @@ test.describe('buttons', () => {
   });
 
   test('should render buttons and handle click events', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=buttons]')).toContainText('Buttons');
+    await expect(page.locator('h2[data-id=buttons]')).toContainText('Buttons');
 
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
     const primaryButton = content.locator('button[class*=_primary_]').first();
     const disabledButton = content.locator('button[disabled]').first();
 

--- a/apps/example/e2e/calendar.spec.ts
+++ b/apps/example/e2e/calendar.spec.ts
@@ -6,7 +6,7 @@ test.describe('calendars', () => {
   });
 
   test('should render calendar with selected date', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=calendars]')).toContainText('Calendar');
+    await expect(page.locator('h2[data-id=calendars]')).toContainText('Calendar');
 
     await expect(page.locator('[data-id="2023-01-02"]')).toHaveClass(/bg-rui-primary/);
     await expect(page.locator('[data-id="2023-01-02"]')).toHaveClass(/text-white/);

--- a/apps/example/e2e/card.spec.ts
+++ b/apps/example/e2e/card.spec.ts
@@ -6,22 +6,22 @@ test.describe('cards', () => {
   });
 
   test('should render card with header, content, and footer', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=cards]')).toContainText('Cards');
+    await expect(page.locator('h2[data-id=cards]')).toContainText('Cards');
 
-    const card = page.locator('div[data-cy=card-0-0]');
+    const card = page.locator('div[data-id=card-0-0]');
     await expect(card.locator('h5[class*=_header_]')).toBeVisible();
     await expect(card.locator('p[class*=_subheader_]')).toBeVisible();
     await expect(card.locator('div[class*=_content_]')).toBeVisible();
     await expect(card.locator('div[class*=_footer_]')).toBeVisible();
-    await expect(card.locator('button[data-cy=card-action-0]')).toBeVisible();
+    await expect(card.locator('button[data-id=card-action-0]')).toBeVisible();
 
-    const action = card.locator('button[data-cy=card-action-1]');
+    const action = card.locator('button[data-id=card-action-1]');
     await action.click();
     await expect(card).toContainText('clicks: 1');
   });
 
   test('should display divided outline card with border styling', async ({ page }) => {
-    const card = page.locator('div[data-cy=card-0-1]').first();
+    const card = page.locator('div[data-id=card-0-1]').first();
 
     const classes = await card.getAttribute('class');
     expect(classes).toContain('_divide_');
@@ -32,7 +32,7 @@ test.describe('cards', () => {
   });
 
   test('should display outline card with image', async ({ page }) => {
-    const card = page.locator('div[data-cy=card-0-6]');
+    const card = page.locator('div[data-id=card-0-6]');
 
     await expect(card.locator('div[class*=_image_]')).toHaveCSS('overflow', /.+/);
     await expect(card.locator('div[class*=_footer_]')).toHaveCSS('border-color', /.+/);
@@ -40,7 +40,7 @@ test.describe('cards', () => {
   });
 
   test('should display elevated flat card with shadow', async ({ page }) => {
-    const card = page.locator('div[data-cy=card-1-4]').first();
+    const card = page.locator('div[data-id=card-1-4]').first();
 
     const classes = await card.getAttribute('class');
     expect(classes).toContain('shadow-1');

--- a/apps/example/e2e/chip.spec.ts
+++ b/apps/example/e2e/chip.spec.ts
@@ -6,43 +6,43 @@ test.describe('chips', () => {
   });
 
   test('should render chip with text', async ({ page }) => {
-    const chip = page.locator('[data-cy=chip-0]');
+    const chip = page.locator('[data-id=chip-0]');
     await expect(chip).toBeVisible();
     await expect(chip).toContainText('Chip');
   });
 
   test('should render closeable chip with close button', async ({ page }) => {
     // chip-0 is closeable (grey, filled)
-    const closeableChip = page.locator('[data-cy=chip-0]');
+    const closeableChip = page.locator('[data-id=chip-0]');
     await expect(closeableChip.locator('button')).toBeVisible();
 
     // chip-14 is non-closeable
-    const nonCloseableChip = page.locator('[data-cy=chip-14]');
+    const nonCloseableChip = page.locator('[data-id=chip-14]');
     await expect(nonCloseableChip.locator('button')).toHaveCount(0);
   });
 
   test('should render different color variants', async ({ page }) => {
     // First 7 chips are the 7 colors (grey, primary, secondary, error, warning, info, success)
     for (let i = 0; i < 7; i++) {
-      const chip = page.locator(`[data-cy=chip-${i}]`);
+      const chip = page.locator(`[data-id=chip-${i}]`);
       await expect(chip).toBeVisible();
     }
   });
 
   test('should render small size chips', async ({ page }) => {
     // chip-35 to chip-41 are closeable+sm (attribute[5], 7 colors)
-    const smChip = page.locator('[data-cy=chip-35]');
+    const smChip = page.locator('[data-id=chip-35]');
     await expect(smChip).toBeVisible();
     await expect(smChip.locator('button')).toBeVisible();
   });
 
   test('should handle chip dismiss actions', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=chips]')).toContainText('Chips');
+    await expect(page.locator('h2[data-id=chips]')).toContainText('Chips');
 
-    const content = page.locator('[data-cy=content]');
-    const dismissibleChip = content.locator('[data-cy=chip-0]');
-    const disabledChip = content.locator('[data-cy=chip-7]');
-    const inDismissibleChip = content.locator('[data-cy=chip-14]');
+    const content = page.locator('[data-id=content]');
+    const dismissibleChip = content.locator('[data-id=chip-0]');
+    const disabledChip = content.locator('[data-id=chip-7]');
+    const inDismissibleChip = content.locator('[data-id=chip-14]');
 
     await expect(dismissibleChip.locator('button')).not.toBeDisabled();
     await dismissibleChip.locator('button').click();

--- a/apps/example/e2e/color-picker.spec.ts
+++ b/apps/example/e2e/color-picker.spec.ts
@@ -6,29 +6,29 @@ test.describe('color pickers', () => {
   });
 
   test('should render color picker with initial values', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=color-pickers]')).toContainText('Color Pickers');
+    await expect(page.locator('h2[data-id=color-pickers]')).toContainText('Color Pickers');
 
-    const firstColorPicker = page.locator('div[data-cy=color-picker-0]');
+    const firstColorPicker = page.locator('div[data-id=color-picker-0]');
     await expect(firstColorPicker.locator('input')).toHaveValue(/000000/);
 
-    const secondColorPicker = page.locator('div[data-cy=color-picker-1]');
+    const secondColorPicker = page.locator('div[data-id=color-picker-1]');
     await expect(secondColorPicker.locator('input')).toHaveValue(/45858a/);
   });
 
   test('should update color when typing hex value', async ({ page }) => {
-    const picker = page.locator('div[data-cy=color-picker-0]');
+    const picker = page.locator('div[data-id=color-picker-0]');
     const input = picker.locator('input');
 
     await input.fill('ff0000');
     await input.blur();
 
     // Color display should reflect the new color
-    const display = picker.locator('[data-cy=color-display]');
+    const display = picker.locator('[data-id=color-display]');
     await expect(display).toHaveCSS('background-color', 'rgb(255, 0, 0)');
   });
 
   test('should switch between hex and RGB input modes', async ({ page }) => {
-    const picker = page.locator('div[data-cy=color-picker-1]');
+    const picker = page.locator('div[data-id=color-picker-1]');
 
     // Initially in hex mode - single input
     await expect(picker.locator('input')).toHaveCount(1);
@@ -47,7 +47,7 @@ test.describe('color pickers', () => {
   });
 
   test('should have aria-label on picker', async ({ page }) => {
-    const picker = page.locator('div[data-cy=color-picker-0]');
+    const picker = page.locator('div[data-id=color-picker-0]');
     await expect(picker).toHaveAttribute('role', 'application');
     await expect(picker).toHaveAttribute('aria-label', 'Color picker');
 

--- a/apps/example/e2e/data-table.spec.ts
+++ b/apps/example/e2e/data-table.spec.ts
@@ -6,7 +6,7 @@ test.describe('data tables - basic', () => {
   });
 
   test('should render table with column definitions', async ({ page }) => {
-    const table = page.locator('[data-cy=table-columns-defined] [data-cy=table]');
+    const table = page.locator('[data-id=table-columns-defined] [data-id=table]');
     await expect(table).toBeVisible();
 
     await expect(
@@ -19,7 +19,7 @@ test.describe('data tables - basic', () => {
   });
 
   test('should render table without column definitions (auto-generated)', async ({ page }) => {
-    const table = page.locator('[data-cy=table-auto-columns] [data-cy=table]');
+    const table = page.locator('[data-id=table-auto-columns] [data-id=table]');
     await expect(table).toBeVisible();
 
     await expect(
@@ -28,19 +28,19 @@ test.describe('data tables - basic', () => {
   });
 
   test('should render outlined table', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=table-outlined] [data-cy=table]');
+    const wrapper = page.locator('[data-id=table-outlined] [data-id=table]');
     await expect(wrapper).toBeVisible();
     await expect(wrapper).toHaveClass(/_outlined_/);
   });
 
   test('should render dense table', async ({ page }) => {
-    const table = page.locator('[data-cy=table-dense] [data-cy=table] table');
+    const table = page.locator('[data-id=table-dense] [data-id=table] table');
     await expect(table).toBeVisible();
     await expect(table).toHaveClass(/_dense_/);
   });
 
   test('should render striped table', async ({ page }) => {
-    const tbody = page.locator('[data-cy=table-striped] [data-cy=table] tbody');
+    const tbody = page.locator('[data-id=table-striped] [data-id=table] tbody');
     await expect(tbody).toBeVisible();
     await expect(tbody).toHaveClass(/_tbody--striped_/);
   });
@@ -52,7 +52,7 @@ test.describe('data tables - sorting', () => {
   });
 
   test('should sort by clicking column header', async ({ page }) => {
-    const table = page.locator('[data-cy=table-single-sort] [data-cy=table]');
+    const table = page.locator('[data-id=table-single-sort] [data-id=table]');
     await expect(table).toBeVisible();
 
     const sortButton = table.locator('thead th[data-id="column-sortable"] button').first();
@@ -71,7 +71,7 @@ test.describe('data tables - sorting', () => {
   });
 
   test('should toggle sort direction on repeated clicks', async ({ page }) => {
-    const table = page.locator('[data-cy=table-single-sort] [data-cy=table]');
+    const table = page.locator('[data-id=table-single-sort] [data-id=table]');
     await expect(table).toBeVisible();
 
     const sortButton = table.locator('thead th[data-id="column-sortable"] button').first();
@@ -95,7 +95,7 @@ test.describe('data tables - sorting', () => {
   });
 
   test('should support multi-column sort', async ({ page }) => {
-    const table = page.locator('[data-cy=table-multi-sort] [data-cy=table]');
+    const table = page.locator('[data-id=table-multi-sort] [data-id=table]');
     await expect(table).toBeVisible();
 
     const sortButtons = table.locator('thead th[data-id="column-sortable"] button');
@@ -116,16 +116,16 @@ test.describe('data tables - pagination', () => {
   });
 
   test('should navigate pages with buttons', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Get first row ID before navigation
     const firstCellBefore = table.locator('tbody tr:first-child td:first-child');
     const textBefore = await firstCellBefore.textContent();
 
-    // Click next page button using data-cy attribute
-    await container.locator('[data-cy=table-pagination-next]').first().click();
+    // Click next page button using data-id attribute
+    await container.locator('[data-id=table-pagination-next]').first().click();
 
     // First row should be different after page change
     const firstCellAfter = table.locator('tbody tr:first-child td:first-child');
@@ -135,36 +135,36 @@ test.describe('data tables - pagination', () => {
   });
 
   test('should navigate back with previous button', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     const firstCell = table.locator('tbody tr:first-child td:first-child');
     const initialText = await firstCell.textContent();
 
     // Go to next page
-    await container.locator('[data-cy=table-pagination-next]').first().click();
+    await container.locator('[data-id=table-pagination-next]').first().click();
 
     const page2Text = await firstCell.textContent();
     expect(page2Text).not.toEqual(initialText);
 
     // Go back to previous page
-    await container.locator('[data-cy=table-pagination-prev]').first().click();
+    await container.locator('[data-id=table-pagination-prev]').first().click();
 
     const backText = await firstCell.textContent();
     expect(backText).toEqual(initialText);
   });
 
   test('should change items per page', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Count initial rows
     const initialRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Open per-page dropdown and select different value
-    const perPageSelect = container.locator('[data-cy=table-pagination-limit] [data-id=activator]').first();
+    const perPageSelect = container.locator('[data-id=table-pagination-limit] [data-id=activator]').first();
     await perPageSelect.click();
 
     // Select a different limit (e.g., 10)
@@ -177,15 +177,15 @@ test.describe('data tables - pagination', () => {
   });
 
   test('should disable navigation buttons appropriately', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Use first() to target top pagination area
-    const firstBtn = container.locator('[data-cy=table-pagination-first]').first();
-    const prevBtn = container.locator('[data-cy=table-pagination-prev]').first();
-    const nextBtn = container.locator('[data-cy=table-pagination-next]').first();
-    const lastBtn = container.locator('[data-cy=table-pagination-last]').first();
+    const firstBtn = container.locator('[data-id=table-pagination-first]').first();
+    const prevBtn = container.locator('[data-id=table-pagination-prev]').first();
+    const nextBtn = container.locator('[data-id=table-pagination-next]').first();
+    const lastBtn = container.locator('[data-id=table-pagination-last]').first();
 
     // On first page: first and prev buttons should be disabled
     await expect(firstBtn).toBeDisabled();
@@ -206,28 +206,28 @@ test.describe('data tables - pagination', () => {
   });
 
   test('should update range display when navigating', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Check initial range shows "1 - 5"
-    const rangeDisplay = container.locator('[data-cy=table-pagination-ranges] [data-id=activator]').first();
+    const rangeDisplay = container.locator('[data-id=table-pagination-ranges] [data-id=activator]').first();
     await expect(rangeDisplay).toContainText('1 - 5');
 
     // Navigate to next page
-    await container.locator('[data-cy=table-pagination-next]').first().click();
+    await container.locator('[data-id=table-pagination-next]').first().click();
 
     // Range should update to "6 - 10"
     await expect(rangeDisplay).toContainText('6 - 10');
   });
 
   test('should hide header pagination when hideDefaultHeader is set', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-hide-header]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-hide-header]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Only one pagination should be visible (footer only)
-    const paginationElements = container.locator('[data-cy=table-pagination]');
+    const paginationElements = container.locator('[data-id=table-pagination]');
     await expect(paginationElements).toHaveCount(1);
 
     // The table element should exist (pagination is outside of it)
@@ -235,18 +235,18 @@ test.describe('data tables - pagination', () => {
   });
 
   test('should hide footer pagination when hideDefaultFooter is set', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-hide-footer]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-hide-footer]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Only one pagination should be visible (header only)
-    const paginationElements = container.locator('[data-cy=table-pagination]');
+    const paginationElements = container.locator('[data-id=table-pagination]');
     await expect(paginationElements).toHaveCount(1);
   });
 
   test('should have sticky header when stickyHeader is set', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-sticky]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-sticky]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // The table thead should have sticky class (library uses absolute/fixed positioning for sticky behavior)
@@ -255,8 +255,8 @@ test.describe('data tables - pagination', () => {
   });
 
   test('should produce consistent header widths after resize cycle', async ({ page }) => {
-    const container = page.locator('[data-cy=table-pagination-sticky]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-pagination-sticky]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     const mainCells = table.locator('table thead[data-id="head-main"] > tr > th');
@@ -295,9 +295,9 @@ test.describe('data tables - search', () => {
   });
 
   test('should filter rows by search input', async ({ page }) => {
-    const container = page.locator('[data-cy=table-search-basic]');
-    const table = container.locator('[data-cy=table]');
-    const searchInput = container.locator('[data-cy=search-input] input');
+    const container = page.locator('[data-id=table-search-basic]');
+    const table = container.locator('[data-id=table]');
+    const searchInput = container.locator('[data-id=search-input] input');
 
     await expect(table).toBeVisible();
     await expect(searchInput).toBeVisible();
@@ -317,9 +317,9 @@ test.describe('data tables - search', () => {
   });
 
   test('should clear search and restore rows', async ({ page }) => {
-    const container = page.locator('[data-cy=table-search-basic]');
-    const table = container.locator('[data-cy=table]');
-    const searchInput = container.locator('[data-cy=search-input] input');
+    const container = page.locator('[data-id=table-search-basic]');
+    const table = container.locator('[data-id=table]');
+    const searchInput = container.locator('[data-id=search-input] input');
 
     await expect(table).toBeVisible();
 
@@ -343,9 +343,9 @@ test.describe('data tables - search', () => {
   });
 
   test('should be case insensitive', async ({ page }) => {
-    const container = page.locator('[data-cy=table-search-basic]');
-    const table = container.locator('[data-cy=table]');
-    const searchInput = container.locator('[data-cy=search-input] input');
+    const container = page.locator('[data-id=table-search-basic]');
+    const table = container.locator('[data-id=table]');
+    const searchInput = container.locator('[data-id=search-input] input');
 
     await expect(table).toBeVisible();
 
@@ -367,9 +367,9 @@ test.describe('data tables - search', () => {
   });
 
   test('should show empty state when no matches', async ({ page }) => {
-    const container = page.locator('[data-cy=table-search-basic]');
-    const table = container.locator('[data-cy=table]');
-    const searchInput = container.locator('[data-cy=search-input] input');
+    const container = page.locator('[data-id=table-search-basic]');
+    const table = container.locator('[data-id=table]');
+    const searchInput = container.locator('[data-id=search-input] input');
 
     await expect(table).toBeVisible();
 
@@ -384,17 +384,17 @@ test.describe('data tables - search', () => {
   });
 
   test('should reset pagination when searching', async ({ page }) => {
-    const container = page.locator('[data-cy=table-search-pagination]');
-    const table = container.locator('[data-cy=table]');
-    const searchInput = container.locator('[data-cy=search-input] input');
+    const container = page.locator('[data-id=table-search-pagination]');
+    const table = container.locator('[data-id=table]');
+    const searchInput = container.locator('[data-id=search-input] input');
 
     await expect(table).toBeVisible();
 
     // Navigate to page 2
-    await container.locator('[data-cy=table-pagination-next]').first().click();
+    await container.locator('[data-id=table-pagination-next]').first().click();
 
     // Verify we're on page 2 by checking the range display
-    const rangeDisplay = container.locator('[data-cy=table-pagination-ranges] [data-id=activator]').first();
+    const rangeDisplay = container.locator('[data-id=table-pagination-ranges] [data-id=activator]').first();
     await expect(rangeDisplay).toContainText('6 - 10');
 
     // Now search
@@ -412,12 +412,12 @@ test.describe('data tables - selection', () => {
   });
 
   test('should select individual rows', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Click first row checkbox
-    const firstRowCheckbox = table.locator('tbody tr:first-child [data-cy*=table-toggle-check-] input');
+    const firstRowCheckbox = table.locator('tbody tr:first-child [data-id*=table-toggle-check-] input');
     await firstRowCheckbox.check();
 
     // First row should be selected (using aria-selected)
@@ -426,11 +426,11 @@ test.describe('data tables - selection', () => {
   });
 
   test('should deselect rows by clicking again', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
-    const firstRowCheckbox = table.locator('tbody tr:first-child [data-cy*=table-toggle-check-] input');
+    const firstRowCheckbox = table.locator('tbody tr:first-child [data-id*=table-toggle-check-] input');
     const firstRow = table.locator('tbody tr:first-child');
 
     // Select
@@ -443,12 +443,12 @@ test.describe('data tables - selection', () => {
   });
 
   test('should select all rows with header checkbox', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Click select all checkbox
-    const selectAllCheckbox = table.locator('thead [data-cy=table-toggle-check-all] input');
+    const selectAllCheckbox = table.locator('thead [data-id=table-toggle-check-all] input');
     await selectAllCheckbox.check();
 
     // All rows should be selected (using aria-selected)
@@ -462,11 +462,11 @@ test.describe('data tables - selection', () => {
   });
 
   test('should deselect all rows with header checkbox', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
-    const selectAllCheckbox = table.locator('thead [data-cy=table-toggle-check-all] input');
+    const selectAllCheckbox = table.locator('thead [data-id=table-toggle-check-all] input');
 
     // Select all
     await selectAllCheckbox.check();
@@ -480,12 +480,12 @@ test.describe('data tables - selection', () => {
   });
 
   test('should persist selection across pages with multi-page select', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-multi-page]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-multi-page]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Select first row on page 1
-    const firstRowCheckbox = table.locator('tbody tr:first-child [data-cy*=table-toggle-check-] input');
+    const firstRowCheckbox = table.locator('tbody tr:first-child [data-id*=table-toggle-check-] input');
     await firstRowCheckbox.check();
 
     // Verify first row is selected (using aria-selected)
@@ -493,40 +493,40 @@ test.describe('data tables - selection', () => {
     await expect(firstRow).toHaveAttribute('aria-selected', 'true');
 
     // Navigate to next page
-    await container.locator('[data-cy=table-pagination-next]').first().click();
+    await container.locator('[data-id=table-pagination-next]').first().click();
 
     // Select first row on page 2
     await firstRowCheckbox.check();
     await expect(firstRow).toHaveAttribute('aria-selected', 'true');
 
     // Navigate back to page 1
-    await container.locator('[data-cy=table-pagination-prev]').first().click();
+    await container.locator('[data-id=table-pagination-prev]').first().click();
 
     // Selection from page 1 should still be there
     await expect(firstRow).toHaveAttribute('aria-selected', 'true');
   });
 
   test('should not allow selection of disabled rows', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-disabled]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-disabled]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // First row checkbox should be disabled
-    const firstRowCheckbox = table.locator('tbody tr:first-child [data-cy*=table-toggle-check-] input');
+    const firstRowCheckbox = table.locator('tbody tr:first-child [data-id*=table-toggle-check-] input');
     await expect(firstRowCheckbox).toBeDisabled();
   });
 
   test('should skip disabled rows when selecting all', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-disabled]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-disabled]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Click the select all checkbox (use click instead of check to handle indeterminate state)
-    const selectAllCheckbox = table.locator('thead [data-cy=table-toggle-check-all]');
+    const selectAllCheckbox = table.locator('thead [data-id=table-toggle-check-all]');
     await selectAllCheckbox.click();
 
     // Count disabled checkboxes
-    const disabledCheckboxes = await table.locator('tbody tr [data-cy*=table-toggle-check-] input:disabled').count();
+    const disabledCheckboxes = await table.locator('tbody tr [data-id*=table-toggle-check-] input:disabled').count();
     expect(disabledCheckboxes).toEqual(3); // First 3 rows are disabled
 
     // Count selected rows (using aria-selected)
@@ -540,12 +540,12 @@ test.describe('data tables - selection', () => {
   });
 
   test('should toggle selection with keyboard (Space)', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Focus the first row checkbox
-    const firstRowCheckbox = table.locator('tbody tr:first-child [data-cy*=table-toggle-check-] input');
+    const firstRowCheckbox = table.locator('tbody tr:first-child [data-id*=table-toggle-check-] input');
     await firstRowCheckbox.focus();
 
     // Verify not selected initially
@@ -562,12 +562,12 @@ test.describe('data tables - selection', () => {
   });
 
   test('should allow keyboard focus on checkboxes', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Focus the first row checkbox directly and verify it's focusable
-    const firstRowCheckbox = table.locator('tbody tr:first-child [data-cy*=table-toggle-check-] input');
+    const firstRowCheckbox = table.locator('tbody tr:first-child [data-id*=table-toggle-check-] input');
     await firstRowCheckbox.focus();
     await expect(firstRowCheckbox).toBeFocused();
 
@@ -578,8 +578,8 @@ test.describe('data tables - selection', () => {
   });
 
   test('should render custom slot content in action column', async ({ page }) => {
-    const container = page.locator('[data-cy=table-selection-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-selection-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Verify the action column has the custom button with icon
@@ -598,8 +598,8 @@ test.describe('data tables - expandable', () => {
   });
 
   test('should expand multiple rows', async ({ page }) => {
-    const container = page.locator('[data-cy=table-expandable-multiple]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-expandable-multiple]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     const expandButtons = table.locator('tbody tr button[aria-expanded]');
@@ -607,23 +607,23 @@ test.describe('data tables - expandable', () => {
     const button2 = expandButtons.nth(1);
 
     // Initially no expanded content
-    await expect(table.locator('[data-cy=expanded-content]')).toHaveCount(0);
+    await expect(table.locator('[data-id=expanded-content]')).toHaveCount(0);
     await expect(button1).toHaveAttribute('aria-expanded', 'false');
 
     // Expand first row
     await button1.click();
     await expect(button1).toHaveAttribute('aria-expanded', 'true');
-    await expect(table.locator('[data-cy=expanded-content]')).toHaveCount(1);
+    await expect(table.locator('[data-id=expanded-content]')).toHaveCount(1);
 
     // Expand second row - both should be expanded
     await button2.click();
     await expect(button2).toHaveAttribute('aria-expanded', 'true');
-    await expect(table.locator('[data-cy=expanded-content]')).toHaveCount(2);
+    await expect(table.locator('[data-id=expanded-content]')).toHaveCount(2);
   });
 
   test('should expand only single row with singleExpand', async ({ page }) => {
-    const container = page.locator('[data-cy=table-expandable-single]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-expandable-single]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     const expandButtons = table.locator('tbody tr button[aria-expanded]');
@@ -638,7 +638,7 @@ test.describe('data tables - expandable', () => {
     await button2.click();
     await expect(button1).toHaveAttribute('aria-expanded', 'false');
     await expect(button2).toHaveAttribute('aria-expanded', 'true');
-    await expect(table.locator('[data-cy=expanded-content]')).toHaveCount(1);
+    await expect(table.locator('[data-id=expanded-content]')).toHaveCount(1);
   });
 });
 
@@ -648,8 +648,8 @@ test.describe('data tables - grouping', () => {
   });
 
   test('should render grouped rows', async ({ page }) => {
-    const container = page.locator('[data-cy=table-grouping-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-grouping-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Should have group header rows
@@ -658,8 +658,8 @@ test.describe('data tables - grouping', () => {
   });
 
   test('should collapse and expand groups', async ({ page }) => {
-    const container = page.locator('[data-cy=table-grouping-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-grouping-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     const groupExpandButton = table.locator('tr[data-id="row-group"] button[aria-expanded]').first();
@@ -681,26 +681,26 @@ test.describe('data tables - grouping', () => {
   });
 
   test('should emit copy event when clicking copy button in group header', async ({ page }) => {
-    const container = page.locator('[data-cy=table-grouping-basic]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-grouping-basic]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Initially no copied group message
-    await expect(container.locator('[data-cy=last-copied-group]')).toHaveCount(0);
+    await expect(container.locator('[data-id=last-copied-group]')).toHaveCount(0);
 
     // Click the copy button in the first group header
-    const copyButton = table.locator('[data-cy=group-copy-button]').first();
+    const copyButton = table.locator('[data-id=group-copy-button]').first();
     await copyButton.click();
 
     // Should show the copied group message
-    const copiedMessage = container.locator('[data-cy=last-copied-group]');
+    const copiedMessage = container.locator('[data-id=last-copied-group]');
     await expect(copiedMessage).toBeVisible();
     await expect(copiedMessage).toContainText('username:');
   });
 
   test('should render expand button at end when groupExpandButtonPosition is end', async ({ page }) => {
-    const container = page.locator('[data-cy=table-grouping-expand-end]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-grouping-expand-end]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Get the first group header row
@@ -724,8 +724,8 @@ test.describe('data tables - empty states', () => {
   });
 
   test('should render empty table with label and description', async ({ page }) => {
-    const container = page.locator('[data-cy=table-empty]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-empty]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     await expect(table.locator('tbody tr[data-id="row-empty"] p[data-id="empty-label"]')).toBeVisible();
@@ -733,8 +733,8 @@ test.describe('data tables - empty states', () => {
   });
 
   test('should render empty table with action slot', async ({ page }) => {
-    const container = page.locator('[data-cy=table-empty-action]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-empty-action]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     await expect(table.locator('tbody tr[data-id="row-empty"] p[data-id="empty-label"]')).toBeVisible();
@@ -742,8 +742,8 @@ test.describe('data tables - empty states', () => {
   });
 
   test('should render loading state without data', async ({ page }) => {
-    const container = page.locator('[data-cy=table-loading-empty]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-loading-empty]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Table should have aria-busy attribute when loading
@@ -752,8 +752,8 @@ test.describe('data tables - empty states', () => {
   });
 
   test('should render loading state with data', async ({ page }) => {
-    const container = page.locator('[data-cy=table-loading-data]');
-    const table = container.locator('[data-cy=table]');
+    const container = page.locator('[data-id=table-loading-data]');
+    const table = container.locator('[data-id=table]');
     await expect(table).toBeVisible();
 
     // Table should have aria-busy attribute when loading
@@ -772,25 +772,25 @@ test.describe('data tables - index', () => {
   test('should render index page with navigation links', async ({ page }) => {
     await page.goto('/data-tables');
 
-    await expect(page.locator('[data-cy=data-tables-index]')).toBeVisible();
-    await expect(page.locator('h2[data-cy=datatables]')).toContainText('Data Tables');
+    await expect(page.locator('[data-id=data-tables-index]')).toBeVisible();
+    await expect(page.locator('h2[data-id=datatables]')).toContainText('Data Tables');
 
     // Check navigation links exist (routes are now path-based)
-    await expect(page.locator('[data-cy="link-/data-tables/basic"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/sorting"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/pagination"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/search"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/selection"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/expandable"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/grouping"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/data-tables/empty"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/basic"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/sorting"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/pagination"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/search"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/selection"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/expandable"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/grouping"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/empty"]')).toBeVisible();
   });
 
   test('should navigate to sub-pages', async ({ page }) => {
     await page.goto('/data-tables');
 
-    await page.locator('[data-cy="link-/data-tables/basic"]').click();
+    await page.locator('[data-id="link-/data-tables/basic"]').click();
     await expect(page).toHaveURL(/\/data-tables\/basic/);
-    await expect(page.locator('[data-cy=data-tables-basic]')).toBeVisible();
+    await expect(page.locator('[data-id=data-tables-basic]')).toBeVisible();
   });
 });

--- a/apps/example/e2e/divider.spec.ts
+++ b/apps/example/e2e/divider.spec.ts
@@ -6,7 +6,7 @@ test.describe('Divider', () => {
   });
 
   test('should render horizontal divider by default', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=divider-horizontal]');
+    const wrapper = page.locator('[data-id=divider-horizontal]');
     const divider = wrapper.locator('[role=separator]');
 
     await expect(divider).toBeVisible();
@@ -14,7 +14,7 @@ test.describe('Divider', () => {
   });
 
   test('should render vertical divider', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=divider-vertical]');
+    const wrapper = page.locator('[data-id=divider-vertical]');
     const divider = wrapper.locator('[role=separator]');
 
     await expect(divider).toBeVisible();

--- a/apps/example/e2e/footer-stepper.spec.ts
+++ b/apps/example/e2e/footer-stepper.spec.ts
@@ -4,11 +4,11 @@ test.describe('footer steppers', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/steppers');
     // Wait for footer steppers section to be visible
-    await expect(page.locator('h2[data-cy=footer-steppers]')).toBeVisible();
+    await expect(page.locator('h2[data-id=footer-steppers]')).toBeVisible();
   });
 
   test('should render footer stepper variants', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=footer-steppers]')).toContainText('Footer Steppers');
+    await expect(page.locator('h2[data-id=footer-steppers]')).toContainText('Footer Steppers');
 
     // Footer steppers are rendered after the h2 element, select from page directly
     // The class names are CSS module scoped: _footer-stepper_xxx _numeric_xxx
@@ -42,7 +42,7 @@ test.describe('footer steppers', () => {
   });
 
   test('should navigate forward and backward with buttons', async ({ page }) => {
-    const stepper = page.locator('[data-cy=footer-stepper-0]');
+    const stepper = page.locator('[data-id=footer-stepper-0]');
     await expect(stepper.locator('span[class*=_numeric_]')).toContainText('1/5');
 
     // Back should be disabled on first page
@@ -62,20 +62,20 @@ test.describe('footer steppers', () => {
   });
 
   test('should have role="navigation" and aria-label on root', async ({ page }) => {
-    const stepper = page.locator('[data-cy=footer-stepper-0]');
+    const stepper = page.locator('[data-id=footer-stepper-0]');
     await expect(stepper).toHaveAttribute('role', 'navigation');
     await expect(stepper).toHaveAttribute('aria-label', 'Step navigation');
   });
 
   test('should have aria-label on navigation buttons', async ({ page }) => {
-    const stepper = page.locator('[data-cy=footer-stepper-0]');
+    const stepper = page.locator('[data-id=footer-stepper-0]');
     await expect(stepper.locator('button[aria-label=Previous]')).toBeVisible();
     await expect(stepper.locator('button[aria-label=Next]')).toBeVisible();
   });
 
   test('should have aria-current="step" on active bullet', async ({ page }) => {
     // Footer stepper at index 1 is bullet variant with value=2
-    const stepper = page.locator('[data-cy=footer-stepper-1]');
+    const stepper = page.locator('[data-id=footer-stepper-1]');
     const activeBullet = stepper.locator('[aria-current=step]');
     await expect(activeBullet).toHaveCount(1);
 
@@ -87,7 +87,7 @@ test.describe('footer steppers', () => {
 
   test('should hide buttons when hideButtons is true', async ({ page }) => {
     // Footer stepper at index 2 has hideButtons=true
-    const stepper = page.locator('[data-cy=footer-stepper-2]');
+    const stepper = page.locator('[data-id=footer-stepper-2]');
     await expect(stepper.locator('button')).toHaveCount(0);
   });
 });

--- a/apps/example/e2e/forms/autocomplete.spec.ts
+++ b/apps/example/e2e/forms/autocomplete.spec.ts
@@ -6,19 +6,19 @@ test.describe('auto-complete - index', () => {
   });
 
   test('should render navigation links', async ({ page }) => {
-    await expect(page.locator('[data-cy=auto-completes-index]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/basic"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/selection"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/search"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/readonly"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/custom"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/keyboard"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/auto-completes/advanced"]')).toBeVisible();
+    await expect(page.locator('[data-id=auto-completes-index]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/basic"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/selection"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/search"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/readonly"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/custom"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/keyboard"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/auto-completes/advanced"]')).toBeVisible();
   });
 
   test('should navigate to sub-routes', async ({ page }) => {
-    await page.locator('[data-cy="link-/auto-completes/basic"]').click();
-    await expect(page.locator('[data-cy=auto-completes-basic]')).toBeVisible();
+    await page.locator('[data-id="link-/auto-completes/basic"]').click();
+    await expect(page.locator('[data-id=auto-completes-basic]')).toBeVisible();
   });
 });
 
@@ -32,26 +32,26 @@ test.describe('auto-complete - basic', () => {
   });
 
   test('should render default variant with pre-selected value', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-default]');
+    const ac = page.locator('[data-id=ac-basic-default]');
     await expect(ac).toBeVisible();
     await expect(ac.locator('input')).toHaveValue('Germany');
   });
 
   test('should render outlined variant', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-outlined]');
+    const ac = page.locator('[data-id=ac-basic-outlined]');
     await expect(ac).toBeVisible();
     await expect(ac.locator('fieldset')).toBeVisible();
     await expect(ac.locator('input')).toHaveValue('Germany');
   });
 
   test('should render dense variant', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-dense]');
+    const ac = page.locator('[data-id=ac-basic-dense]');
     await expect(ac).toBeVisible();
     await expect(ac.locator('input')).toHaveValue('Germany');
   });
 
   test('should not open menu when disabled', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-disabled]');
+    const ac = page.locator('[data-id=ac-basic-disabled]');
     const activator = ac.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-disabled', 'true');
     await activator.click({ force: true });
@@ -59,37 +59,37 @@ test.describe('auto-complete - basic', () => {
   });
 
   test('should show loading indicator', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-loading]');
+    const ac = page.locator('[data-id=ac-basic-loading]');
     const activator = ac.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-busy', 'true');
   });
 
   test('should display error messages', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-error]');
+    const ac = page.locator('[data-id=ac-basic-error]');
     await expect(ac).toContainText('This field is required');
     await expect(ac.locator('input')).toHaveAttribute('aria-invalid', 'true');
   });
 
   test('should display success messages', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-success]');
+    const ac = page.locator('[data-id=ac-basic-success]');
     await expect(ac).toContainText('Looks good!');
   });
 
   test('should hide details when hideDetails is set', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-hide-details]');
+    const ac = page.locator('[data-id=ac-basic-hide-details]');
     await expect(ac).toBeVisible();
     await expect(ac).not.toContainText('This field is required');
   });
 
   test('should show required indicator', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-required]');
+    const ac = page.locator('[data-id=ac-basic-required]');
     const activator = ac.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-required', 'true');
     await expect(activator).toContainText('\uFE61');
   });
 
   test('should display hint text', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-basic-hint]');
+    const ac = page.locator('[data-id=ac-basic-hint]');
     await expect(ac).toBeVisible();
     await expect(ac).toContainText('Select your country');
   });
@@ -105,7 +105,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should open menu and select single value', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-single]');
+    const ac = page.locator('[data-id=ac-select-single]');
     const activator = ac.locator('[data-id=activator]');
 
     await expect(activator).toHaveAttribute('aria-expanded', 'false');
@@ -119,7 +119,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should clear value with clear button', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-single-preselected]');
+    const ac = page.locator('[data-id=ac-select-single-preselected]');
     await expect(ac.locator('input')).toHaveValue('Lorem');
 
     const activator = ac.locator('[data-id=activator]');
@@ -129,7 +129,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should select multiple values as chips', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-multi]');
+    const ac = page.locator('[data-id=ac-select-multi]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -145,7 +145,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should remove chip by clicking close', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-multi-preselected]');
+    const ac = page.locator('[data-id=ac-select-multi-preselected]');
     const chips = ac.locator('[data-id=activator] [data-value]');
     await expect(chips).toHaveCount(2);
 
@@ -155,7 +155,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should auto-select first option on open', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-auto-first]');
+    const ac = page.locator('[data-id=ac-select-auto-first]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -166,7 +166,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should hide selected items from dropdown', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-hide-selected]');
+    const ac = page.locator('[data-id=ac-select-hide-selected]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -182,7 +182,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should navigate options with keyboard', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-single]');
+    const ac = page.locator('[data-id=ac-select-single]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -200,7 +200,7 @@ test.describe('auto-complete - selection', () => {
   });
 
   test('should select with Tab in single mode', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-select-single]');
+    const ac = page.locator('[data-id=ac-select-single]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -224,7 +224,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should filter options by typing', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-filter]');
+    const ac = page.locator('[data-id=ac-search-filter]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -241,7 +241,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should not filter when noFilter is set', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-no-filter]');
+    const ac = page.locator('[data-id=ac-search-no-filter]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -256,7 +256,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should allow custom value entry', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-custom-value]');
+    const ac = page.locator('[data-id=ac-search-custom-value]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -267,7 +267,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should hide custom value option from menu', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-custom-hide]');
+    const ac = page.locator('[data-id=ac-search-custom-hide]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -279,7 +279,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should show no-data message when no matches', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-no-data]');
+    const ac = page.locator('[data-id=ac-search-no-data]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -290,7 +290,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should hide no-data when hideNoData is set', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-hide-no-data]');
+    const ac = page.locator('[data-id=ac-search-hide-no-data]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -300,7 +300,7 @@ test.describe('auto-complete - search', () => {
   });
 
   test('should show placeholder only when focused', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-search-placeholder]');
+    const ac = page.locator('[data-id=ac-search-placeholder]');
     const input = ac.locator('input');
 
     // Before focus, placeholder should be empty
@@ -322,7 +322,7 @@ test.describe('auto-complete - readonly', () => {
   });
 
   test('should not open menu when read-only', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-readonly-default]');
+    const ac = page.locator('[data-id=ac-readonly-default]');
     const activator = ac.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-readonly', 'true');
     await activator.click({ force: true });
@@ -330,12 +330,12 @@ test.describe('auto-complete - readonly', () => {
   });
 
   test('should display pre-selected value', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-readonly-default]');
+    const ac = page.locator('[data-id=ac-readonly-default]');
     await expect(ac.locator('input')).toHaveValue('Lorem');
   });
 
   test('should display read-only chips', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-readonly-multi]');
+    const ac = page.locator('[data-id=ac-readonly-multi]');
     const chips = ac.locator('[data-id=activator] [data-value]');
     await expect(chips).toHaveCount(2);
   });
@@ -351,8 +351,8 @@ test.describe('auto-complete - custom slots', () => {
   });
 
   test('should open menu via custom activator button', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-custom-activator]');
-    const button = ac.locator('[data-cy=activator]');
+    const ac = page.locator('[data-id=ac-custom-activator]');
+    const button = ac.locator('[data-id=activator]');
 
     await expect(button).toBeVisible();
     await expect(button).toContainText('Choose Option');
@@ -362,7 +362,7 @@ test.describe('auto-complete - custom slots', () => {
   });
 
   test('should render custom item append content', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-custom-item]');
+    const ac = page.locator('[data-id=ac-custom-item]');
     const activator = ac.locator('[data-id=activator]');
 
     await activator.click();
@@ -390,7 +390,7 @@ test.describe('auto-complete - keyboard', () => {
   });
 
   test('should remove last value with Backspace in non-chips multi mode', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-kb-multi-no-chips]');
+    const ac = page.locator('[data-id=ac-kb-multi-no-chips]');
     const activator = ac.locator('[data-id=activator]');
 
     // Verify initial state: 3 items selected (Lorem, Ipsum, Dolor)
@@ -409,7 +409,7 @@ test.describe('auto-complete - keyboard', () => {
   });
 
   test('should focus chip on first Backspace, then delete on second', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-kb-multi-chips]');
+    const ac = page.locator('[data-id=ac-kb-multi-chips]');
     const activator = ac.locator('[data-id=activator]');
     const chips = activator.locator('[data-value]');
 
@@ -430,7 +430,7 @@ test.describe('auto-complete - keyboard', () => {
   });
 
   test('should navigate between chips with arrow keys', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-kb-chip-nav]');
+    const ac = page.locator('[data-id=ac-kb-chip-nav]');
     const activator = ac.locator('[data-id=activator]');
     const chips = activator.locator('[data-value]');
 
@@ -454,7 +454,7 @@ test.describe('auto-complete - keyboard', () => {
   });
 
   test('should close menu with Escape', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-kb-escape]');
+    const ac = page.locator('[data-id=ac-kb-escape]');
     const activator = ac.locator('[data-id=activator]');
 
     // Open the menu
@@ -467,8 +467,8 @@ test.describe('auto-complete - keyboard', () => {
   });
 
   test('should submit form on Enter when menu is closed and value is set', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-kb-form-submit]');
-    const form = page.locator('[data-cy=ac-kb-form]');
+    const ac = page.locator('[data-id=ac-kb-form-submit]');
+    const form = page.locator('[data-id=ac-kb-form]');
 
     // Value is preselected ('Lorem'), verify it
     await expect(ac.locator('input')).toHaveValue('Lorem');
@@ -483,11 +483,11 @@ test.describe('auto-complete - keyboard', () => {
 
     // Press Enter - should submit the form
     await ac.locator('input').press('Enter');
-    await expect(form.locator('[data-cy=form-submitted]')).toBeVisible();
+    await expect(form.locator('[data-id=form-submitted]')).toBeVisible();
   });
 
   test('should highlight selected item when re-opening menu', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-kb-reopen]');
+    const ac = page.locator('[data-id=ac-kb-reopen]');
     const activator = ac.locator('[data-id=activator]');
 
     // Open and select an item
@@ -523,7 +523,7 @@ test.describe('auto-complete - advanced', () => {
   });
 
   test('should work with return-object mode', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-return-object]');
+    const ac = page.locator('[data-id=ac-adv-return-object]');
     const activator = ac.locator('[data-id=activator]');
 
     // Open and select an item
@@ -536,12 +536,12 @@ test.describe('auto-complete - advanced', () => {
   });
 
   test('should display pre-selected return-object value', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-return-object-pre]');
+    const ac = page.locator('[data-id=ac-adv-return-object-pre]');
     await expect(ac.locator('input')).toHaveValue('Germany');
   });
 
   test('should render filled variant', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-filled]');
+    const ac = page.locator('[data-id=ac-adv-filled]');
     await expect(ac).toBeVisible();
 
     // Filled variant should be functional - open and select
@@ -554,8 +554,8 @@ test.describe('auto-complete - advanced', () => {
   });
 
   test('should handle falsy modelValue like 0 correctly', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-falsy]');
-    const display = page.locator('[data-cy=ac-adv-falsy-display]');
+    const ac = page.locator('[data-id=ac-adv-falsy]');
+    const display = page.locator('[data-id=ac-adv-falsy-display]');
 
     // Value is preselected as 0, should display "Zero"
     await expect(ac.locator('input')).toHaveValue('Zero');
@@ -580,8 +580,8 @@ test.describe('auto-complete - advanced', () => {
   });
 
   test('should sync search input model', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-search-input]');
-    const display = page.locator('[data-cy=ac-adv-search-display]');
+    const ac = page.locator('[data-id=ac-adv-search-input]');
+    const display = page.locator('[data-id=ac-adv-search-display]');
 
     // Initially search should be empty
     await expect(display).toContainText('Search: ""');
@@ -597,7 +597,7 @@ test.describe('auto-complete - advanced', () => {
   });
 
   test('should clear all values in multi-select with clear button', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-multi-clear]');
+    const ac = page.locator('[data-id=ac-adv-multi-clear]');
     const activator = ac.locator('[data-id=activator]');
     const chips = activator.locator('[data-value]');
 
@@ -613,14 +613,14 @@ test.describe('auto-complete - advanced', () => {
   });
 
   test('should set custom value on blur', async ({ page }) => {
-    const ac = page.locator('[data-cy=ac-adv-custom-blur]');
+    const ac = page.locator('[data-id=ac-adv-custom-blur]');
 
     // Focus and type a custom value
     await ac.locator('[data-id=activator]').click();
     await ac.locator('input').fill('MyCustomBlur');
 
     // Click somewhere else to blur
-    await page.locator('[data-cy=auto-completes-advanced] h2').click();
+    await page.locator('[data-id=auto-completes-advanced] h2').click();
 
     // The custom value should be set
     await expect(ac.locator('input')).toHaveValue('MyCustomBlur');

--- a/apps/example/e2e/forms/checkbox.spec.ts
+++ b/apps/example/e2e/forms/checkbox.spec.ts
@@ -6,7 +6,7 @@ test.describe('forms/Checkbox', () => {
   });
 
   test('checks for checkboxes', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=checkboxes]')).toContainText('Checkboxes');
+    await expect(page.locator('h2[data-id=checkboxes]')).toContainText('Checkboxes');
 
     const firstCheckbox = page.locator('input[type="checkbox"]').first();
     const secondCheckbox = page.locator('input[type="checkbox"]').nth(1);

--- a/apps/example/e2e/forms/menu-select.spec.ts
+++ b/apps/example/e2e/forms/menu-select.spec.ts
@@ -6,16 +6,16 @@ test.describe('menu-select - index', () => {
   });
 
   test('should render navigation links', async ({ page }) => {
-    await expect(page.locator('[data-cy=menu-selects-index]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/menu-selects/basic"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/menu-selects/selection"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/menu-selects/readonly"]')).toBeVisible();
-    await expect(page.locator('[data-cy="link-/menu-selects/custom"]')).toBeVisible();
+    await expect(page.locator('[data-id=menu-selects-index]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/menu-selects/basic"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/menu-selects/selection"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/menu-selects/readonly"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/menu-selects/custom"]')).toBeVisible();
   });
 
   test('should navigate to sub-routes', async ({ page }) => {
-    await page.locator('[data-cy="link-/menu-selects/basic"]').click();
-    await expect(page.locator('[data-cy=menu-selects-basic]')).toBeVisible();
+    await page.locator('[data-id="link-/menu-selects/basic"]').click();
+    await expect(page.locator('[data-id=menu-selects-basic]')).toBeVisible();
   });
 });
 
@@ -29,26 +29,26 @@ test.describe('menu-select - basic', () => {
   });
 
   test('should render default variant with pre-selected value', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-default]');
+    const ms = page.locator('[data-id=ms-basic-default]');
     await expect(ms).toBeVisible();
     await expect(ms.locator('[data-id=activator]')).toContainText('Germany');
   });
 
   test('should render outlined variant', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-outlined]');
+    const ms = page.locator('[data-id=ms-basic-outlined]');
     await expect(ms).toBeVisible();
     await expect(ms.locator('fieldset')).toBeVisible();
     await expect(ms.locator('[data-id=activator]')).toContainText('Germany');
   });
 
   test('should render dense variant', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-dense]');
+    const ms = page.locator('[data-id=ms-basic-dense]');
     await expect(ms).toBeVisible();
     await expect(ms.locator('[data-id=activator]')).toContainText('Germany');
   });
 
   test('should not open menu when disabled', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-disabled]');
+    const ms = page.locator('[data-id=ms-basic-disabled]');
     const activator = ms.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-disabled', 'true');
     await activator.click({ force: true });
@@ -56,37 +56,37 @@ test.describe('menu-select - basic', () => {
   });
 
   test('should show loading indicator', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-loading]');
+    const ms = page.locator('[data-id=ms-basic-loading]');
     const activator = ms.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-busy', 'true');
   });
 
   test('should display error messages', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-error]');
+    const ms = page.locator('[data-id=ms-basic-error]');
     await expect(ms).toContainText('This field is required');
     await expect(ms.locator('[data-id=activator]')).toHaveAttribute('aria-invalid', 'true');
   });
 
   test('should display success messages', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-success]');
+    const ms = page.locator('[data-id=ms-basic-success]');
     await expect(ms).toContainText('Looks good!');
   });
 
   test('should hide details when hideDetails is set', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-hide-details]');
+    const ms = page.locator('[data-id=ms-basic-hide-details]');
     await expect(ms).toBeVisible();
     await expect(ms).not.toContainText('This field is required');
   });
 
   test('should show required indicator', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-required]');
+    const ms = page.locator('[data-id=ms-basic-required]');
     const activator = ms.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-required', 'true');
     await expect(activator).toContainText('\uFE61');
   });
 
   test('should display hint text', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-basic-hint]');
+    const ms = page.locator('[data-id=ms-basic-hint]');
     await expect(ms).toBeVisible();
     await expect(ms).toContainText('Pick a country');
   });
@@ -102,7 +102,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should open menu and select value', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-single]');
+    const ms = page.locator('[data-id=ms-select-single]');
     const activator = ms.locator('[data-id=activator]');
 
     await expect(activator).toHaveAttribute('aria-expanded', 'false');
@@ -116,7 +116,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should clear value with clear button', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-preselected]');
+    const ms = page.locator('[data-id=ms-select-preselected]');
     const activator = ms.locator('[data-id=activator]');
     await expect(activator).toContainText('Lorem');
 
@@ -126,7 +126,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should auto-select first option on open', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-auto-first]');
+    const ms = page.locator('[data-id=ms-select-auto-first]');
     const activator = ms.locator('[data-id=activator]');
 
     await activator.click();
@@ -137,7 +137,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should navigate options with keyboard', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-auto-first]');
+    const ms = page.locator('[data-id=ms-select-auto-first]');
     const activator = ms.locator('[data-id=activator]');
 
     await activator.click();
@@ -163,7 +163,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should show no-data message when options empty', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-no-data]');
+    const ms = page.locator('[data-id=ms-select-no-data]');
     const activator = ms.locator('[data-id=activator]');
 
     await activator.click();
@@ -173,7 +173,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should hide no-data when hideNoData is set', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-hide-no-data]');
+    const ms = page.locator('[data-id=ms-select-hide-no-data]');
     const activator = ms.locator('[data-id=activator]');
 
     await activator.click();
@@ -186,7 +186,7 @@ test.describe('menu-select - selection', () => {
   });
 
   test('should show aria-selected on active option', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-select-single]');
+    const ms = page.locator('[data-id=ms-select-single]');
     const activator = ms.locator('[data-id=activator]');
 
     // Select an item first
@@ -215,7 +215,7 @@ test.describe('menu-select - readonly', () => {
   });
 
   test('should not open menu when read-only', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-readonly-default]');
+    const ms = page.locator('[data-id=ms-readonly-default]');
     const activator = ms.locator('[data-id=activator]');
     await expect(activator).toHaveAttribute('aria-readonly', 'true');
     await activator.click({ force: true });
@@ -223,7 +223,7 @@ test.describe('menu-select - readonly', () => {
   });
 
   test('should display pre-selected value', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-readonly-default]');
+    const ms = page.locator('[data-id=ms-readonly-default]');
     await expect(ms.locator('[data-id=activator]')).toContainText('Lorem');
   });
 });
@@ -238,8 +238,8 @@ test.describe('menu-select - custom slots', () => {
   });
 
   test('should open menu via custom activator button', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-custom-activator]');
-    const button = ms.locator('[data-cy=activator]');
+    const ms = page.locator('[data-id=ms-custom-activator]');
+    const button = ms.locator('[data-id=activator]');
 
     await expect(button).toBeVisible();
     await expect(button).toContainText('Choose option');
@@ -249,7 +249,7 @@ test.describe('menu-select - custom slots', () => {
   });
 
   test('should render custom selection display', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-custom-selection]');
+    const ms = page.locator('[data-id=ms-custom-selection]');
     const activator = ms.locator('[data-id=activator]');
 
     await activator.click();
@@ -261,7 +261,7 @@ test.describe('menu-select - custom slots', () => {
   });
 
   test('should render custom item append content', async ({ page }) => {
-    const ms = page.locator('[data-cy=ms-custom-item]');
+    const ms = page.locator('[data-id=ms-custom-item]');
     const activator = ms.locator('[data-id=activator]');
 
     // Select first item
@@ -274,6 +274,6 @@ test.describe('menu-select - custom slots', () => {
     await expect(page.locator('div[role=menu]')).toBeVisible();
 
     const activeButton = page.locator('div[role=menu] button[aria-selected=true]');
-    await expect(activeButton.locator('[data-cy=check-icon]')).toBeVisible();
+    await expect(activeButton.locator('[data-id=check-icon]')).toBeVisible();
   });
 });

--- a/apps/example/e2e/forms/radio.spec.ts
+++ b/apps/example/e2e/forms/radio.spec.ts
@@ -6,9 +6,9 @@ test.describe('forms/Radio', () => {
   });
 
   test('checks for radios', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=radio-buttons]')).toContainText('Radio Buttons');
+    await expect(page.locator('h2[data-id=radio-buttons]')).toContainText('Radio Buttons');
 
-    const contentWrapper = page.locator('[data-cy=radio-wrapper]');
+    const contentWrapper = page.locator('[data-id=radio-wrapper]');
     const firstRadio = contentWrapper.locator('input[type="radio"]').first();
     const secondRadio = contentWrapper.locator('input[type="radio"]').nth(1);
     const thirdRadio = contentWrapper.locator('input[type="radio"]').nth(2);
@@ -26,13 +26,13 @@ test.describe('forms/Radio', () => {
   });
 
   test('should have role="radiogroup" on radio group containers', async ({ page }) => {
-    const radioGroups = page.locator('[data-cy=radio-group-wrapper] [role=radiogroup]');
+    const radioGroups = page.locator('[data-id=radio-group-wrapper] [role=radiogroup]');
     const count = await radioGroups.count();
     expect(count).toBeGreaterThanOrEqual(3);
   });
 
   test('should show disabled radio group', async ({ page }) => {
-    const contentWrapper = page.locator('[data-cy=radio-group-wrapper]');
+    const contentWrapper = page.locator('[data-id=radio-group-wrapper]');
     // Third radio group is disabled (index 2)
     const disabledGroup = contentWrapper.locator('[role=radiogroup]').nth(2);
     const disabledRadio = disabledGroup.locator('input[type="radio"]').first();
@@ -40,15 +40,15 @@ test.describe('forms/Radio', () => {
   });
 
   test('should display hint messages', async ({ page }) => {
-    const contentWrapper = page.locator('[data-cy=radio-group-wrapper]');
+    const contentWrapper = page.locator('[data-id=radio-group-wrapper]');
     const firstGroupHint = contentWrapper.locator('.details').first();
     await expect(firstGroupHint).toContainText('Selected value:');
   });
 
   test('checks for radio groups', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=radio-group-buttons]')).toContainText('Radio Groups');
+    await expect(page.locator('h2[data-id=radio-group-buttons]')).toContainText('Radio Groups');
 
-    const contentWrapper = page.locator('[data-cy=radio-group-wrapper]');
+    const contentWrapper = page.locator('[data-id=radio-group-wrapper]');
     // Radio group is rendered as a plain div, find the first radio within wrapper
     // The first 6 radios belong to the first radio group
     const firstRadio = contentWrapper.locator('input[type="radio"]').first();

--- a/apps/example/e2e/forms/simple-select.spec.ts
+++ b/apps/example/e2e/forms/simple-select.spec.ts
@@ -6,7 +6,7 @@ test.describe('forms/SimpleSelect', () => {
   });
 
   test('should render default variant with selected value', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-default]');
+    const wrapper = page.locator('[data-id=ss-default]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toBeVisible();
@@ -14,7 +14,7 @@ test.describe('forms/SimpleSelect', () => {
   });
 
   test('should render outlined variant', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-outlined]');
+    const wrapper = page.locator('[data-id=ss-outlined]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toBeVisible();
@@ -23,7 +23,7 @@ test.describe('forms/SimpleSelect', () => {
   });
 
   test('should change value on select', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-default]');
+    const wrapper = page.locator('[data-id=ss-default]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toHaveValue('Option 1');
@@ -32,14 +32,14 @@ test.describe('forms/SimpleSelect', () => {
   });
 
   test('should not allow interaction when disabled', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-disabled]');
+    const wrapper = page.locator('[data-id=ss-disabled]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toBeDisabled();
   });
 
   test('should render disabled outlined variant', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-disabled-outlined]');
+    const wrapper = page.locator('[data-id=ss-disabled-outlined]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toBeDisabled();
@@ -47,14 +47,14 @@ test.describe('forms/SimpleSelect', () => {
   });
 
   test('should have name attribute', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-named]');
+    const wrapper = page.locator('[data-id=ss-named]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toHaveAttribute('name', 'country');
   });
 
   test('should work with number options', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-number-options]');
+    const wrapper = page.locator('[data-id=ss-number-options]');
     const select = wrapper.locator('[data-id=select]');
 
     await expect(select).toHaveValue('10');
@@ -63,7 +63,7 @@ test.describe('forms/SimpleSelect', () => {
   });
 
   test('should render chevron icon', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=ss-default]');
+    const wrapper = page.locator('[data-id=ss-default]');
 
     await expect(wrapper.locator('svg')).toBeVisible();
   });

--- a/apps/example/e2e/forms/slider.spec.ts
+++ b/apps/example/e2e/forms/slider.spec.ts
@@ -6,10 +6,10 @@ test.describe('forms/Slider', () => {
   });
 
   test('checks for sliders', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=sliders]')).toContainText('Sliders');
+    await expect(page.locator('h2[data-id=sliders]')).toContainText('Sliders');
 
     const firstSlider = page.locator('input[type="range"]').first();
-    const secondWrapper = page.locator('[data-cy=content] > div > div').nth(2);
+    const secondWrapper = page.locator('[data-id=content] > div > div').nth(2);
     const disabledSlider = page.locator('input[type="range"][disabled]').first();
 
     await expect(firstSlider).toHaveValue('50');
@@ -23,18 +23,18 @@ test.describe('forms/Slider', () => {
 
   test('should display label text', async ({ page }) => {
     // Slider at index 2 has label "With Label"
-    const slider = page.locator('[data-cy=slider-2]');
+    const slider = page.locator('[data-id=slider-2]');
     await expect(slider).toContainText('With Label');
 
     // Slider at index 0 has no label
-    const noLabelSlider = page.locator('[data-cy=slider-0]');
+    const noLabelSlider = page.locator('[data-id=slider-0]');
     const labelDiv = noLabelSlider.locator('div[class*=label]');
     await expect(labelDiv).toHaveCount(0);
   });
 
   test('should show thumb label when showThumbLabel is true', async ({ page }) => {
     // Sliders at index 8-9 have showThumbLabel: true
-    const slider = page.locator('[data-cy=slider-8]');
+    const slider = page.locator('[data-id=slider-8]');
     await expect(slider).toContainText('Show Thumb Label');
 
     const input = slider.locator('input[type="range"]');
@@ -44,13 +44,13 @@ test.describe('forms/Slider', () => {
 
   test('should display hint text', async ({ page }) => {
     // Slider at index 12 has hint "Slider hints"
-    const slider = page.locator('[data-cy=slider-12]');
+    const slider = page.locator('[data-id=slider-12]');
     await expect(slider).toContainText('Slider hints');
   });
 
   test('should display error messages', async ({ page }) => {
     // Slider at index 14 has errorMessages
-    const slider = page.locator('[data-cy=slider-14]');
+    const slider = page.locator('[data-id=slider-14]');
     await expect(slider).toContainText('Slider error messages');
 
     const input = slider.locator('input[type="range"]');
@@ -59,22 +59,22 @@ test.describe('forms/Slider', () => {
 
   test('should display success messages', async ({ page }) => {
     // Slider at index 15 has successMessages
-    const slider = page.locator('[data-cy=slider-15]');
+    const slider = page.locator('[data-id=slider-15]');
     await expect(slider).toContainText('Slider success messages');
   });
 
   test('should have aria-label on input when label is provided', async ({ page }) => {
     // Slider at index 2 has label "With Label"
-    const input = page.locator('[data-cy=slider-2] input[type="range"]');
+    const input = page.locator('[data-id=slider-2] input[type="range"]');
     await expect(input).toHaveAttribute('aria-label', 'With Label');
 
     // Slider at index 0 has no label, so aria-label should not be present
-    const noLabelInput = page.locator('[data-cy=slider-0] input[type="range"]');
+    const noLabelInput = page.locator('[data-id=slider-0] input[type="range"]');
     await expect(noLabelInput).not.toHaveAttribute('aria-label');
   });
 
   test('should have aria-valuetext reflecting current value', async ({ page }) => {
-    const input = page.locator('[data-cy=slider-0] input[type="range"]');
+    const input = page.locator('[data-id=slider-0] input[type="range"]');
     await expect(input).toHaveAttribute('aria-valuetext', '50');
 
     await input.fill('25');
@@ -83,7 +83,7 @@ test.describe('forms/Slider', () => {
 
   test('should not be interactable when disabled', async ({ page }) => {
     // Slider at index 4 is disabled
-    const slider = page.locator('[data-cy=slider-4]');
+    const slider = page.locator('[data-id=slider-4]');
     const input = slider.locator('input[type="range"]');
 
     await expect(input).toBeDisabled();
@@ -95,7 +95,7 @@ test.describe('forms/Slider', () => {
   });
 
   test('should update value with keyboard interaction', async ({ page }) => {
-    const input = page.locator('[data-cy=slider-0] input[type="range"]');
+    const input = page.locator('[data-id=slider-0] input[type="range"]');
     await expect(input).toHaveValue('50');
 
     await input.focus();

--- a/apps/example/e2e/forms/switch.spec.ts
+++ b/apps/example/e2e/forms/switch.spec.ts
@@ -6,7 +6,7 @@ test.describe('forms/Switch', () => {
   });
 
   test('checks for switches', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=switches]')).toContainText('Switches');
+    await expect(page.locator('h2[data-id=switches]')).toContainText('Switches');
 
     const firstSwitch = page.locator('input[type="checkbox"]').first();
     const secondSwitch = page.locator('input[type="checkbox"]').nth(1);

--- a/apps/example/e2e/forms/text-area.spec.ts
+++ b/apps/example/e2e/forms/text-area.spec.ts
@@ -6,16 +6,16 @@ test.describe('forms/TextArea', () => {
   });
 
   test('should render text areas', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=text-fields]')).toContainText('Text Fields');
+    await expect(page.locator('h2[data-id=text-fields]')).toContainText('Text Fields');
 
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
     const textareas = content.locator('textarea:not([aria-hidden="true"])');
 
     await expect(textareas.first()).toBeVisible();
   });
 
   test('should accept input and display value', async ({ page }) => {
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
     const firstTextarea = content.locator('textarea:not([aria-hidden="true"])').first();
 
     await expect(firstTextarea).toHaveValue('');
@@ -24,28 +24,28 @@ test.describe('forms/TextArea', () => {
   });
 
   test('should have disabled text areas', async ({ page }) => {
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
     const disabledTextarea = content.locator('textarea[disabled]:not([aria-hidden="true"])').first();
 
     await expect(disabledTextarea).toBeDisabled();
   });
 
   test('should display hint text', async ({ page }) => {
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
     const hintText = content.locator('.details >> text=Text field hint').first();
 
     await expect(hintText).toBeVisible();
   });
 
   test('should display error messages', async ({ page }) => {
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
     const errorText = content.locator('.details >> text=Text field error message').first();
 
     await expect(errorText).toBeVisible();
   });
 
   test('should show clear button on clearable textarea with value', async ({ page }) => {
-    const content = page.locator('[data-cy=content]');
+    const content = page.locator('[data-id=content]');
 
     // The clearable textarea with pre-filled value 'lorem ipsum dolor' renders a clear button
     // Verify the clear button is present when the textarea has focus and a value

--- a/apps/example/e2e/forms/text-field.spec.ts
+++ b/apps/example/e2e/forms/text-field.spec.ts
@@ -6,10 +6,10 @@ test.describe('forms/TextField', () => {
   });
 
   test('checks for text-fields', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=text-fields]').first()).toContainText('Text Fields');
+    await expect(page.locator('h2[data-id=text-fields]').first()).toContainText('Text Fields');
 
     // Select the first grid (text fields) immediately after the h2, not the revealable text fields section
-    const textFieldsGrid = page.locator('h2[data-cy=text-fields]').first().locator('+ div');
+    const textFieldsGrid = page.locator('h2[data-id=text-fields]').first().locator('+ div');
     const firstText = textFieldsGrid.locator('input').first();
     const secondText = textFieldsGrid.locator('input').nth(2);
     const disabledText = textFieldsGrid.locator('input[disabled]').first();

--- a/apps/example/e2e/icon.spec.ts
+++ b/apps/example/e2e/icon.spec.ts
@@ -6,24 +6,24 @@ test.describe('icons', () => {
   });
 
   test('should render SVG icons with aria-hidden', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=icons]')).toContainText('Icons');
+    await expect(page.locator('h2[data-id=icons]')).toContainText('Icons');
 
     // Icons are inside the content div following the h2
-    const contentArea = page.locator('h2[data-cy=icons] + div[data-cy=content]');
+    const contentArea = page.locator('h2[data-id=icons] + div[data-id=content]');
     const icon = contentArea.locator('svg[aria-hidden="true"]').first();
     await expect(icon).toBeVisible();
     await expect(icon).toHaveAttribute('aria-hidden', 'true');
   });
 
   test('should render icons with correct dimensions', async ({ page }) => {
-    const contentArea = page.locator('h2[data-cy=icons] + div[data-cy=content]');
+    const contentArea = page.locator('h2[data-id=icons] + div[data-id=content]');
     const icon = contentArea.locator('svg[aria-hidden="true"]').first();
     await expect(icon).toHaveAttribute('width', '24');
     await expect(icon).toHaveAttribute('height', '24');
   });
 
   test('should render multiple icons', async ({ page }) => {
-    const contentArea = page.locator('h2[data-cy=icons] + div[data-cy=content]');
+    const contentArea = page.locator('h2[data-id=icons] + div[data-id=content]');
     const icons = contentArea.locator('svg[aria-hidden="true"]');
     const count = await icons.count();
     expect(count).toBeGreaterThanOrEqual(3);

--- a/apps/example/e2e/loader.spec.ts
+++ b/apps/example/e2e/loader.spec.ts
@@ -6,7 +6,7 @@ test.describe('loaders', () => {
   });
 
   test('should render text and heading skeleton loaders', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=skeleton-loader]')).toContainText('Skeleton Loader');
+    await expect(page.locator('h2[data-id=skeleton-loader]')).toContainText('Skeleton Loader');
 
     const defaultSkeleton = page.locator('div[class*=skeleton_text]').first();
     const headingSkeleton = page.locator('div[class*=skeleton_heading]').first();

--- a/apps/example/e2e/logo.spec.ts
+++ b/apps/example/e2e/logo.spec.ts
@@ -6,7 +6,7 @@ test.describe('Logo', () => {
   });
 
   test('should render fallback image', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=logo-default]');
+    const wrapper = page.locator('[data-id=logo-default]');
     const img = wrapper.locator('img[data-image=fallback]');
 
     await expect(img).toBeVisible();
@@ -14,7 +14,7 @@ test.describe('Logo', () => {
   });
 
   test('should render with text', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=logo-text]');
+    const wrapper = page.locator('[data-id=logo-text]');
     const img = wrapper.locator('img[data-image=fallback]');
 
     await expect(img).toBeVisible();
@@ -22,14 +22,14 @@ test.describe('Logo', () => {
   });
 
   test('should apply custom size', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=logo-size]');
+    const wrapper = page.locator('[data-id=logo-size]');
     const container = wrapper.locator('div').first();
 
     await expect(container).toHaveCSS('height', '80px'); // 5rem = 80px
   });
 
   test('should apply small size', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=logo-small]');
+    const wrapper = page.locator('[data-id=logo-small]');
     const container = wrapper.locator('div').first();
 
     await expect(container).toHaveCSS('height', '24px'); // 1.5rem = 24px

--- a/apps/example/e2e/overlays/badge.spec.ts
+++ b/apps/example/e2e/overlays/badge.spec.ts
@@ -6,9 +6,9 @@ test.describe('badge', () => {
   });
 
   test('checks for and trigger badge', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=badges]')).toContainText('Badges');
+    await expect(page.locator('h2[data-id=badges]')).toContainText('Badges');
 
-    const defaultBadge = page.locator('div[data-cy=badge-0]');
+    const defaultBadge = page.locator('div[data-id=badge-0]');
     await expect(defaultBadge.locator('div[role=status]')).toBeVisible();
 
     await defaultBadge.locator('> button').click();
@@ -18,7 +18,7 @@ test.describe('badge', () => {
   });
 
   test('should have correct ARIA attributes on badge', async ({ page }) => {
-    const badge = page.locator('div[data-cy=badge-0] div[role=status]');
+    const badge = page.locator('div[data-id=badge-0] div[role=status]');
     await expect(badge).toBeVisible();
     await expect(badge).toHaveAttribute('aria-live', 'polite');
     await expect(badge).toHaveAttribute('aria-atomic', 'true');
@@ -26,7 +26,7 @@ test.describe('badge', () => {
   });
 
   test('should render dot badge variant', async ({ page }) => {
-    const dotBadge = page.locator('div[data-cy=badge-84] div[role=status]');
+    const dotBadge = page.locator('div[data-id=badge-84] div[role=status]');
     await expect(dotBadge).toBeVisible();
     // Dot badge should not have content span
     await expect(dotBadge.locator('span')).toHaveCount(0);
@@ -35,13 +35,13 @@ test.describe('badge', () => {
   test('should render different color variants', async ({ page }) => {
     // badge-0 = default, badge-1 = primary, badge-2 = secondary, badge-3 = error
     for (const index of [0, 1, 2, 3, 4, 5, 6]) {
-      const badge = page.locator(`div[data-cy=badge-${index}] div[role=status]`);
+      const badge = page.locator(`div[data-id=badge-${index}] div[role=status]`);
       await expect(badge).toBeVisible();
     }
   });
 
   test('checks for and trigger dot badge', async ({ page }) => {
-    const dotBadge = page.locator('div[data-cy=badge-84]');
+    const dotBadge = page.locator('div[data-id=badge-84]');
     await expect(dotBadge.locator('div[role=status]')).toBeVisible();
 
     await dotBadge.locator('> button').click();

--- a/apps/example/e2e/overlays/bottom-sheet.spec.ts
+++ b/apps/example/e2e/overlays/bottom-sheet.spec.ts
@@ -11,12 +11,12 @@ test.describe('bottom-sheet', () => {
   });
 
   test('check persistent bottom sheet', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=bottom-sheets]')).toContainText('Bottom Sheets');
+    await expect(page.locator('h2[data-id=bottom-sheets]')).toContainText('Bottom Sheets');
 
-    const defaultBottomSheet = page.locator('div[data-cy=bottom-sheet-0]');
+    const defaultBottomSheet = page.locator('div[data-id=bottom-sheet-0]');
 
     // open bottom sheet
-    const activator = defaultBottomSheet.locator('[data-cy=activator]');
+    const activator = defaultBottomSheet.locator('[data-id=activator]');
     await activator.click();
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
@@ -29,15 +29,15 @@ test.describe('bottom-sheet', () => {
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // close the bottom sheet
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(page.locator('div[role=dialog]')).toHaveCount(0);
   });
 
   test('check non-persistent bottom sheet', async ({ page }) => {
-    const defaultBottomSheet = page.locator('div[data-cy=bottom-sheet-1]');
+    const defaultBottomSheet = page.locator('div[data-id=bottom-sheet-1]');
 
     // open bottom sheet
-    const activator = defaultBottomSheet.locator('[data-cy=activator]');
+    const activator = defaultBottomSheet.locator('[data-id=activator]');
     await activator.click();
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
@@ -55,23 +55,23 @@ test.describe('bottom-sheet', () => {
   });
 
   test('should have aria-modal attribute when open', async ({ page }) => {
-    const defaultBottomSheet = page.locator('div[data-cy=bottom-sheet-0]');
+    const defaultBottomSheet = page.locator('div[data-id=bottom-sheet-0]');
 
-    const activator = defaultBottomSheet.locator('[data-cy=activator]');
+    const activator = defaultBottomSheet.locator('[data-id=activator]');
     await activator.click();
 
     const dialog = page.locator('div[role=dialog]');
     await expect(dialog).toBeVisible();
     await expect(dialog).toHaveAttribute('aria-modal', 'true');
 
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(dialog).toHaveCount(0);
   });
 
   test('should apply custom width to bottom sheet content', async ({ page }) => {
-    const defaultBottomSheet = page.locator('div[data-cy=bottom-sheet-0]');
+    const defaultBottomSheet = page.locator('div[data-id=bottom-sheet-0]');
 
-    const activator = defaultBottomSheet.locator('[data-cy=activator]');
+    const activator = defaultBottomSheet.locator('[data-id=activator]');
     await activator.click();
 
     const dialog = page.locator('div[role=dialog]');
@@ -80,7 +80,7 @@ test.describe('bottom-sheet', () => {
     const content = dialog.locator('[data-id=content]');
     await expect(content).toHaveCSS('width', '900px');
 
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(dialog).toHaveCount(0);
   });
 });

--- a/apps/example/e2e/overlays/dialog.spec.ts
+++ b/apps/example/e2e/overlays/dialog.spec.ts
@@ -11,12 +11,12 @@ test.describe('dialog', () => {
   });
 
   test('check persistent dialog', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=dialogs]')).toContainText('Dialogs');
+    await expect(page.locator('h2[data-id=dialogs]')).toContainText('Dialogs');
 
-    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+    const defaultDialog = page.locator('div[data-id=dialog-0]');
 
     // open dialog
-    const activator = defaultDialog.locator('[data-cy=activator]');
+    const activator = defaultDialog.locator('[data-id=activator]');
     await activator.click();
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
@@ -29,57 +29,57 @@ test.describe('dialog', () => {
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 
     // close the dialog
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(page.locator('div[role=dialog]')).toHaveCount(0);
   });
 
   test('should have aria-modal attribute when open', async ({ page }) => {
-    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+    const defaultDialog = page.locator('div[data-id=dialog-0]');
 
-    const activator = defaultDialog.locator('[data-cy=activator]');
+    const activator = defaultDialog.locator('[data-id=activator]');
     await activator.click();
 
     const dialog = page.locator('div[role=dialog]');
     await expect(dialog).toBeVisible();
     await expect(dialog).toHaveAttribute('aria-modal', 'true');
 
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(dialog).toHaveCount(0);
   });
 
   test('should have aria-label attribute when provided', async ({ page }) => {
-    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+    const defaultDialog = page.locator('div[data-id=dialog-0]');
 
-    const activator = defaultDialog.locator('[data-cy=activator]');
+    const activator = defaultDialog.locator('[data-id=activator]');
     await activator.click();
 
     const dialog = page.locator('div[role=dialog]');
     await expect(dialog).toBeVisible();
     await expect(dialog).toHaveAttribute('aria-label', 'Persistent dialog');
 
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(dialog).toHaveCount(0);
   });
 
   test('should display content inside dialog', async ({ page }) => {
-    const defaultDialog = page.locator('div[data-cy=dialog-0]');
+    const defaultDialog = page.locator('div[data-id=dialog-0]');
 
-    const activator = defaultDialog.locator('[data-cy=activator]');
+    const activator = defaultDialog.locator('[data-id=activator]');
     await activator.click();
 
     const dialog = page.locator('div[role=dialog]');
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText('Contents 0');
 
-    await page.locator('button[data-cy=close]').click();
+    await page.locator('button[data-id=close]').click();
     await expect(dialog).toHaveCount(0);
   });
 
   test('check non-persistent dialog', async ({ page }) => {
-    const defaultDialog = page.locator('div[data-cy=dialog-1]');
+    const defaultDialog = page.locator('div[data-id=dialog-1]');
 
     // open dialog
-    const activator = defaultDialog.locator('[data-cy=activator]');
+    const activator = defaultDialog.locator('[data-id=activator]');
     await activator.click();
     await expect(page.locator('div[role=dialog]')).toBeVisible();
 

--- a/apps/example/e2e/overlays/menu.spec.ts
+++ b/apps/example/e2e/overlays/menu.spec.ts
@@ -13,13 +13,13 @@ test.describe('menu', () => {
   });
 
   test('checks for and trigger menu', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=menus]')).toContainText('Menus');
+    await expect(page.locator('h2[data-id=menus]')).toContainText('Menus');
 
-    await expect(page.locator('[data-cy=content]')).toBeVisible();
-    await expect(page.locator('div[data-cy=menu-0]')).toBeVisible();
+    await expect(page.locator('[data-id=content]')).toBeVisible();
+    await expect(page.locator('div[data-id=menu-0]')).toBeVisible();
 
-    const defaultMenu = page.locator('div[data-cy=menu-0]');
-    const activator = defaultMenu.locator('[data-cy=activator]');
+    const defaultMenu = page.locator('div[data-id=menu-0]');
+    const activator = defaultMenu.locator('[data-id=activator]');
 
     await expect(activator).toBeVisible();
     await activator.click();
@@ -38,16 +38,16 @@ test.describe('menu', () => {
   });
 
   test('disabled should not trigger menu', async ({ page }) => {
-    const disabledMenu = page.locator('div[data-cy=menu-4]');
-    const activator = disabledMenu.locator('[data-cy=activator]');
+    const disabledMenu = page.locator('div[data-id=menu-4]');
+    const activator = disabledMenu.locator('[data-id=activator]');
 
     await expect(activator).toBeDisabled();
     await expect(page.locator('div[role=menu-content]')).toHaveCount(0);
   });
 
   test('menu should be opened on hover', async ({ page }) => {
-    const menu = page.locator('div[data-cy=menu-8]');
-    const activator = menu.locator('[data-cy=activator]');
+    const menu = page.locator('div[data-id=menu-8]');
+    const activator = menu.locator('[data-id=activator]');
 
     await activator.hover();
     await expect(page.locator('div[role=menu-content]')).toBeVisible();
@@ -69,14 +69,14 @@ test.describe('menu', () => {
   });
 
   test('should have aria-expanded toggle on open/close', async ({ page }) => {
-    const menu = page.locator('div[data-cy=menu-0]');
+    const menu = page.locator('div[data-id=menu-0]');
     const activatorWrapper = menu.locator('[aria-haspopup=true]');
 
     // Initially aria-expanded should be false
     await expect(activatorWrapper).toHaveAttribute('aria-expanded', 'false');
 
     // Open menu
-    await menu.locator('[data-cy=activator]').click();
+    await menu.locator('[data-id=activator]').click();
     await expect(page.locator('div[role=menu-content]')).toBeVisible();
     await expect(activatorWrapper).toHaveAttribute('aria-expanded', 'true');
 
@@ -87,36 +87,36 @@ test.describe('menu', () => {
   });
 
   test('should close menu when clicking outside', async ({ page }) => {
-    const menu = page.locator('div[data-cy=menu-0]');
-    await menu.locator('[data-cy=activator]').click();
+    const menu = page.locator('div[data-id=menu-0]');
+    await menu.locator('[data-id=activator]').click();
     await expect(page.locator('div[role=menu-content]')).toBeVisible();
 
     // Click outside the menu
-    await page.locator('h2[data-cy=menus]').click();
+    await page.locator('h2[data-id=menus]').click();
     await expect(page.locator('div[role=menu-content]')).toHaveCount(0);
   });
 
   test('should not close persistent menu when clicking outside', async ({ page }) => {
     // Persistent menu is at index 16
-    const menu = page.locator('div[data-cy=menu-16]');
+    const menu = page.locator('div[data-id=menu-16]');
     await menu.scrollIntoViewIfNeeded();
-    await menu.locator('[data-cy=activator]').click();
+    await menu.locator('[data-id=activator]').click();
 
     const menuContent = page.locator('div[role=menu-content]');
     await expect(menuContent).toBeVisible();
 
     // Click outside should not close persistent menu
-    await page.locator('h2[data-cy=menus]').click();
+    await page.locator('h2[data-id=menus]').click();
     await expect(menuContent).toBeVisible();
 
     // Clicking the activator again should close it
-    await menu.locator('[data-cy=activator]').click();
+    await menu.locator('[data-id=activator]').click();
     await expect(menuContent).toHaveCount(0);
   });
 
   test('should focus menu content on open and return focus to activator on close', async ({ page }) => {
-    const menu = page.locator('div[data-cy=menu-0]');
-    const activator = menu.locator('[data-cy=activator]');
+    const menu = page.locator('div[data-id=menu-0]');
+    const activator = menu.locator('[data-id=activator]');
 
     await activator.click();
     await expect(page.locator('div[role=menu-content]')).toBeVisible();
@@ -133,8 +133,8 @@ test.describe('menu', () => {
   });
 
   test('menu should be closed by clicking the menu content', async ({ page }) => {
-    const menu = page.locator('div[data-cy=menu-12]');
-    const activator = menu.locator('[data-cy=activator]');
+    const menu = page.locator('div[data-id=menu-12]');
+    const activator = menu.locator('[data-id=activator]');
 
     await activator.click();
     await expect(page.locator('div[role=menu-content]')).toBeVisible();

--- a/apps/example/e2e/overlays/navigation-drawer.spec.ts
+++ b/apps/example/e2e/overlays/navigation-drawer.spec.ts
@@ -13,41 +13,41 @@ test.describe('navigation drawer', () => {
   });
 
   test('check non-persistent navigation-drawer', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=navigation-drawers]')).toContainText('Navigation Drawers');
+    await expect(page.locator('h2[data-id=navigation-drawers]')).toContainText('Navigation Drawers');
 
-    const defaultDrawer = page.locator('div[data-cy=navigation-drawer-0]');
+    const defaultDrawer = page.locator('div[data-id=navigation-drawer-0]');
 
     // open drawer
-    const activator = defaultDrawer.locator('[data-cy=activator]');
+    const activator = defaultDrawer.locator('[data-id=activator]');
     await activator.click();
     // Wait for the aside element with visible class to appear (drawer is open)
     await expect(page.locator('aside[class*=_visible]')).toBeVisible();
 
     // should close the drawer by clicking outside (temporary drawer uses onClickOutside)
     // clicking on h2 closes the drawer since it's outside the aside content
-    await page.locator('h2[data-cy=navigation-drawers]').click();
+    await page.locator('h2[data-id=navigation-drawers]').click();
     // After closing, there should be no visible drawer (no aside with _visible class)
     await expect(page.locator('aside[class*=_visible]')).toHaveCount(0);
   });
 
   test('check persistent drawer', async ({ page }) => {
-    const defaultDrawer = page.locator('div[data-cy=navigation-drawer-2]');
+    const defaultDrawer = page.locator('div[data-id=navigation-drawer-2]');
 
     // open drawer
-    const activator = defaultDrawer.locator('[data-cy=activator]');
+    const activator = defaultDrawer.locator('[data-id=activator]');
     await activator.click();
     // Wait for the aside element with visible class to appear
     await expect(page.locator('aside[class*=_visible]')).toBeVisible();
 
     // should not close the drawer when clicking elsewhere (temporary: false)
-    await page.locator('h2[data-cy=navigation-drawers]').click();
+    await page.locator('h2[data-id=navigation-drawers]').click();
     // The drawer should still be visible
     await expect(page.locator('aside[class*=_visible]')).toBeVisible();
   });
 
   test('should render drawer on left by default', async ({ page }) => {
-    const defaultDrawer = page.locator('div[data-cy=navigation-drawer-0]');
-    await defaultDrawer.locator('[data-cy=activator]').click();
+    const defaultDrawer = page.locator('div[data-id=navigation-drawer-0]');
+    await defaultDrawer.locator('[data-id=activator]').click();
 
     const aside = page.locator('aside[class*=_visible]');
     await expect(aside).toBeVisible();
@@ -56,8 +56,8 @@ test.describe('navigation drawer', () => {
   });
 
   test('should render drawer on right with position="right"', async ({ page }) => {
-    const rightDrawer = page.locator('div[data-cy=navigation-drawer-1]');
-    await rightDrawer.locator('[data-cy=activator]').click();
+    const rightDrawer = page.locator('div[data-id=navigation-drawer-1]');
+    await rightDrawer.locator('[data-id=activator]').click();
 
     const aside = page.locator('aside[class*=_visible]');
     await expect(aside).toBeVisible();
@@ -66,8 +66,8 @@ test.describe('navigation drawer', () => {
   });
 
   test('should show overlay when overlay prop is true', async ({ page }) => {
-    const overlayDrawer = page.locator('div[data-cy=navigation-drawer-3]');
-    await overlayDrawer.locator('[data-cy=activator]').click();
+    const overlayDrawer = page.locator('div[data-id=navigation-drawer-3]');
+    await overlayDrawer.locator('[data-id=activator]').click();
 
     const aside = page.locator('aside[class*=_visible]');
     await expect(aside).toBeVisible();
@@ -82,8 +82,8 @@ test.describe('navigation drawer', () => {
   });
 
   test('should have aria-label on drawer', async ({ page }) => {
-    const defaultDrawer = page.locator('div[data-cy=navigation-drawer-0]');
-    await defaultDrawer.locator('[data-cy=activator]').click();
+    const defaultDrawer = page.locator('div[data-id=navigation-drawer-0]');
+    await defaultDrawer.locator('[data-id=activator]').click();
 
     const aside = page.locator('aside[class*=_visible]');
     await expect(aside).toBeVisible();

--- a/apps/example/e2e/overlays/notification.spec.ts
+++ b/apps/example/e2e/overlays/notification.spec.ts
@@ -11,55 +11,55 @@ test.describe('notifications', () => {
   });
 
   test('should toggle visibility through button', async ({ page }) => {
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0);
-    await page.locator('[data-cy="visibility-toggle"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toBeVisible();
-    await expect(page.locator('[data-cy="notification-content"]')).toContainText('This is a notification');
-    await page.locator('[data-cy="visibility-toggle"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0);
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0);
+    await page.locator('[data-id="visibility-toggle"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toBeVisible();
+    await expect(page.locator('[data-id="notification-content"]')).toContainText('This is a notification');
+    await page.locator('[data-id="visibility-toggle"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0);
   });
 
   test('should have role="alert" and aria-live="polite"', async ({ page }) => {
-    await page.locator('[data-cy="visibility-toggle"]').click();
+    await page.locator('[data-id="visibility-toggle"]').click();
     const notification = page.locator('[role="alert"]');
     await expect(notification).toBeVisible();
     await expect(notification).toHaveAttribute('aria-live', 'polite');
   });
 
   test('should contain notification text content', async ({ page }) => {
-    await page.locator('[data-cy="visibility-toggle"]').click();
+    await page.locator('[data-id="visibility-toggle"]').click();
     const notification = page.locator('[role="alert"]');
     await expect(notification).toBeVisible();
     await expect(notification).toContainText('This is a notification');
   });
 
   test('should dismiss by click', async ({ page }) => {
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0);
-    await page.locator('[data-cy="visibility-toggle"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toBeVisible();
-    await page.locator('[data-cy="notification-content"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0);
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0);
+    await page.locator('[data-id="visibility-toggle"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toBeVisible();
+    await page.locator('[data-id="notification-content"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0);
   });
 
   test('should not dismiss by click when timeout is negative', async ({ page }) => {
-    const timeoutInput = page.locator('[data-cy="timeout"] input');
+    const timeoutInput = page.locator('[data-id="timeout"] input');
     await timeoutInput.clear();
     await timeoutInput.fill('-1');
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0);
-    await page.locator('[data-cy="visibility-toggle"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toBeVisible();
-    await page.locator('[data-cy="notification-content"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toBeVisible();
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0);
+    await page.locator('[data-id="visibility-toggle"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toBeVisible();
+    await page.locator('[data-id="notification-content"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toBeVisible();
   });
 
   test('should auto dismiss on timeout', async ({ page }) => {
-    const timeoutInput = page.locator('[data-cy="timeout"] input');
+    const timeoutInput = page.locator('[data-id="timeout"] input');
     await timeoutInput.clear();
     await timeoutInput.fill('100');
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0);
-    await page.locator('[data-cy="visibility-toggle"]').click();
-    await expect(page.locator('[data-cy="notification-content"]')).toBeVisible();
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0);
+    await page.locator('[data-id="visibility-toggle"]').click();
+    await expect(page.locator('[data-id="notification-content"]')).toBeVisible();
     // Wait for the notification to auto-dismiss after 100ms timeout
-    await expect(page.locator('[data-cy="notification-content"]')).toHaveCount(0, { timeout: 5000 });
+    await expect(page.locator('[data-id="notification-content"]')).toHaveCount(0, { timeout: 5000 });
   });
 });

--- a/apps/example/e2e/overlays/tooltip.spec.ts
+++ b/apps/example/e2e/overlays/tooltip.spec.ts
@@ -13,9 +13,9 @@ test.describe('tooltip', () => {
   });
 
   test('checks for and trigger tooltip', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=tooltips]')).toContainText('Tooltips');
+    await expect(page.locator('h2[data-id=tooltips]')).toContainText('Tooltips');
 
-    const defaultTooltip = page.locator('div[data-cy=tooltip-0]');
+    const defaultTooltip = page.locator('div[data-id=tooltip-0]');
 
     await expect(defaultTooltip.locator('#activator')).toBeVisible();
     await defaultTooltip.hover();
@@ -27,7 +27,7 @@ test.describe('tooltip', () => {
   });
 
   test('checks for and trigger arrow tooltip', async ({ page }) => {
-    const tooltipWithArrow = page.locator('div[data-cy=tooltip-4]');
+    const tooltipWithArrow = page.locator('div[data-id=tooltip-4]');
 
     await expect(tooltipWithArrow.locator('#activator')).toBeVisible();
     await tooltipWithArrow.hover();
@@ -45,7 +45,7 @@ test.describe('tooltip', () => {
   test('disabled should not trigger tooltip', async ({ page }) => {
     // Disabled tooltips are at indices 12-15 (4th attribute set)
     // tooltip-12 is the first disabled tooltip
-    const disabledTooltip = page.locator('div[data-cy=tooltip-12]');
+    const disabledTooltip = page.locator('div[data-id=tooltip-12]');
     await disabledTooltip.scrollIntoViewIfNeeded();
 
     // Move mouse to a safe area first
@@ -62,7 +62,7 @@ test.describe('tooltip', () => {
   });
 
   test('should show tooltip on keyboard focus', async ({ page }) => {
-    const defaultTooltip = page.locator('div[data-cy=tooltip-0]');
+    const defaultTooltip = page.locator('div[data-id=tooltip-0]');
     const activator = defaultTooltip.locator('#activator');
 
     // Focus the activator via keyboard (tab)
@@ -76,7 +76,7 @@ test.describe('tooltip', () => {
   });
 
   test('should have aria-describedby linking activator to tooltip', async ({ page }) => {
-    const defaultTooltip = page.locator('div[data-cy=tooltip-0]');
+    const defaultTooltip = page.locator('div[data-id=tooltip-0]');
 
     // Initially no aria-describedby
     await expect(defaultTooltip).not.toHaveAttribute('aria-describedby');

--- a/apps/example/e2e/progress.spec.ts
+++ b/apps/example/e2e/progress.spec.ts
@@ -32,7 +32,7 @@ test.describe('progress indicators', () => {
   });
 
   test('should render all progress variants', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=progress]')).toContainText('Progress');
+    await expect(page.locator('h2[data-id=progress]')).toContainText('Progress');
 
     const determinateProgress = page.locator('div[class*=progress][class*=determinate]').first();
     const indeterminateProgress = page.locator('div[class*=progress][class*=indeterminate]').first();

--- a/apps/example/e2e/stepper.spec.ts
+++ b/apps/example/e2e/stepper.spec.ts
@@ -6,22 +6,22 @@ test.describe('steppers', () => {
   });
 
   test('should render stepper with correct states', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=steppers]')).toContainText('Steppers');
+    await expect(page.locator('h2[data-id=steppers]')).toContainText('Steppers');
 
-    const horizontalStepper = page.locator('[data-cy=stepper-0]');
+    const horizontalStepper = page.locator('[data-id=stepper-0]');
 
     await expect(horizontalStepper.locator('div[class*=_step][class*=_inactive]')).toContainText('Inactive');
     await expect(horizontalStepper.locator('div[class*=_step][class*=_success]')).toContainText('Success');
   });
 
   test('should have role="list" and aria-label on stepper', async ({ page }) => {
-    const stepper = page.locator('[data-cy=stepper-0]');
+    const stepper = page.locator('[data-id=stepper-0]');
     await expect(stepper).toHaveAttribute('role', 'list');
     await expect(stepper).toHaveAttribute('aria-label', 'Progress steps');
   });
 
   test('should have role="listitem" on each step', async ({ page }) => {
-    const stepper = page.locator('[data-cy=stepper-0]');
+    const stepper = page.locator('[data-id=stepper-0]');
     const items = stepper.locator('[role=listitem]');
 
     // First stepper has 7 steps
@@ -29,7 +29,7 @@ test.describe('steppers', () => {
   });
 
   test('should have aria-current="step" on active step', async ({ page }) => {
-    const stepper = page.locator('[data-cy=stepper-0]');
+    const stepper = page.locator('[data-id=stepper-0]');
     const activeStep = stepper.locator('[aria-current=step]');
 
     await expect(activeStep).toHaveCount(1);
@@ -38,7 +38,7 @@ test.describe('steppers', () => {
 
   test('should render vertical stepper', async ({ page }) => {
     // Stepper at index 1 is vertical
-    const stepper = page.locator('[data-cy=stepper-1]');
+    const stepper = page.locator('[data-id=stepper-1]');
     await expect(stepper).toBeVisible();
 
     const items = stepper.locator('[role=listitem]');
@@ -47,7 +47,7 @@ test.describe('steppers', () => {
 
   test('should render icon-top stepper', async ({ page }) => {
     // Stepper at index 2 has iconTop=true
-    const stepper = page.locator('[data-cy=stepper-2]');
+    const stepper = page.locator('[data-id=stepper-2]');
     await expect(stepper).toBeVisible();
 
     const items = stepper.locator('[role=listitem]');
@@ -56,7 +56,7 @@ test.describe('steppers', () => {
 
   test('should render custom stepper variant', async ({ page }) => {
     // Stepper at index 4 has custom=true
-    const stepper = page.locator('[data-cy=stepper-4]');
+    const stepper = page.locator('[data-id=stepper-4]');
     await expect(stepper).toBeVisible();
 
     const items = stepper.locator('[role=listitem]');

--- a/apps/example/e2e/tabs.spec.ts
+++ b/apps/example/e2e/tabs.spec.ts
@@ -6,16 +6,16 @@ test.describe('tabs', () => {
   });
 
   test('should render tabs and handle navigation', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=tabs]')).toContainText('Tabs');
+    await expect(page.locator('h2[data-id=tabs]')).toContainText('Tabs');
 
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const tablist = wrapper.locator('[data-id=tabs] [role=tablist]');
 
     await expect(tablist.locator('> *')).toHaveCount(6);
     await expect(tablist.locator('button:first-child')).toHaveClass(/active-tab/);
     await expect(tablist.locator('button:nth-child(2)')).toBeDisabled();
 
-    const tabcontent = wrapper.locator('[data-cy=tab-items]');
+    const tabcontent = wrapper.locator('[data-id=tab-items]');
     await expect(tabcontent).toHaveText('Tab 1 Content');
 
     // Click third tab
@@ -30,20 +30,20 @@ test.describe('tabs', () => {
   });
 
   test('should have role="tablist" on tab container', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const tablist = wrapper.locator('[data-id=tabs] [role=tablist]');
     await expect(tablist).toBeVisible();
   });
 
   test('should have role="tab" on each tab button', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const tabs = wrapper.locator('[data-cy=tabs] [role=tab]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const tabs = wrapper.locator('[data-id=tabs] [role=tab]');
     await expect(tabs).toHaveCount(6);
   });
 
   test('should have aria-selected on active tab', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const tablist = wrapper.locator('[data-id=tabs] [role=tablist]');
 
     // First tab is active by default
     await expect(tablist.locator('[role=tab]:first-child')).toHaveAttribute('aria-selected', 'true');
@@ -56,25 +56,25 @@ test.describe('tabs', () => {
   });
 
   test('should have role="tabpanel" on tab content items', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const panels = wrapper.locator('[data-cy=tab-items] [role=tabpanel]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const panels = wrapper.locator('[data-id=tab-items] [role=tabpanel]');
     await expect(panels.first()).toBeVisible();
   });
 
   test('should render vertical tabs', async ({ page }) => {
     // wrapper-1 is the first vertical tab set (primary color, vertical=true)
-    const wrapper = page.locator('[data-cy=wrapper-1]');
-    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
+    const wrapper = page.locator('[data-id=wrapper-1]');
+    const tablist = wrapper.locator('[data-id=tabs] [role=tablist]');
     await expect(tablist).toBeVisible();
 
-    const tabs = wrapper.locator('[data-cy=tabs] [role=tab]');
+    const tabs = wrapper.locator('[data-id=tabs] [role=tab]');
     await expect(tabs).toHaveCount(6);
   });
 
   test('should switch content when clicking different tabs', async ({ page }) => {
-    const wrapper = page.locator('[data-cy=wrapper-0]');
-    const tablist = wrapper.locator('[data-cy=tabs] [role=tablist]');
-    const tabcontent = wrapper.locator('[data-cy=tab-items]');
+    const wrapper = page.locator('[data-id=wrapper-0]');
+    const tablist = wrapper.locator('[data-id=tabs] [role=tablist]');
+    const tabcontent = wrapper.locator('[data-id=tab-items]');
 
     await expect(tabcontent).toHaveText('Tab 1 Content');
 

--- a/apps/example/e2e/timepicker.spec.ts
+++ b/apps/example/e2e/timepicker.spec.ts
@@ -6,7 +6,7 @@ test.describe('timepickers', () => {
   });
 
   test('should render timepicker with initial values', async ({ page }) => {
-    await expect(page.locator('h2[data-cy=timepickers]')).toContainText('Time Pickers');
+    await expect(page.locator('h2[data-id=timepickers]')).toContainText('Time Pickers');
 
     await expect(page.locator('[class*=_rui-digit_]', { hasText: '08' }).first()).toBeVisible();
     await expect(page.locator('[class*=_rui-digit_]', { hasText: '20' }).first()).toBeVisible();
@@ -14,7 +14,7 @@ test.describe('timepickers', () => {
   });
 
   test('should be able to select time', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-0]');
+    const picker = page.locator('[data-id=timepicker-0]');
     await picker.locator('.rui-hour-06').click();
     await picker.locator('.rui-minute-30').click();
 
@@ -24,7 +24,7 @@ test.describe('timepickers', () => {
   });
 
   test('should toggle AM/PM', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-0]');
+    const picker = page.locator('[data-id=timepicker-0]');
     const amPmToggle = picker.locator('.rui-time-picker-period');
 
     await expect(amPmToggle).toHaveText('PM');
@@ -35,7 +35,7 @@ test.describe('timepickers', () => {
   });
 
   test('should show seconds when accuracy includes seconds', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-1]');
+    const picker = page.locator('[data-id=timepicker-1]');
 
     // Second picker has accuracy='second', should show seconds digit
     const digits = picker.locator('[role=button][aria-label="Select seconds"]');
@@ -44,15 +44,15 @@ test.describe('timepickers', () => {
   });
 
   test('should have aria-label on time picker root', async ({ page }) => {
-    // data-cy is on the same root div as role="group"
-    const picker = page.locator('[data-cy=timepicker-0]');
+    // data-id is on the same root div as role="group"
+    const picker = page.locator('[data-id=timepicker-0]');
 
     await expect(picker).toHaveAttribute('role', 'group');
     await expect(picker).toHaveAttribute('aria-label', 'Time picker');
   });
 
   test('should have role="listbox" on clock face with aria-label', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-0]');
+    const picker = page.locator('[data-id=timepicker-0]');
     const clockFace = picker.locator('[role=listbox]');
 
     await expect(clockFace).toBeVisible();
@@ -60,7 +60,7 @@ test.describe('timepickers', () => {
   });
 
   test('should have role="option" with aria-selected on clock numbers', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-0]');
+    const picker = page.locator('[data-id=timepicker-0]');
     const options = picker.locator('[role=option]');
 
     await expect(options.first()).toBeVisible();
@@ -72,7 +72,7 @@ test.describe('timepickers', () => {
   });
 
   test('should update clock face aria-label when switching modes', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-0]');
+    const picker = page.locator('[data-id=timepicker-0]');
     const clockFace = picker.locator('[role=listbox]');
 
     // Initially in hour mode
@@ -89,7 +89,7 @@ test.describe('timepickers', () => {
   });
 
   test('should switch mode by clicking digit selectors', async ({ page }) => {
-    const picker = page.locator('[data-cy=timepicker-1]');
+    const picker = page.locator('[data-id=timepicker-1]');
     const clockFace = picker.locator('[role=listbox]');
 
     // Click minutes digit selector

--- a/apps/example/playwright.config.ts
+++ b/apps/example/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     ['list'],
   ],
   use: {
+    testIdAttribute: 'data-id',
     baseURL,
     trace: 'on-first-retry',
     video: process.env.CI ? 'on-first-retry' : 'off',

--- a/apps/example/src/components/ComponentGroup.vue
+++ b/apps/example/src/components/ComponentGroup.vue
@@ -7,11 +7,11 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const { items, itemClass, getItemClass: getItemClassFn, getItemDataCy } = defineProps<{
+const { items, itemClass, getItemClass: getItemClassFn, getItemDataId } = defineProps<{
   items: T[];
   itemClass?: StaticClassProps | StaticClassProps[];
   getItemClass?: (item: T, index: number) => StaticClassProps;
-  getItemDataCy?: (item: T, index: number) => string;
+  getItemDataId?: (item: T, index: number) => string;
 }>();
 
 defineSlots<{
@@ -39,16 +39,16 @@ function getItemClass(item: T, index: number): StaticClassProps | StaticClassPro
   <h4
     v-if="$slots.title"
     class="text-h4 mb-6 mt-14"
-    v-bind="objectPick($attrs, ['data-cy'])"
+    v-bind="objectPick($attrs, ['data-id'])"
   >
     <slot name="title" />
   </h4>
-  <div v-bind="objectOmit($attrs, ['data-cy'])">
+  <div v-bind="objectOmit($attrs, ['data-id'])">
     <div
       v-for="(item, i) in items"
       :key="i"
       :class="getItemClass(item, i)"
-      :data-cy="getItemDataCy?.(item, i)"
+      :data-id="getItemDataId?.(item, i)"
     >
       <slot
         name="item"

--- a/apps/example/src/components/ComponentView.vue
+++ b/apps/example/src/components/ComponentView.vue
@@ -12,15 +12,15 @@ defineSlots<{
 </script>
 
 <template>
-  <div v-bind="objectOmit($attrs, ['data-cy'])">
+  <div v-bind="objectOmit($attrs, ['data-id'])">
     <h2
       class="text-h4 mb-6"
-      v-bind="objectPick($attrs, ['data-cy'])"
+      v-bind="objectPick($attrs, ['data-id'])"
     >
       <slot name="title" />
     </h2>
 
-    <div data-cy="content">
+    <div data-id="content">
       <slot />
     </div>
   </div>

--- a/apps/example/src/components/buttons/ButtonGroups.vue
+++ b/apps/example/src/components/buttons/ButtonGroups.vue
@@ -24,7 +24,7 @@ onBeforeMount(() => {
 
 <template>
   <ComponentGroup
-    data-cy="button-groups"
+    data-id="button-groups"
     class="grid gap-4 grid-rows-2 grid-cols-2 justify-items-start mb-14"
     :items="buttonGroups"
   >

--- a/apps/example/src/components/buttons/MultiToggleButtonGroups.vue
+++ b/apps/example/src/components/buttons/MultiToggleButtonGroups.vue
@@ -22,7 +22,7 @@ onBeforeMount(() => {
 <template>
   <ComponentGroup
     :items="multipleToggleButtons"
-    data-cy="multiple-toggleable-button-groups"
+    data-id="multiple-toggleable-button-groups"
     class="grid gap-4 grid-rows-2 grid-cols-2 justify-items-start"
   >
     <template #title>

--- a/apps/example/src/components/buttons/ToggleButtonGroups.vue
+++ b/apps/example/src/components/buttons/ToggleButtonGroups.vue
@@ -28,7 +28,7 @@ onBeforeMount(() => {
   <ComponentGroup
     :items="toggleButtons"
     class="grid gap-4 grid-rows-2 grid-cols-2 justify-items-start mb-14"
-    data-cy="toggleable-button-groups"
+    data-id="toggleable-button-groups"
   >
     <template #title>
       Toggleable Button Groups

--- a/apps/example/src/views/AccordionView.vue
+++ b/apps/example/src/views/AccordionView.vue
@@ -21,14 +21,14 @@ const accordions = ref<AccordionItem[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="accordions">
+  <ComponentView data-id="accordions">
     <template #title>
       Accordions
     </template>
 
     <div
       class="grid gap-4 grid-cols-2 mb-14"
-      data-cy="accordions-wrapper"
+      data-id="accordions-wrapper"
     >
       <template
         v-for="(accordion, i) in accordions"
@@ -36,7 +36,7 @@ const accordions = ref<AccordionItem[]>([
       >
         <div
           class="flex flex-col gap-3"
-          :data-cy="`wrapper-${i}`"
+          :data-id="`wrapper-${i}`"
         >
           <div>
             {{ accordion.label }}
@@ -44,7 +44,7 @@ const accordions = ref<AccordionItem[]>([
           <RuiAccordions
             v-model="accordion.modelValue"
             v-bind="accordion"
-            data-cy="accordions"
+            data-id="accordions"
           >
             <RuiAccordion header-class="py-4 border-y border-default">
               <template #header>

--- a/apps/example/src/views/AlertView.vue
+++ b/apps/example/src/views/AlertView.vue
@@ -42,7 +42,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="alerts">
+  <ComponentView data-id="alerts">
     <template #title>
       Alerts
     </template>

--- a/apps/example/src/views/BadgeView.vue
+++ b/apps/example/src/views/BadgeView.vue
@@ -58,7 +58,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="badges">
+  <ComponentView data-id="badges">
     <template #title>
       Badges
     </template>
@@ -71,7 +71,7 @@ onBeforeMount(() => {
       >
         <RuiBadge
           v-bind="badge"
-          :data-cy="`badge-${i}`"
+          :data-id="`badge-${i}`"
         >
           <RuiButton @click="badge.modelValue = !badge.modelValue">
             Badge

--- a/apps/example/src/views/BottomSheetView.vue
+++ b/apps/example/src/views/BottomSheetView.vue
@@ -19,7 +19,7 @@ const bottomSheets = ref<BottomSheetData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="bottom-sheets">
+  <ComponentView data-id="bottom-sheets">
     <template #title>
       Bottom Sheets
     </template>
@@ -30,11 +30,11 @@ const bottomSheets = ref<BottomSheetData[]>([
         :key="i"
         v-bind="bottomSheet"
         width="900px"
-        :data-cy="`bottom-sheet-${i}`"
+        :data-id="`bottom-sheet-${i}`"
       >
         <template #activator="{ attrs }">
           <RuiButton
-            data-cy="activator"
+            data-id="activator"
             v-bind="attrs"
           >
             {{ bottomSheet.label }}
@@ -57,7 +57,7 @@ const bottomSheets = ref<BottomSheetData[]>([
               <div class="border-t border-default py-4">
                 <div class="flex gap-2 w-full justify-end">
                   <RuiButton
-                    data-cy="close"
+                    data-id="close"
                     variant="outlined"
                     color="primary"
                     @click="close()"

--- a/apps/example/src/views/BreakpointView.vue
+++ b/apps/example/src/views/BreakpointView.vue
@@ -58,7 +58,7 @@ const groups = computed<{ name: string; value: string | number | boolean }[][]>(
 </script>
 
 <template>
-  <ComponentView data-cy="breakpoint">
+  <ComponentView data-id="breakpoint">
     <template #title>
       Breakpoint
     </template>

--- a/apps/example/src/views/ButtonView.vue
+++ b/apps/example/src/views/ButtonView.vue
@@ -7,7 +7,7 @@ import ComponentView from '@/components/ComponentView.vue';
 </script>
 
 <template>
-  <ComponentView data-cy="buttons">
+  <ComponentView data-id="buttons">
     <template #title>
       Buttons
     </template>

--- a/apps/example/src/views/CalendarView.vue
+++ b/apps/example/src/views/CalendarView.vue
@@ -14,7 +14,7 @@ const calendars = ref<CalendarData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="calendars">
+  <ComponentView data-id="calendars">
     <template #title>
       Calendar
     </template>

--- a/apps/example/src/views/CardView.vue
+++ b/apps/example/src/views/CardView.vue
@@ -494,7 +494,7 @@ const sections = ref<CardData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="cards">
+  <ComponentView data-id="cards">
     <template #title>
       Cards
     </template>
@@ -520,7 +520,7 @@ const sections = ref<CardData[]>([
                 'actions',
               ])
             "
-            :data-cy="`card-${i}-${j}`"
+            :data-id="`card-${i}-${j}`"
           >
             <template
               v-if="card.image"
@@ -574,7 +574,7 @@ const sections = ref<CardData[]>([
                 v-for="(action, k) in card.actions"
                 v-bind="objectOmit(action, ['clicks', 'text'])"
                 :key="k"
-                :data-cy="`card-action-${k}`"
+                :data-id="`card-action-${k}`"
                 @click="action.clicks++"
               >
                 {{ action.text }}

--- a/apps/example/src/views/CheckboxView.vue
+++ b/apps/example/src/views/CheckboxView.vue
@@ -52,7 +52,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="checkboxes">
+  <ComponentView data-id="checkboxes">
     <template #title>
       Checkboxes
     </template>

--- a/apps/example/src/views/ChipView.vue
+++ b/apps/example/src/views/ChipView.vue
@@ -61,7 +61,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="chips">
+  <ComponentView data-id="chips">
     <template #title>
       Chips
     </template>
@@ -72,7 +72,7 @@ onBeforeMount(() => {
     >
       <template #item="{ item, index }">
         <RuiChip
-          :data-cy="`chip-${index}`"
+          :data-id="`chip-${index}`"
           v-bind="item"
           @click:close="onRemove(index)"
         >
@@ -86,7 +86,7 @@ onBeforeMount(() => {
 
     <ComponentGroup
       :items="chips"
-      data-cy="chip"
+      data-id="chip"
       class="grid gap-6 grid-cols-7"
     >
       <template #title>
@@ -94,7 +94,7 @@ onBeforeMount(() => {
       </template>
       <template #item="{ item, index }">
         <RuiChip
-          :data-cy="`pre-chip-${index}`"
+          :data-id="`pre-chip-${index}`"
           v-bind="item"
           @click:close="onRemove(`pre-${index}`)"
         >

--- a/apps/example/src/views/ColorPickerView.vue
+++ b/apps/example/src/views/ColorPickerView.vue
@@ -13,7 +13,7 @@ const colorPickers = ref<ColorPickerItem[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="color-pickers">
+  <ComponentView data-id="color-pickers">
     <template #title>
       Color Pickers
     </template>
@@ -26,7 +26,7 @@ const colorPickers = ref<ColorPickerItem[]>([
         <RuiCard class="mb-2">
           <RuiColorPicker
             v-model="item.modelValue"
-            :data-cy="`color-picker-${i}`"
+            :data-id="`color-picker-${i}`"
           />
         </RuiCard>
         Selected value: {{ item.modelValue }}

--- a/apps/example/src/views/DateTimePickerView.vue
+++ b/apps/example/src/views/DateTimePickerView.vue
@@ -12,7 +12,7 @@ const timePickers = ref<RuiDateTimePickerProps[]>([{
 </script>
 
 <template>
-  <ComponentView data-cy="timepickers">
+  <ComponentView data-id="timepickers">
     <template #title>
       DateTime Pickers
     </template>

--- a/apps/example/src/views/DialogView.vue
+++ b/apps/example/src/views/DialogView.vue
@@ -19,7 +19,7 @@ const dialogs = ref<DialogData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="dialogs">
+  <ComponentView data-id="dialogs">
     <template #title>
       Dialogs
     </template>
@@ -30,11 +30,11 @@ const dialogs = ref<DialogData[]>([
         :key="i"
         v-bind="dialog"
         width="900px"
-        :data-cy="`dialog-${i}`"
+        :data-id="`dialog-${i}`"
       >
         <template #activator="{ attrs }">
           <RuiButton
-            data-cy="activator"
+            data-id="activator"
             v-bind="attrs"
           >
             {{ dialog.label }}
@@ -57,7 +57,7 @@ const dialogs = ref<DialogData[]>([
               <div class="border-t border-default py-4">
                 <div class="flex gap-2 w-full justify-end">
                   <RuiButton
-                    data-cy="close"
+                    data-id="close"
                     variant="outlined"
                     color="primary"
                     @click="close()"

--- a/apps/example/src/views/DividerView.vue
+++ b/apps/example/src/views/DividerView.vue
@@ -4,7 +4,7 @@ import ComponentView from '@/components/ComponentView.vue';
 </script>
 
 <template>
-  <ComponentView data-cy="dividers">
+  <ComponentView data-id="dividers">
     <template #title>
       Dividers
     </template>
@@ -16,7 +16,7 @@ import ComponentView from '@/components/ComponentView.vue';
         </h3>
         <div
           class="p-4 border rounded"
-          data-cy="divider-horizontal"
+          data-id="divider-horizontal"
         >
           <p>Content above</p>
           <RuiDivider class="my-4" />
@@ -30,7 +30,7 @@ import ComponentView from '@/components/ComponentView.vue';
         </h3>
         <div
           class="flex items-center gap-4 p-4 border rounded h-20"
-          data-cy="divider-vertical"
+          data-id="divider-vertical"
         >
           <span>Left</span>
           <RuiDivider

--- a/apps/example/src/views/IconView.vue
+++ b/apps/example/src/views/IconView.vue
@@ -19,7 +19,7 @@ const logos = ref<(LogoProps & { name: string })[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="icons">
+  <ComponentView data-id="icons">
     <template #title>
       Icons
     </template>
@@ -34,7 +34,7 @@ const logos = ref<(LogoProps & { name: string })[]>([
 
     <h2
       class="text-h4 mb-6"
-      data-cy="logos"
+      data-id="logos"
     >
       rotki Logo
     </h2>

--- a/apps/example/src/views/LoaderView.vue
+++ b/apps/example/src/views/LoaderView.vue
@@ -35,7 +35,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="skeleton-loader">
+  <ComponentView data-id="skeleton-loader">
     <template #title>
       Skeleton Loader
     </template>

--- a/apps/example/src/views/LogoView.vue
+++ b/apps/example/src/views/LogoView.vue
@@ -4,7 +4,7 @@ import ComponentView from '@/components/ComponentView.vue';
 </script>
 
 <template>
-  <ComponentView data-cy="logos">
+  <ComponentView data-id="logos">
     <template #title>
       Logos
     </template>
@@ -14,7 +14,7 @@ import ComponentView from '@/components/ComponentView.vue';
         <h3 class="text-subtitle-1 mb-2">
           Default (Fallback)
         </h3>
-        <div data-cy="logo-default">
+        <div data-id="logo-default">
           <RuiLogo />
         </div>
       </div>
@@ -23,7 +23,7 @@ import ComponentView from '@/components/ComponentView.vue';
         <h3 class="text-subtitle-1 mb-2">
           With Text
         </h3>
-        <div data-cy="logo-text">
+        <div data-id="logo-text">
           <RuiLogo text />
         </div>
       </div>
@@ -32,7 +32,7 @@ import ComponentView from '@/components/ComponentView.vue';
         <h3 class="text-subtitle-1 mb-2">
           Custom Size (5rem)
         </h3>
-        <div data-cy="logo-size">
+        <div data-id="logo-size">
           <RuiLogo :size="5" />
         </div>
       </div>
@@ -41,7 +41,7 @@ import ComponentView from '@/components/ComponentView.vue';
         <h3 class="text-subtitle-1 mb-2">
           Small Size (1.5rem)
         </h3>
-        <div data-cy="logo-small">
+        <div data-id="logo-small">
           <RuiLogo :size="1.5" />
         </div>
       </div>

--- a/apps/example/src/views/MenuView.vue
+++ b/apps/example/src/views/MenuView.vue
@@ -125,7 +125,7 @@ const menus = ref<SimpleMenu[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="menus">
+  <ComponentView data-id="menus">
     <template #title>
       Menus
     </template>
@@ -138,14 +138,14 @@ const menus = ref<SimpleMenu[]>([
       >
         <RuiMenu
           v-bind="objectOmit(menu, ['buttonColor'])"
-          :data-cy="`menu-${i}`"
+          :data-id="`menu-${i}`"
           :open-delay="10"
         >
           <template #activator="{ attrs, disabled }">
             <RuiButton
               :color="menu.buttonColor"
               :disabled="disabled"
-              v-bind="{ ...attrs, 'data-cy': 'activator' }"
+              v-bind="{ ...attrs, 'data-id': 'activator' }"
             >
               {{ menu.buttonText }}
             </RuiButton>

--- a/apps/example/src/views/NavigationDrawerView.vue
+++ b/apps/example/src/views/NavigationDrawerView.vue
@@ -23,7 +23,7 @@ const navigationDrawers = ref<NavigationDrawerItem[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="navigation-drawers">
+  <ComponentView data-id="navigation-drawers">
     <template #title>
       Navigation Drawers
     </template>
@@ -32,7 +32,7 @@ const navigationDrawers = ref<NavigationDrawerItem[]>([
       <div
         v-for="(navigationDrawer, i) in navigationDrawers"
         :key="i"
-        :data-cy="`navigation-drawer-${i}`"
+        :data-id="`navigation-drawer-${i}`"
       >
         <RuiNavigationDrawer
           v-bind="navigationDrawer"
@@ -42,7 +42,7 @@ const navigationDrawers = ref<NavigationDrawerItem[]>([
           <template #activator="{ attrs }">
             <RuiButton
               color="primary"
-              data-cy="activator"
+              data-id="activator"
               v-bind="attrs"
             >
               {{ navigationDrawer.label }}

--- a/apps/example/src/views/NotificationView.vue
+++ b/apps/example/src/views/NotificationView.vue
@@ -16,14 +16,14 @@ const options = ['light', 'dark'];
 </script>
 
 <template>
-  <ComponentView data-cy="notification">
+  <ComponentView data-id="notification">
     <template #title>
       Notification
     </template>
 
     <div>
       <RuiButton
-        data-cy="visibility-toggle"
+        data-id="visibility-toggle"
         @click="visible = !visible"
       >
         {{ visible ? 'Hide' : 'Show' }}
@@ -34,7 +34,7 @@ const options = ['light', 'dark'];
         variant="outlined"
         label="timeout"
         class="mt-4"
-        data-cy="timeout"
+        data-id="timeout"
       />
       <RuiMenuSelect
         v-model="theme"
@@ -42,7 +42,7 @@ const options = ['light', 'dark'];
         label="theme"
         variant="outlined"
         clearable
-        data-cy="menu"
+        data-id="menu"
       />
     </div>
 
@@ -53,7 +53,7 @@ const options = ['light', 'dark'];
     >
       <div
         class="m-4"
-        data-cy="notification-content"
+        data-id="notification-content"
       >
         This is a notification
       </div>

--- a/apps/example/src/views/ProgressView.vue
+++ b/apps/example/src/views/ProgressView.vue
@@ -139,7 +139,7 @@ const progress = ref<ProgressProps[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="progress">
+  <ComponentView data-id="progress">
     <template #title>
       Progress
     </template>

--- a/apps/example/src/views/RadioView.vue
+++ b/apps/example/src/views/RadioView.vue
@@ -257,14 +257,14 @@ const customTypeRadioGroup = ref<
 </script>
 
 <template>
-  <ComponentView data-cy="radio-buttons">
+  <ComponentView data-id="radio-buttons">
     <template #title>
       Radio Buttons
     </template>
 
     <div
       class="grid gap-4 grid-cols-6 mb-14"
-      data-cy="radio-wrapper"
+      data-id="radio-wrapper"
     >
       <RuiRadio
         v-for="(radio, j) in radios"
@@ -282,13 +282,13 @@ const customTypeRadioGroup = ref<
     </div>
     <h2
       class="text-h4 mb-6"
-      data-cy="radio-group-buttons"
+      data-id="radio-group-buttons"
     >
       Radio Groups
     </h2>
     <div
       class="grid gap-8"
-      data-cy="radio-group-wrapper"
+      data-id="radio-group-wrapper"
     >
       <RuiRadioGroup
         v-for="(radioGroup, i) in radioGroups"

--- a/apps/example/src/views/SimpleSelectView.vue
+++ b/apps/example/src/views/SimpleSelectView.vue
@@ -14,7 +14,7 @@ const numberValue = ref<number>(10);
 </script>
 
 <template>
-  <ComponentView data-cy="simple-selects">
+  <ComponentView data-id="simple-selects">
     <template #title>
       Simple Selects
     </template>
@@ -28,7 +28,7 @@ const numberValue = ref<number>(10);
           v-model="defaultValue"
           :options="stringOptions"
           label="Default select"
-          data-cy="ss-default"
+          data-id="ss-default"
         />
       </div>
 
@@ -41,7 +41,7 @@ const numberValue = ref<number>(10);
           :options="stringOptions"
           label="Outlined select"
           variant="outlined"
-          data-cy="ss-outlined"
+          data-id="ss-outlined"
         />
       </div>
 
@@ -54,7 +54,7 @@ const numberValue = ref<number>(10);
           :options="stringOptions"
           label="Disabled select"
           disabled
-          data-cy="ss-disabled"
+          data-id="ss-disabled"
         />
       </div>
 
@@ -68,7 +68,7 @@ const numberValue = ref<number>(10);
           label="Disabled outlined select"
           disabled
           variant="outlined"
-          data-cy="ss-disabled-outlined"
+          data-id="ss-disabled-outlined"
         />
       </div>
 
@@ -81,7 +81,7 @@ const numberValue = ref<number>(10);
           :options="stringOptions"
           label="Country select"
           name="country"
-          data-cy="ss-named"
+          data-id="ss-named"
         />
       </div>
 
@@ -93,7 +93,7 @@ const numberValue = ref<number>(10);
           v-model="numberValue"
           :options="numberOptions"
           label="Number select"
-          data-cy="ss-number-options"
+          data-id="ss-number-options"
         />
       </div>
     </div>

--- a/apps/example/src/views/SliderView.vue
+++ b/apps/example/src/views/SliderView.vue
@@ -62,7 +62,7 @@ const textFields = ref<SliderData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="sliders">
+  <ComponentView data-id="sliders">
     <template #title>
       Sliders
     </template>
@@ -73,7 +73,7 @@ const textFields = ref<SliderData[]>([
         :key="i"
         v-model="field.value"
         :label="field.label"
-        :data-cy="`slider-${i}`"
+        :data-id="`slider-${i}`"
         v-bind="field"
       />
     </div>

--- a/apps/example/src/views/StepperView.vue
+++ b/apps/example/src/views/StepperView.vue
@@ -347,7 +347,7 @@ const footerSteppers = ref<FooterStepperData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="steppers">
+  <ComponentView data-id="steppers">
     <template #title>
       Steppers
     </template>
@@ -355,13 +355,13 @@ const footerSteppers = ref<FooterStepperData[]>([
     <RuiStepper
       v-for="(stepper, i) in steppers"
       :key="i"
-      :data-cy="`stepper-${i}`"
+      :data-id="`stepper-${i}`"
       class="mb-6"
       v-bind="stepper"
     />
     <h2
       class="text-h4 mb-6 mt-14"
-      data-cy="footer-steppers"
+      data-id="footer-steppers"
     >
       Footer Steppers
     </h2>
@@ -369,7 +369,7 @@ const footerSteppers = ref<FooterStepperData[]>([
       v-for="(stepper, i) in footerSteppers"
       :key="i"
       v-model="stepper.value"
-      :data-cy="`footer-stepper-${i}`"
+      :data-id="`footer-stepper-${i}`"
       class="mb-6"
       v-bind="stepper"
     />

--- a/apps/example/src/views/SwitchView.vue
+++ b/apps/example/src/views/SwitchView.vue
@@ -44,7 +44,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="switches">
+  <ComponentView data-id="switches">
     <template #title>
       Switches
     </template>

--- a/apps/example/src/views/TabView.vue
+++ b/apps/example/src/views/TabView.vue
@@ -46,7 +46,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="tabs">
+  <ComponentView data-id="tabs">
     <template #title>
       Tabs
     </template>
@@ -55,13 +55,13 @@ onBeforeMount(() => {
       :items="tabs"
       item-class="flex mb-6 gap-x-6"
       :get-item-class="item => item.vertical ? 'flex-row' : 'flex-col'"
-      :get-item-data-cy="(_, i) => `wrapper-${i}`"
+      :get-item-data-id="(_, i) => `wrapper-${i}`"
     >
       <template #item="{ item }">
         <RuiTabs
           v-bind="item"
           v-model="item.modelValue"
-          data-cy="tabs"
+          data-id="tabs"
         >
           <RuiTab>
             <template #prepend>
@@ -87,7 +87,7 @@ onBeforeMount(() => {
         </RuiTabs>
         <RuiTabItems
           v-model="item.modelValue"
-          data-cy="tab-items"
+          data-id="tab-items"
         >
           <RuiTabItem
             v-for="n in 4"

--- a/apps/example/src/views/TextAreaView.vue
+++ b/apps/example/src/views/TextAreaView.vue
@@ -225,7 +225,7 @@ const textAreas = ref<TextAreaData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="text-fields">
+  <ComponentView data-id="text-fields">
     <template #title>
       Text Fields
     </template>

--- a/apps/example/src/views/TextFieldView.vue
+++ b/apps/example/src/views/TextFieldView.vue
@@ -276,7 +276,7 @@ const revealableTextFields = ref<RevealableTextFieldData[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="text-fields">
+  <ComponentView data-id="text-fields">
     <template #title>
       Text Fields
     </template>
@@ -306,7 +306,7 @@ const revealableTextFields = ref<RevealableTextFieldData[]>([
     </div>
     <h2
       class="text-h4 mb-6 mt-14"
-      data-cy="text-fields"
+      data-id="text-fields"
     >
       Revealable Text Fields
     </h2>

--- a/apps/example/src/views/TimePickerView.vue
+++ b/apps/example/src/views/TimePickerView.vue
@@ -18,7 +18,7 @@ const timePickers = ref<RuiTimePickerProps[]>([
 </script>
 
 <template>
-  <ComponentView data-cy="timepickers">
+  <ComponentView data-id="timepickers">
     <template #title>
       Time Pickers
     </template>
@@ -27,7 +27,7 @@ const timePickers = ref<RuiTimePickerProps[]>([
         v-for="(field, i) in timePickers"
         :key="i"
         v-model="field.modelValue"
-        :data-cy="`timepicker-${i}`"
+        :data-id="`timepicker-${i}`"
         v-bind="objectOmit(field, ['modelValue'])"
       />
     </div>

--- a/apps/example/src/views/TooltipView.vue
+++ b/apps/example/src/views/TooltipView.vue
@@ -84,7 +84,7 @@ onBeforeMount(() => {
 </script>
 
 <template>
-  <ComponentView data-cy="tooltips">
+  <ComponentView data-id="tooltips">
     <template #title>
       Tooltips
     </template>
@@ -96,7 +96,7 @@ onBeforeMount(() => {
       <template #item="{ item, index }">
         <RuiTooltip
           v-bind="objectOmit(item, ['buttonColor'])"
-          :data-cy="`tooltip-${index}`"
+          :data-id="`tooltip-${index}`"
         >
           <template #activator>
             <RuiButton
@@ -114,7 +114,7 @@ onBeforeMount(() => {
     <ComponentGroup
       class="flex space-x-4"
       :items="tooltips.slice(0, 4)"
-      data-cy="tooltips"
+      data-id="tooltips"
     >
       <template #title>
         Full width content
@@ -125,7 +125,7 @@ onBeforeMount(() => {
           :key="index"
           v-bind="objectOmit(item, ['buttonColor'])"
           class="w-full"
-          :data-cy="`tooltip-full-${index}`"
+          :data-id="`tooltip-full-${index}`"
         >
           <template #activator>
             <RuiButton

--- a/apps/example/src/views/auto-completes/AutoCompleteAdvancedView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteAdvancedView.vue
@@ -26,7 +26,7 @@ const customBlurValue = ref<string>();
 </script>
 
 <template>
-  <div data-cy="auto-completes-advanced">
+  <div data-id="auto-completes-advanced">
     <h2 class="text-2xl font-bold mb-6">
       Advanced
     </h2>
@@ -40,7 +40,7 @@ const customBlurValue = ref<string>();
           key-attr="id"
           text-attr="label"
           label="Return Object"
-          data-cy="ac-adv-return-object"
+          data-id="ac-adv-return-object"
         />
       </div>
 
@@ -52,7 +52,7 @@ const customBlurValue = ref<string>();
           key-attr="id"
           text-attr="label"
           label="Return Object (pre-selected)"
-          data-cy="ac-adv-return-object-pre"
+          data-id="ac-adv-return-object-pre"
         />
       </div>
 
@@ -62,7 +62,7 @@ const customBlurValue = ref<string>();
           variant="filled"
           :options="primitiveOptions"
           label="Filled Variant"
-          data-cy="ac-adv-filled"
+          data-id="ac-adv-filled"
         />
       </div>
 
@@ -72,7 +72,7 @@ const customBlurValue = ref<string>();
           variant="outlined"
           :options="primitiveOptions"
           label="Outlined (comparison)"
-          data-cy="ac-adv-outlined"
+          data-id="ac-adv-outlined"
         />
       </div>
 
@@ -83,10 +83,10 @@ const customBlurValue = ref<string>();
           key-attr="id"
           text-attr="label"
           label="Falsy Value (0)"
-          data-cy="ac-adv-falsy"
+          data-id="ac-adv-falsy"
         />
         <div
-          data-cy="ac-adv-falsy-display"
+          data-id="ac-adv-falsy-display"
           class="mt-2 text-sm"
         >
           Model: {{ falsyValue === undefined ? 'undefined' : falsyValue }}
@@ -99,10 +99,10 @@ const customBlurValue = ref<string>();
           v-model:search-input="searchInputText"
           :options="primitiveOptions"
           label="Search Input Model"
-          data-cy="ac-adv-search-input"
+          data-id="ac-adv-search-input"
         />
         <div
-          data-cy="ac-adv-search-display"
+          data-id="ac-adv-search-display"
           class="mt-2 text-sm"
         >
           Search: "{{ searchInputText }}"
@@ -116,7 +116,7 @@ const customBlurValue = ref<string>();
           clearable
           :options="primitiveOptions"
           label="Multi Clear"
-          data-cy="ac-adv-multi-clear"
+          data-id="ac-adv-multi-clear"
         />
       </div>
 
@@ -126,7 +126,7 @@ const customBlurValue = ref<string>();
           custom-value
           :options="primitiveOptions"
           label="Custom Value on Blur"
-          data-cy="ac-adv-custom-blur"
+          data-id="ac-adv-custom-blur"
         />
       </div>
     </div>

--- a/apps/example/src/views/auto-completes/AutoCompleteBasicView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteBasicView.vue
@@ -18,7 +18,7 @@ const hintValue = ref<number>();
 </script>
 
 <template>
-  <div data-cy="auto-completes-basic">
+  <div data-id="auto-completes-basic">
     <h2 class="text-2xl font-bold mb-6">
       Basic
     </h2>
@@ -32,7 +32,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Default"
-          data-cy="ac-basic-default"
+          data-id="ac-basic-default"
         />
       </div>
 
@@ -45,7 +45,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Outlined"
-          data-cy="ac-basic-outlined"
+          data-id="ac-basic-outlined"
         />
       </div>
 
@@ -58,7 +58,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Dense"
-          data-cy="ac-basic-dense"
+          data-id="ac-basic-dense"
         />
       </div>
 
@@ -70,7 +70,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Disabled"
-          data-cy="ac-basic-disabled"
+          data-id="ac-basic-disabled"
         />
       </div>
 
@@ -83,7 +83,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Disabled Outlined"
-          data-cy="ac-basic-disabled-outlined"
+          data-id="ac-basic-disabled-outlined"
         />
       </div>
 
@@ -95,7 +95,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Loading"
-          data-cy="ac-basic-loading"
+          data-id="ac-basic-loading"
         />
       </div>
 
@@ -107,7 +107,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="With Error"
-          data-cy="ac-basic-error"
+          data-id="ac-basic-error"
         />
       </div>
 
@@ -119,7 +119,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="With Success"
-          data-cy="ac-basic-success"
+          data-id="ac-basic-success"
         />
       </div>
 
@@ -132,7 +132,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Hide Details"
-          data-cy="ac-basic-hide-details"
+          data-id="ac-basic-hide-details"
         />
       </div>
 
@@ -145,7 +145,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           label="Required"
-          data-cy="ac-basic-required"
+          data-id="ac-basic-required"
         />
       </div>
 
@@ -157,7 +157,7 @@ const hintValue = ref<number>();
           text-attr="label"
           hint="Select your country"
           label="With Hint"
-          data-cy="ac-basic-hint"
+          data-id="ac-basic-hint"
         />
       </div>
     </div>

--- a/apps/example/src/views/auto-completes/AutoCompleteCustomView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteCustomView.vue
@@ -18,7 +18,7 @@ function getDisplayText(value?: SelectOption | SelectOption[]): string {
 </script>
 
 <template>
-  <div data-cy="auto-completes-custom">
+  <div data-id="auto-completes-custom">
     <h2 class="text-2xl font-bold mb-6">
       Custom Slots
     </h2>
@@ -31,14 +31,14 @@ function getDisplayText(value?: SelectOption | SelectOption[]): string {
           key-attr="id"
           text-attr="label"
           label="Custom Activator"
-          data-cy="ac-custom-activator"
+          data-id="ac-custom-activator"
         >
           <template #activator="{ attrs, disabled, open, value }">
             <RuiButton
               class="!rounded-md border"
               variant="list"
               :disabled="disabled"
-              v-bind="{ ...attrs, 'data-cy': 'activator' }"
+              v-bind="{ ...attrs, 'data-id': 'activator' }"
             >
               {{ getDisplayText(value) }}
               <template #append>
@@ -62,7 +62,7 @@ function getDisplayText(value?: SelectOption | SelectOption[]): string {
           text-attr="label"
           :append-width="1.5"
           label="Custom Item"
-          data-cy="ac-custom-item"
+          data-id="ac-custom-item"
         >
           <template #item.append="{ active }">
             <RuiIcon

--- a/apps/example/src/views/auto-completes/AutoCompleteKeyboardView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteKeyboardView.vue
@@ -17,7 +17,7 @@ function onFormSubmit(): void {
 </script>
 
 <template>
-  <div data-cy="auto-completes-keyboard">
+  <div data-id="auto-completes-keyboard">
     <h2 class="text-2xl font-bold mb-6">
       Keyboard
     </h2>
@@ -28,7 +28,7 @@ function onFormSubmit(): void {
           v-model="multiNonChipsValue"
           :options="primitiveOptions"
           label="Multi Non-Chips (Backspace)"
-          data-cy="ac-kb-multi-no-chips"
+          data-id="ac-kb-multi-no-chips"
         />
       </div>
 
@@ -38,7 +38,7 @@ function onFormSubmit(): void {
           chips
           :options="primitiveOptions"
           label="Multi Chips (Backspace)"
-          data-cy="ac-kb-multi-chips"
+          data-id="ac-kb-multi-chips"
         />
       </div>
 
@@ -48,7 +48,7 @@ function onFormSubmit(): void {
           chips
           :options="primitiveOptions"
           label="Chip Navigation (Arrows)"
-          data-cy="ac-kb-chip-nav"
+          data-id="ac-kb-chip-nav"
         />
       </div>
 
@@ -57,24 +57,24 @@ function onFormSubmit(): void {
           v-model="escapeValue"
           :options="primitiveOptions"
           label="Escape to Close"
-          data-cy="ac-kb-escape"
+          data-id="ac-kb-escape"
         />
       </div>
 
       <div class="py-4">
         <form
-          data-cy="ac-kb-form"
+          data-id="ac-kb-form"
           @submit.prevent="onFormSubmit()"
         >
           <RuiAutoComplete
             v-model="formValue"
             :options="primitiveOptions"
             label="Form Submit (Enter)"
-            data-cy="ac-kb-form-submit"
+            data-id="ac-kb-form-submit"
           />
           <div
             v-if="formSubmitted"
-            data-cy="form-submitted"
+            data-id="form-submitted"
             class="mt-2 text-green-600"
           >
             Form submitted!
@@ -87,7 +87,7 @@ function onFormSubmit(): void {
           v-model="reopenValue"
           :options="primitiveOptions"
           label="Re-open Highlight"
-          data-cy="ac-kb-reopen"
+          data-id="ac-kb-reopen"
         />
       </div>
     </div>

--- a/apps/example/src/views/auto-completes/AutoCompleteReadonlyView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteReadonlyView.vue
@@ -9,7 +9,7 @@ const readonlyMulti = ref<string[]>(['Lorem', 'Ipsum']);
 </script>
 
 <template>
-  <div data-cy="auto-completes-readonly">
+  <div data-id="auto-completes-readonly">
     <h2 class="text-2xl font-bold mb-6">
       Read-only
     </h2>
@@ -21,7 +21,7 @@ const readonlyMulti = ref<string[]>(['Lorem', 'Ipsum']);
           read-only
           :options="primitiveOptions"
           label="Read-only Default"
-          data-cy="ac-readonly-default"
+          data-id="ac-readonly-default"
         />
       </div>
 
@@ -32,7 +32,7 @@ const readonlyMulti = ref<string[]>(['Lorem', 'Ipsum']);
           variant="outlined"
           :options="primitiveOptions"
           label="Read-only Outlined"
-          data-cy="ac-readonly-outlined"
+          data-id="ac-readonly-outlined"
         />
       </div>
 
@@ -43,7 +43,7 @@ const readonlyMulti = ref<string[]>(['Lorem', 'Ipsum']);
           chips
           :options="primitiveOptions"
           label="Read-only Multi"
-          data-cy="ac-readonly-multi"
+          data-id="ac-readonly-multi"
         />
       </div>
     </div>

--- a/apps/example/src/views/auto-completes/AutoCompleteSearchView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteSearchView.vue
@@ -15,7 +15,7 @@ const placeholderValue = ref<string>();
 </script>
 
 <template>
-  <div data-cy="auto-completes-search">
+  <div data-id="auto-completes-search">
     <h2 class="text-2xl font-bold mb-6">
       Search
     </h2>
@@ -28,7 +28,7 @@ const placeholderValue = ref<string>();
           key-attr="id"
           text-attr="label"
           label="Filter (type to search)"
-          data-cy="ac-search-filter"
+          data-id="ac-search-filter"
         />
       </div>
 
@@ -38,7 +38,7 @@ const placeholderValue = ref<string>();
           no-filter
           :options="primitiveOptions"
           label="No Filter"
-          data-cy="ac-search-no-filter"
+          data-id="ac-search-no-filter"
         />
       </div>
 
@@ -48,7 +48,7 @@ const placeholderValue = ref<string>();
           custom-value
           :options="primitiveOptions"
           label="Custom Value"
-          data-cy="ac-search-custom-value"
+          data-id="ac-search-custom-value"
         />
       </div>
 
@@ -59,7 +59,7 @@ const placeholderValue = ref<string>();
           hide-custom-value
           :options="primitiveOptions"
           label="Custom Value (hidden)"
-          data-cy="ac-search-custom-hide"
+          data-id="ac-search-custom-hide"
         />
       </div>
 
@@ -69,7 +69,7 @@ const placeholderValue = ref<string>();
           :options="primitiveOptions"
           no-data-text="Nothing found"
           label="No Data Text"
-          data-cy="ac-search-no-data"
+          data-id="ac-search-no-data"
         />
       </div>
 
@@ -79,7 +79,7 @@ const placeholderValue = ref<string>();
           hide-no-data
           :options="primitiveOptions"
           label="Hide No Data"
-          data-cy="ac-search-hide-no-data"
+          data-id="ac-search-hide-no-data"
         />
       </div>
 
@@ -89,7 +89,7 @@ const placeholderValue = ref<string>();
           :options="primitiveOptions"
           placeholder="Type here..."
           label="With Placeholder"
-          data-cy="ac-search-placeholder"
+          data-id="ac-search-placeholder"
         />
       </div>
     </div>

--- a/apps/example/src/views/auto-completes/AutoCompleteSelectionView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteSelectionView.vue
@@ -12,7 +12,7 @@ const hideSelectedValue = ref<string[]>([]);
 </script>
 
 <template>
-  <div data-cy="auto-completes-selection">
+  <div data-id="auto-completes-selection">
     <h2 class="text-2xl font-bold mb-6">
       Selection
     </h2>
@@ -23,7 +23,7 @@ const hideSelectedValue = ref<string[]>([]);
           v-model="singleValue"
           :options="primitiveOptions"
           label="Single Select"
-          data-cy="ac-select-single"
+          data-id="ac-select-single"
         />
       </div>
 
@@ -33,7 +33,7 @@ const hideSelectedValue = ref<string[]>([]);
           clearable
           :options="primitiveOptions"
           label="Single Pre-selected"
-          data-cy="ac-select-single-preselected"
+          data-id="ac-select-single-preselected"
         />
       </div>
 
@@ -43,7 +43,7 @@ const hideSelectedValue = ref<string[]>([]);
           chips
           :options="primitiveOptions"
           label="Multi Select"
-          data-cy="ac-select-multi"
+          data-id="ac-select-multi"
         />
       </div>
 
@@ -53,7 +53,7 @@ const hideSelectedValue = ref<string[]>([]);
           chips
           :options="primitiveOptions"
           label="Multi Pre-selected"
-          data-cy="ac-select-multi-preselected"
+          data-id="ac-select-multi-preselected"
         />
       </div>
 
@@ -63,7 +63,7 @@ const hideSelectedValue = ref<string[]>([]);
           auto-select-first
           :options="primitiveOptions"
           label="Auto Select First"
-          data-cy="ac-select-auto-first"
+          data-id="ac-select-auto-first"
         />
       </div>
 
@@ -74,7 +74,7 @@ const hideSelectedValue = ref<string[]>([]);
           hide-selected
           :options="primitiveOptions"
           label="Hide Selected"
-          data-cy="ac-select-hide-selected"
+          data-id="ac-select-hide-selected"
         />
       </div>
     </div>

--- a/apps/example/src/views/auto-completes/index.vue
+++ b/apps/example/src/views/auto-completes/index.vue
@@ -49,9 +49,9 @@ const sections = [
 </script>
 
 <template>
-  <div data-cy="auto-completes-index">
+  <div data-id="auto-completes-index">
     <h2
-      data-cy="auto-completes"
+      data-id="auto-completes"
       class="text-2xl font-bold mb-6"
     >
       Auto Completes
@@ -67,7 +67,7 @@ const sections = [
         <RuiCard
           variant="outlined"
           class="h-full hover:border-primary transition-colors cursor-pointer"
-          :data-cy="`link-${section.route}`"
+          :data-id="`link-${section.route}`"
         >
           <template #header>
             <div class="flex items-center gap-2">

--- a/apps/example/src/views/data-tables/DataTableBasicView.vue
+++ b/apps/example/src/views/data-tables/DataTableBasicView.vue
@@ -8,7 +8,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
 </script>
 
 <template>
-  <div data-cy="data-tables-basic">
+  <div data-id="data-tables-basic">
     <h2 class="text-2xl font-bold mb-6">
       Basic Tables
     </h2>
@@ -17,7 +17,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
       <!-- With Column definitions -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-columns-defined"
+        data-id="table-columns-defined"
       >
         <h4>With Column definitions</h4>
         <RuiDataTable
@@ -25,7 +25,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           :cols="fixedColumns"
           row-attr="id"
           hide-default-footer
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -45,20 +45,20 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
       <!-- No Column definitions (auto-generated) -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-auto-columns"
+        data-id="table-auto-columns"
       >
         <h4>No Column definitions (auto-generated)</h4>
         <RuiDataTable
           :rows="fixedRows"
           row-attr="id"
-          data-cy="table"
+          data-id="table"
         />
       </div>
 
       <!-- Outlined -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-outlined"
+        data-id="table-outlined"
       >
         <h4>Outlined</h4>
         <RuiDataTable
@@ -66,7 +66,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           :cols="fixedColumns"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -86,7 +86,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
       <!-- Dense -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-dense"
+        data-id="table-dense"
       >
         <h4>Dense</h4>
         <RuiDataTable
@@ -95,7 +95,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           row-attr="id"
           outlined
           dense
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -115,7 +115,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
       <!-- Striped -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-striped"
+        data-id="table-striped"
       >
         <h4>Striped</h4>
         <RuiDataTable
@@ -124,7 +124,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           row-attr="id"
           outlined
           striped
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton

--- a/apps/example/src/views/data-tables/DataTableEmptyView.vue
+++ b/apps/example/src/views/data-tables/DataTableEmptyView.vue
@@ -8,7 +8,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
 </script>
 
 <template>
-  <div data-cy="data-tables-empty">
+  <div data-id="data-tables-empty">
     <h2 class="text-2xl font-bold mb-6">
       Empty &amp; Loading States
     </h2>
@@ -17,7 +17,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
       <!-- Empty table -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-empty"
+        data-id="table-empty"
       >
         <h4>Empty Table</h4>
         <RuiDataTable
@@ -30,14 +30,14 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           row-attr="id"
           outlined
           rounded="sm"
-          data-cy="table"
+          data-id="table"
         />
       </div>
 
       <!-- Empty table with action slot -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-empty-action"
+        data-id="table-empty-action"
       >
         <h4>Empty Table with Action</h4>
         <RuiDataTable
@@ -47,7 +47,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           row-attr="id"
           outlined
           rounded="md"
-          data-cy="table"
+          data-id="table"
         >
           <template #empty-description>
             <div class="flex space-x-1 items-center">
@@ -72,7 +72,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
       <!-- Loading without data -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-loading-empty"
+        data-id="table-loading-empty"
       >
         <h4>Loading without Data</h4>
         <RuiDataTable
@@ -82,14 +82,14 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           outlined
           rounded="lg"
           loading
-          data-cy="table"
+          data-id="table"
         />
       </div>
 
       <!-- Loading with data -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-loading-data"
+        data-id="table-loading-data"
       >
         <h4>Loading with Data</h4>
         <RuiDataTable
@@ -98,7 +98,7 @@ import { fixedColumns, fixedRows } from '@/data/table-configs';
           row-attr="id"
           outlined
           loading
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton

--- a/apps/example/src/views/data-tables/DataTableExpandableView.vue
+++ b/apps/example/src/views/data-tables/DataTableExpandableView.vue
@@ -29,7 +29,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
 </script>
 
 <template>
-  <div data-cy="data-tables-expandable">
+  <div data-id="data-tables-expandable">
     <h2 class="text-2xl font-bold mb-6">
       Expandable Rows
     </h2>
@@ -38,7 +38,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
       <!-- Multiple expandable -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-expandable-multiple"
+        data-id="table-expandable-multiple"
       >
         <h4>Multiple Expandable</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -51,7 +51,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
           row-attr="id"
           outlined
           sticky-header
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -66,7 +66,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
             </RuiButton>
           </template>
           <template #expanded-item>
-            <RuiCard data-cy="expanded-content">
+            <RuiCard data-id="expanded-content">
               <template #header>
                 Expanded content
               </template>
@@ -79,7 +79,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
       <!-- Single expandable -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-expandable-single"
+        data-id="table-expandable-single"
       >
         <h4>Single Expandable</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -92,7 +92,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
           row-attr="id"
           outlined
           single-expand
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -107,7 +107,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
             </RuiButton>
           </template>
           <template #expanded-item>
-            <RuiCard data-cy="expanded-content">
+            <RuiCard data-id="expanded-content">
               <template #header>
                 Expanded content
               </template>
@@ -120,7 +120,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
       <!-- Custom expand control -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-expandable-custom"
+        data-id="table-expandable-custom"
       >
         <h4>Custom Expand Control</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -133,7 +133,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
           row-attr="id"
           outlined
           single-expand
-          data-cy="table"
+          data-id="table"
         >
           <template #item.expand="{ row }">
             <RuiTableRowExpander
@@ -155,7 +155,7 @@ function toggleRow(row: BaseUser, expanded: ExtendedUser[]): void {
             </RuiButton>
           </template>
           <template #expanded-item>
-            <RuiCard data-cy="expanded-content">
+            <RuiCard data-id="expanded-content">
               <template #header>
                 Expanded content
               </template>

--- a/apps/example/src/views/data-tables/DataTableGroupingView.vue
+++ b/apps/example/src/views/data-tables/DataTableGroupingView.vue
@@ -41,7 +41,7 @@ function onCopyGroup(data: GroupData<ExtendedUser>): void {
 </script>
 
 <template>
-  <div data-cy="data-tables-grouping">
+  <div data-id="data-tables-grouping">
     <h2 class="text-2xl font-bold mb-6">
       Row Grouping
     </h2>
@@ -50,7 +50,7 @@ function onCopyGroup(data: GroupData<ExtendedUser>): void {
       <!-- Basic grouping -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-grouping-basic"
+        data-id="table-grouping-basic"
       >
         <h4>Basic Grouping</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -59,7 +59,7 @@ function onCopyGroup(data: GroupData<ExtendedUser>): void {
         <p
           v-if="lastCopiedGroup"
           class="text-sm text-rui-text-secondary"
-          data-cy="last-copied-group"
+          data-id="last-copied-group"
         >
           Last copied: {{ lastCopiedGroup }}
         </p>
@@ -70,7 +70,7 @@ function onCopyGroup(data: GroupData<ExtendedUser>): void {
           :cols="fixedColumns"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
           @copy:group="onCopyGroup($event)"
         >
           <template #item.action>
@@ -91,7 +91,7 @@ function onCopyGroup(data: GroupData<ExtendedUser>): void {
       <!-- Grouping with expand button at end -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-grouping-expand-end"
+        data-id="table-grouping-expand-end"
       >
         <h4>Grouping with Expand Button at End</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -106,7 +106,7 @@ function onCopyGroup(data: GroupData<ExtendedUser>): void {
           row-attr="id"
           outlined
           group-expand-button-position="end"
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton

--- a/apps/example/src/views/data-tables/DataTablePaginationView.vue
+++ b/apps/example/src/views/data-tables/DataTablePaginationView.vue
@@ -39,7 +39,7 @@ const paginationSticky = ref<TablePaginationData>({
 </script>
 
 <template>
-  <div data-cy="data-tables-pagination">
+  <div data-id="data-tables-pagination">
     <h2 class="text-2xl font-bold mb-6">
       Pagination
     </h2>
@@ -48,7 +48,7 @@ const paginationSticky = ref<TablePaginationData>({
       <!-- Basic pagination -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-pagination-basic"
+        data-id="table-pagination-basic"
       >
         <h4>Basic Pagination</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -60,7 +60,7 @@ const paginationSticky = ref<TablePaginationData>({
           :cols="fixedColumns"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -80,7 +80,7 @@ const paginationSticky = ref<TablePaginationData>({
       <!-- Pagination without per-page selector -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-pagination-no-per-page"
+        data-id="table-pagination-no-per-page"
       >
         <h4>Pagination (disabled per-page selector)</h4>
         <RuiDataTable
@@ -90,7 +90,7 @@ const paginationSticky = ref<TablePaginationData>({
           row-attr="id"
           outlined
           disable-per-page
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -110,7 +110,7 @@ const paginationSticky = ref<TablePaginationData>({
       <!-- Hide header pagination -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-pagination-hide-header"
+        data-id="table-pagination-hide-header"
       >
         <h4>Hide Header Pagination</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -123,7 +123,7 @@ const paginationSticky = ref<TablePaginationData>({
           row-attr="id"
           outlined
           hide-default-header
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -143,7 +143,7 @@ const paginationSticky = ref<TablePaginationData>({
       <!-- Hide footer pagination -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-pagination-hide-footer"
+        data-id="table-pagination-hide-footer"
       >
         <h4>Hide Footer Pagination</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -156,7 +156,7 @@ const paginationSticky = ref<TablePaginationData>({
           row-attr="id"
           outlined
           hide-default-footer
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -176,7 +176,7 @@ const paginationSticky = ref<TablePaginationData>({
       <!-- Sticky header -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-pagination-sticky"
+        data-id="table-pagination-sticky"
       >
         <h4>Sticky Header</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -190,7 +190,7 @@ const paginationSticky = ref<TablePaginationData>({
             row-attr="id"
             outlined
             sticky-header
-            data-cy="table"
+            data-id="table"
           >
             <template #item.action>
               <RuiButton

--- a/apps/example/src/views/data-tables/DataTableSearchView.vue
+++ b/apps/example/src/views/data-tables/DataTableSearchView.vue
@@ -19,7 +19,7 @@ const pagination = ref<TablePaginationData>({
 </script>
 
 <template>
-  <div data-cy="data-tables-search">
+  <div data-id="data-tables-search">
     <h2 class="text-2xl font-bold mb-6">
       Search
     </h2>
@@ -28,7 +28,7 @@ const pagination = ref<TablePaginationData>({
       <!-- Basic search -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-search-basic"
+        data-id="table-search-basic"
       >
         <h4>Basic Search</h4>
         <RuiTextField
@@ -39,7 +39,7 @@ const pagination = ref<TablePaginationData>({
           variant="outlined"
           color="primary"
           hide-details
-          data-cy="search-input"
+          data-id="search-input"
         />
         <RuiDataTable
           :rows="fixedRows"
@@ -47,7 +47,7 @@ const pagination = ref<TablePaginationData>({
           :search="search"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -67,7 +67,7 @@ const pagination = ref<TablePaginationData>({
       <!-- Search with pagination -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-search-pagination"
+        data-id="table-search-pagination"
       >
         <h4>Search with Pagination</h4>
         <RuiTextField
@@ -78,7 +78,7 @@ const pagination = ref<TablePaginationData>({
           variant="outlined"
           color="primary"
           hide-details
-          data-cy="search-input"
+          data-id="search-input"
         />
         <RuiDataTable
           v-model:pagination="pagination"
@@ -87,7 +87,7 @@ const pagination = ref<TablePaginationData>({
           :search="searchWithPagination"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton

--- a/apps/example/src/views/data-tables/DataTableSelectionView.vue
+++ b/apps/example/src/views/data-tables/DataTableSelectionView.vue
@@ -21,7 +21,7 @@ const disabledRows = fixedRows.slice(0, 3);
 </script>
 
 <template>
-  <div data-cy="data-tables-selection">
+  <div data-id="data-tables-selection">
     <h2 class="text-2xl font-bold mb-6">
       Selection
     </h2>
@@ -30,7 +30,7 @@ const disabledRows = fixedRows.slice(0, 3);
       <!-- Basic selection -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-selection-basic"
+        data-id="table-selection-basic"
       >
         <h4>Basic Selection</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -42,7 +42,7 @@ const disabledRows = fixedRows.slice(0, 3);
           :cols="fixedColumns"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -62,7 +62,7 @@ const disabledRows = fixedRows.slice(0, 3);
       <!-- Multi-page selection -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-selection-multi-page"
+        data-id="table-selection-multi-page"
       >
         <h4>Multi-page Selection</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -76,7 +76,7 @@ const disabledRows = fixedRows.slice(0, 3);
           row-attr="id"
           outlined
           multi-page-select
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -96,7 +96,7 @@ const disabledRows = fixedRows.slice(0, 3);
       <!-- Selection with disabled rows -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-selection-disabled"
+        data-id="table-selection-disabled"
       >
         <h4>Selection with Disabled Rows</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -109,7 +109,7 @@ const disabledRows = fixedRows.slice(0, 3);
           :disabled-rows="disabledRows"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton

--- a/apps/example/src/views/data-tables/DataTableSortingView.vue
+++ b/apps/example/src/views/data-tables/DataTableSortingView.vue
@@ -30,7 +30,7 @@ const sortDisplay = computed<string>(() => {
 </script>
 
 <template>
-  <div data-cy="data-tables-sorting">
+  <div data-id="data-tables-sorting">
     <h2 class="text-2xl font-bold mb-6">
       Sorting
     </h2>
@@ -39,7 +39,7 @@ const sortDisplay = computed<string>(() => {
       <!-- Single column sort -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-single-sort"
+        data-id="table-single-sort"
       >
         <h4>Single Column Sort</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -51,7 +51,7 @@ const sortDisplay = computed<string>(() => {
           :cols="columns"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton
@@ -71,7 +71,7 @@ const sortDisplay = computed<string>(() => {
       <!-- Multi column sort -->
       <div
         class="flex flex-col space-y-3"
-        data-cy="table-multi-sort"
+        data-id="table-multi-sort"
       >
         <h4>Multi Column Sort</h4>
         <p class="text-sm text-rui-text-secondary">
@@ -83,7 +83,7 @@ const sortDisplay = computed<string>(() => {
           :cols="columns"
           row-attr="id"
           outlined
-          data-cy="table"
+          data-id="table"
         >
           <template #item.action>
             <RuiButton

--- a/apps/example/src/views/data-tables/index.vue
+++ b/apps/example/src/views/data-tables/index.vue
@@ -55,9 +55,9 @@ const sections = [
 </script>
 
 <template>
-  <div data-cy="data-tables-index">
+  <div data-id="data-tables-index">
     <h2
-      data-cy="datatables"
+      data-id="datatables"
       class="text-2xl font-bold mb-6"
     >
       Data Tables
@@ -73,7 +73,7 @@ const sections = [
         <RuiCard
           variant="outlined"
           class="h-full hover:border-primary transition-colors cursor-pointer"
-          :data-cy="`link-${section.route}`"
+          :data-id="`link-${section.route}`"
         >
           <template #header>
             <div class="flex items-center gap-2">

--- a/apps/example/src/views/menu-selects/MenuSelectBasicView.vue
+++ b/apps/example/src/views/menu-selects/MenuSelectBasicView.vue
@@ -18,7 +18,7 @@ const hintValue = ref<number>();
 </script>
 
 <template>
-  <div data-cy="menu-selects-basic">
+  <div data-id="menu-selects-basic">
     <h2 class="text-2xl font-bold mb-6">
       Menu Selects: Basic
     </h2>
@@ -31,7 +31,7 @@ const hintValue = ref<number>();
           :options="options"
           key-attr="id"
           text-attr="label"
-          data-cy="ms-basic-default"
+          data-id="ms-basic-default"
         />
       </div>
 
@@ -43,7 +43,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           variant="outlined"
-          data-cy="ms-basic-outlined"
+          data-id="ms-basic-outlined"
         />
       </div>
 
@@ -55,7 +55,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           dense
-          data-cy="ms-basic-dense"
+          data-id="ms-basic-dense"
         />
       </div>
 
@@ -67,7 +67,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           disabled
-          data-cy="ms-basic-disabled"
+          data-id="ms-basic-disabled"
         />
       </div>
 
@@ -80,7 +80,7 @@ const hintValue = ref<number>();
           text-attr="label"
           disabled
           variant="outlined"
-          data-cy="ms-basic-disabled-outlined"
+          data-id="ms-basic-disabled-outlined"
         />
       </div>
 
@@ -92,7 +92,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           loading
-          data-cy="ms-basic-loading"
+          data-id="ms-basic-loading"
         />
       </div>
 
@@ -104,7 +104,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           :error-messages="['This field is required']"
-          data-cy="ms-basic-error"
+          data-id="ms-basic-error"
         />
       </div>
 
@@ -116,7 +116,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           :success-messages="['Looks good!']"
-          data-cy="ms-basic-success"
+          data-id="ms-basic-success"
         />
       </div>
 
@@ -129,7 +129,7 @@ const hintValue = ref<number>();
           text-attr="label"
           hide-details
           :error-messages="['This field is required']"
-          data-cy="ms-basic-hide-details"
+          data-id="ms-basic-hide-details"
         />
       </div>
 
@@ -142,7 +142,7 @@ const hintValue = ref<number>();
           text-attr="label"
           required
           variant="outlined"
-          data-cy="ms-basic-required"
+          data-id="ms-basic-required"
         />
       </div>
 
@@ -154,7 +154,7 @@ const hintValue = ref<number>();
           key-attr="id"
           text-attr="label"
           hint="Pick a country"
-          data-cy="ms-basic-hint"
+          data-id="ms-basic-hint"
         />
       </div>
     </div>

--- a/apps/example/src/views/menu-selects/MenuSelectCustomView.vue
+++ b/apps/example/src/views/menu-selects/MenuSelectCustomView.vue
@@ -10,7 +10,7 @@ const customItemValue = ref<number>();
 </script>
 
 <template>
-  <div data-cy="menu-selects-custom">
+  <div data-id="menu-selects-custom">
     <h2 class="text-2xl font-bold mb-6">
       Menu Selects: Custom Slots
     </h2>
@@ -23,14 +23,14 @@ const customItemValue = ref<number>();
           :options="options"
           key-attr="id"
           text-attr="label"
-          data-cy="ms-custom-activator"
+          data-id="ms-custom-activator"
         >
           <template #activator="{ attrs, disabled, open, value }">
             <RuiButton
               class="!rounded-md border"
               variant="list"
               :disabled="disabled"
-              v-bind="{ ...attrs, 'data-cy': 'activator' }"
+              v-bind="{ ...attrs, 'data-id': 'activator' }"
             >
               {{ value ? value.label : 'Choose option' }}
               <template #append>
@@ -55,7 +55,7 @@ const customItemValue = ref<number>();
           text-attr="label"
           clearable
           variant="outlined"
-          data-cy="ms-custom-selection"
+          data-id="ms-custom-selection"
         >
           <template #selection="{ item }">
             {{ item.id }} | {{ item.label }}
@@ -71,7 +71,7 @@ const customItemValue = ref<number>();
           key-attr="id"
           text-attr="label"
           :append-width="1.5"
-          data-cy="ms-custom-item"
+          data-id="ms-custom-item"
         >
           <template #item.append="{ active }">
             <RuiIcon
@@ -79,7 +79,7 @@ const customItemValue = ref<number>();
               class="transition"
               name="lu-check"
               size="24"
-              data-cy="check-icon"
+              data-id="check-icon"
             />
           </template>
         </RuiMenuSelect>

--- a/apps/example/src/views/menu-selects/MenuSelectReadonlyView.vue
+++ b/apps/example/src/views/menu-selects/MenuSelectReadonlyView.vue
@@ -8,7 +8,7 @@ const readonlyOutlined = ref<string>('Lorem');
 </script>
 
 <template>
-  <div data-cy="menu-selects-readonly">
+  <div data-id="menu-selects-readonly">
     <h2 class="text-2xl font-bold mb-6">
       Menu Selects: Read-only
     </h2>
@@ -20,7 +20,7 @@ const readonlyOutlined = ref<string>('Lorem');
           v-model="readonlyDefault"
           :options="primitiveOptions"
           read-only
-          data-cy="ms-readonly-default"
+          data-id="ms-readonly-default"
         />
       </div>
 
@@ -31,7 +31,7 @@ const readonlyOutlined = ref<string>('Lorem');
           :options="primitiveOptions"
           read-only
           variant="outlined"
-          data-cy="ms-readonly-outlined"
+          data-id="ms-readonly-outlined"
         />
       </div>
     </div>

--- a/apps/example/src/views/menu-selects/MenuSelectSelectionView.vue
+++ b/apps/example/src/views/menu-selects/MenuSelectSelectionView.vue
@@ -11,7 +11,7 @@ const hideNoDataValue = ref<string>();
 </script>
 
 <template>
-  <div data-cy="menu-selects-selection">
+  <div data-id="menu-selects-selection">
     <h2 class="text-2xl font-bold mb-6">
       Menu Selects: Selection
     </h2>
@@ -22,7 +22,7 @@ const hideNoDataValue = ref<string>();
         <RuiMenuSelect
           v-model="singleValue"
           :options="primitiveOptions"
-          data-cy="ms-select-single"
+          data-id="ms-select-single"
         />
       </div>
 
@@ -32,7 +32,7 @@ const hideNoDataValue = ref<string>();
           v-model="preselectedValue"
           :options="primitiveOptions"
           clearable
-          data-cy="ms-select-preselected"
+          data-id="ms-select-preselected"
         />
       </div>
 
@@ -42,7 +42,7 @@ const hideNoDataValue = ref<string>();
           v-model="autoFirstValue"
           :options="primitiveOptions"
           auto-select-first
-          data-cy="ms-select-auto-first"
+          data-id="ms-select-auto-first"
         />
       </div>
 
@@ -52,7 +52,7 @@ const hideNoDataValue = ref<string>();
           v-model="noDataValue"
           :options="[]"
           no-data-text="Nothing found"
-          data-cy="ms-select-no-data"
+          data-id="ms-select-no-data"
         />
       </div>
 
@@ -62,7 +62,7 @@ const hideNoDataValue = ref<string>();
           v-model="hideNoDataValue"
           :options="[]"
           hide-no-data
-          data-cy="ms-select-hide-no-data"
+          data-id="ms-select-hide-no-data"
         />
       </div>
     </div>

--- a/apps/example/src/views/menu-selects/index.vue
+++ b/apps/example/src/views/menu-selects/index.vue
@@ -31,7 +31,7 @@ const sections = [
 </script>
 
 <template>
-  <div data-cy="menu-selects-index">
+  <div data-id="menu-selects-index">
     <h2 class="text-2xl font-bold mb-6">
       Menu Selects
     </h2>
@@ -46,7 +46,7 @@ const sections = [
         <RuiCard
           variant="outlined"
           class="h-full hover:border-primary transition-colors cursor-pointer"
-          :data-cy="`link-${section.route}`"
+          :data-id="`link-${section.route}`"
         >
           <template #header>
             <div class="flex items-center gap-2">

--- a/packages/ui-library/src/components/color-picker/RuiColorDisplay.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorDisplay.vue
@@ -23,7 +23,7 @@ const { copy, copied } = useClipboard({ source: () => color });
     <template #activator>
       <div
         class="w-8 h-8 min-w-8 min-h-8 rounded-full cursor-pointer"
-        data-cy="color-display"
+        data-id="color-display"
         :style="{ background: color }"
         @click="copy()"
       />

--- a/packages/ui-library/src/components/color-picker/RuiColorPicker.spec.ts
+++ b/packages/ui-library/src/components/color-picker/RuiColorPicker.spec.ts
@@ -39,7 +39,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     wrapper = createWrapper();
 
     expect(wrapper.find('.rui-color-board').exists()).toBeTruthy();
-    expect(wrapper.find('[data-cy="color-display"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="color-display"]').exists()).toBeTruthy();
     expect(wrapper.find('.rui-color-hue').exists()).toBeTruthy();
     expect(wrapper.find('.rui-color-input').exists()).toBeTruthy();
   });
@@ -55,7 +55,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     // UI reflected
     expect(wrapper.find('.rui-color-board').attributes('style')).toBe('background-color: rgb(255, 0, 0);');
     expect(wrapper.find('.rui-color-board div[class*=_cursor_]').attributes('style')).toBe('top: 0%; left: 100%;');
-    expect(wrapper.find('[data-cy="color-display"]').attributes('style')).toBe('background: rgb(255, 0, 0);');
+    expect(wrapper.find('[data-id="color-display"]').attributes('style')).toBe('background: rgb(255, 0, 0);');
     expect(wrapper.find('.rui-color-hue div[class*=_cursor_]').attributes('style')).toBe('left: calc(0% + 8px);');
     // Hex input value reflected
     expect(wrapper.find<HTMLInputElement>('input').element.value).toBe('ff0000');
@@ -76,7 +76,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     // UI reflected
     expect(wrapper.find('.rui-color-board').attributes('style')).toBe('background-color: rgb(0, 255, 255);');
     expect(wrapper.find('.rui-color-board div[class*=_cursor_]').attributes('style')).toBe('top: 0%; left: 50%;');
-    expect(wrapper.find('[data-cy="color-display"]').attributes('style')).toBe('background: rgb(128, 255, 255);');
+    expect(wrapper.find('[data-id="color-display"]').attributes('style')).toBe('background: rgb(128, 255, 255);');
 
     // middle position, then substract by (half thumb size / element width defined on the useElementBounding);
     const percentagePosition = roundTwoDecimal(50 - ((16 / 2) / 300 * 100));
@@ -108,7 +108,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     // UI reflected
     expect(wrapper.find('.rui-color-board').attributes('style')).toBe('background-color: rgb(255, 0, 0);');
     expect(wrapper.find('.rui-color-board div[class*=_cursor_]').attributes('style')).toBe('top: 0%; left: 100%;');
-    expect(wrapper.find('[data-cy="color-display"]').attributes('style')).toBe('background: rgb(255, 0, 0);');
+    expect(wrapper.find('[data-id="color-display"]').attributes('style')).toBe('background: rgb(255, 0, 0);');
     expect(wrapper.find('.rui-color-hue div[class*=_cursor_]').attributes('style')).toBe('left: calc(0% + 8px);');
     expect(wrapper.emitted('update:modelValue')!.at(-1)![0]).toBe('ff0000');
 
@@ -137,7 +137,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     expect(wrapper.find('.rui-color-board').attributes('style')).toBe('background-color: rgb(0, 255, 255);');
     expect(wrapper.find('.rui-color-board div[class*=_cursor_]').attributes('style')).toBe('top: 0%; left: 50%;');
 
-    expect(wrapper.find('[data-cy="color-display"]').attributes('style')).toBe('background: rgb(128, 255, 255);');
+    expect(wrapper.find('[data-id="color-display"]').attributes('style')).toBe('background: rgb(128, 255, 255);');
 
     // middle position, then substract by (half thumb size / element width defined on the useElementBounding);
     const percentagePosition = roundTwoDecimal(50 - ((16 / 2) / 300 * 100));
@@ -188,7 +188,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
 
     // Selected color: hsv(360, 100, 100) => rgb(255, 0, 0);
     expect(wrapper.find('.rui-color-board').attributes('style')).toBe('background-color: rgb(255, 0, 0);');
-    expect(wrapper.find('[data-cy="color-display"]').attributes('style')).toBe('background: rgb(255, 0, 0);');
+    expect(wrapper.find('[data-id="color-display"]').attributes('style')).toBe('background: rgb(255, 0, 0);');
     expect(wrapper.find<HTMLInputElement>('input').element.value).toBe('ff0000');
 
     // end position, then substract by (thumb size / element width defined on the useElementBounding);
@@ -204,7 +204,7 @@ describe('components/color-picker/RuiColorPicker.vue', () => {
     await vi.runAllTimersAsync();
 
     // Selected color: hsv(360, 50, 50) => rgb(128, 64, 64);
-    expect(wrapper.find('[data-cy="color-display"]').attributes('style')).toBe('background: rgb(128, 64, 64);');
+    expect(wrapper.find('[data-id="color-display"]').attributes('style')).toBe('background: rgb(128, 64, 64);');
     expect(wrapper.find<HTMLInputElement>('input').element.value).toBe('804040');
     expect(wrapper.find('.rui-color-board div[class*=_cursor_]').attributes('style')).toBe('top: 50%; left: 50%;');
 

--- a/packages/ui-library/src/components/divider/RuiDivider.spec.ts
+++ b/packages/ui-library/src/components/divider/RuiDivider.spec.ts
@@ -57,9 +57,9 @@ describe('components/divider/RuiDivider.vue', () => {
   it('should pass attrs to root element', () => {
     wrapper = createWrapper({
       attrs: {
-        'data-cy': 'test-divider',
+        'data-id': 'test-divider',
       },
     });
-    expect(wrapper.attributes('data-cy')).toBe('test-divider');
+    expect(wrapper.attributes('data-id')).toBe('test-divider');
   });
 });

--- a/packages/ui-library/src/components/forms/select/RuiSimpleSelect.spec.ts
+++ b/packages/ui-library/src/components/forms/select/RuiSimpleSelect.spec.ts
@@ -165,7 +165,7 @@ describe('components/forms/select/RuiSimpleSelect.vue', () => {
   it('should pass attrs to wrapper div', () => {
     wrapper = createWrapper({
       attrs: {
-        'data-cy': 'test',
+        'data-id': 'test',
       },
       props: {
         modelValue: 'Option 0',
@@ -173,6 +173,6 @@ describe('components/forms/select/RuiSimpleSelect.vue', () => {
       },
     });
 
-    expect(wrapper.attributes('data-cy')).toBe('test');
+    expect(wrapper.attributes('data-id')).toBe('test');
   });
 });

--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -99,7 +99,7 @@ describe('components/tables/RuiDataTable.vue', () => {
       },
       slots: {
         'expanded-item': {
-          template: '<div data-cy="expanded-content">Expanded content</div>',
+          template: '<div data-id="expanded-content">Expanded content</div>',
         },
       },
     });
@@ -113,15 +113,15 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(wrapper.find('div div[class*=_navigation_] button[disabled]').exists()).toBeTruthy();
 
     expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').exists()).toBeTruthy();
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeFalsy();
 
     await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
-    expect(wrapper.find('div[data-cy=table-pagination] div[class*=limit]').exists()).toBeTruthy();
-    expect(wrapper.find('div[data-cy=table-pagination] div[class*=ranges]').exists()).toBeTruthy();
-    expect(wrapper.find('div[data-cy=table-pagination] div[class*=navigation]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeTruthy();
+    expect(wrapper.find('div[data-id=table-pagination] div[class*=limit]').exists()).toBeTruthy();
+    expect(wrapper.find('div[data-id=table-pagination] div[class*=ranges]').exists()).toBeTruthy();
+    expect(wrapper.find('div[data-id=table-pagination] div[class*=navigation]').exists()).toBeTruthy();
   });
 
   it('should multiple expand toggles correctly', async () => {
@@ -136,25 +136,25 @@ describe('components/tables/RuiDataTable.vue', () => {
       },
       slots: {
         'expanded-item': {
-          template: '<div data-cy="expanded-content">Expanded content</div>',
+          template: '<div data-id="expanded-content">Expanded content</div>',
         },
       },
     });
 
     expect(wrapper.props().expanded).toHaveLength(0);
-    expect(wrapper.find('tbody tr[hidden]:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody tr[hidden]:nth-child(2) div[data-id=expanded-content]').exists()).toBeFalsy();
 
     await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(1);
     expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeTruthy();
 
     await wrapper.find('tbody tr:nth-child(3) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(2);
     expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
-    expect(wrapper.find('tbody tr:nth-child(4) div[data-cy=expanded-content]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(4) div[data-id=expanded-content]').exists()).toBeTruthy();
   });
 
   it('should selection toggles correctly', async () => {
@@ -169,19 +169,19 @@ describe('components/tables/RuiDataTable.vue', () => {
     });
 
     expect(wrapper.props().modelValue).toHaveLength(0);
-    expect(wrapper.find('thead tr [data-cy=table-toggle-check-all] input').exists()).toBeTruthy();
+    expect(wrapper.find('thead tr [data-id=table-toggle-check-all] input').exists()).toBeTruthy();
 
-    await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(true);
+    await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(true);
 
     expect(wrapper.props().modelValue).toHaveLength(10);
-    expect(wrapper.find('tr [data-cy*=table-toggle-check-] span[class*=checkbox][class*=checked]').exists()).toBeTruthy();
-    expect(wrapper.findAll('tr [data-cy*=table-toggle-check-] span[class*=checkbox][class*=checked]')).toHaveLength(11);
+    expect(wrapper.find('tr [data-id*=table-toggle-check-] span[class*=checkbox][class*=checked]').exists()).toBeTruthy();
+    expect(wrapper.findAll('tr [data-id*=table-toggle-check-] span[class*=checkbox][class*=checked]')).toHaveLength(11);
 
-    await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(false);
+    await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(false);
 
     expect(wrapper.props().modelValue).toHaveLength(0);
 
-    await wrapper.find('tr [data-cy=table-toggle-check-0] input').setValue(true);
+    await wrapper.find('tr [data-id=table-toggle-check-0] input').setValue(true);
 
     expect(wrapper.props().modelValue).toHaveLength(1);
   });
@@ -199,34 +199,34 @@ describe('components/tables/RuiDataTable.vue', () => {
       },
       slots: {
         'expanded-item': {
-          template: '<div data-cy="expanded-content">Expanded content</div>',
+          template: '<div data-id="expanded-content">Expanded content</div>',
         },
       },
     });
 
     expect(wrapper.props().expanded).toHaveLength(0);
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeFalsy();
 
     await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(1);
     expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeTruthy();
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeTruthy();
 
     await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(0);
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeFalsy();
 
     await wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').trigger('click');
 
-    expect(wrapper.find('tbody tr:nth-child(2) div[data-cy=expanded-content]').exists()).toBeTruthy();
+    expect(wrapper.find('tbody tr:nth-child(2) div[data-id=expanded-content]').exists()).toBeTruthy();
 
     await wrapper.find('tbody tr:nth-child(3) button[data-id="expand-button"]').trigger('click');
 
     expect(wrapper.props().expanded).toHaveLength(1);
     expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"][aria-expanded="true"]').exists()).toBeFalsy();
-    expect(wrapper.find('tbody tr:nth-child(4) div[data-cy=expanded-content]').exists()).toBeFalsy();
+    expect(wrapper.find('tbody tr:nth-child(4) div[data-id=expanded-content]').exists()).toBeFalsy();
   });
 
   it('should sticky header behaves as expected', async () => {
@@ -675,7 +675,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const headerCheckbox = wrapper.find('thead [data-cy=table-toggle-check-all]');
+      const headerCheckbox = wrapper.find('thead [data-id=table-toggle-check-all]');
       expect(headerCheckbox.find('span[class*=_checked_]').exists()).toBeTruthy();
     });
 
@@ -690,7 +690,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const headerCheckbox = wrapper.find('thead [data-cy=table-toggle-check-all]');
+      const headerCheckbox = wrapper.find('thead [data-id=table-toggle-check-all]');
       expect(headerCheckbox.find('span[class*=_checked_]').exists()).toBeFalsy();
     });
   });
@@ -773,7 +773,7 @@ describe('components/tables/RuiDataTable.vue', () => {
 
       expect(wrapper.props().modelValue).toHaveLength(10);
 
-      await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(false);
+      await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(false);
 
       expect(wrapper.props().modelValue).toHaveLength(0);
     });
@@ -795,7 +795,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const ungroupButton = wrapper.find('tr[data-id="row-group"] [data-cy="group-ungroup-button"]');
+      const ungroupButton = wrapper.find('tr[data-id="row-group"] [data-id="group-ungroup-button"]');
       expect(ungroupButton.exists()).toBe(true);
       await ungroupButton.trigger('click');
       expect(onUpdateGroup).toHaveBeenCalledWith(undefined);
@@ -962,9 +962,9 @@ describe('components/tables/RuiDataTable.vue', () => {
 
     const paginator = wrapper.findComponent(RuiTablePagination);
     expect(paginator.exists()).toBeTruthy();
-    expect(paginator.find('div[data-cy=table-pagination] div[class*=limit]').exists()).toBeTruthy();
-    expect(paginator.find('div[data-cy=table-pagination] div[class*=ranges]').exists()).toBeTruthy();
-    expect(paginator.find('div[data-cy=table-pagination] div[class*=navigation]').exists()).toBeTruthy();
+    expect(paginator.find('div[data-id=table-pagination] div[class*=limit]').exists()).toBeTruthy();
+    expect(paginator.find('div[data-id=table-pagination] div[class*=ranges]').exists()).toBeTruthy();
+    expect(paginator.find('div[data-id=table-pagination] div[class*=navigation]').exists()).toBeTruthy();
 
     const navButtons = paginator.findAllComponents(RuiButton);
     expect(navButtons).toHaveLength(4);
@@ -1026,7 +1026,7 @@ describe('components/tables/RuiDataTable.vue', () => {
 
     // Verify pagination is after the scroller (footer position)
     const wrapperEl = wrapper.find('[data-id="table-wrapper"]').element;
-    const pagination = wrapper.find('[data-cy="table-pagination"]').element;
+    const pagination = wrapper.find('[data-id="table-pagination"]').element;
     const scroller = wrapper.find('[data-id="table-scroller"]').element;
     const children = Array.from(wrapperEl.children);
     expect(children.indexOf(pagination)).toBeGreaterThan(children.indexOf(scroller));
@@ -1047,7 +1047,7 @@ describe('components/tables/RuiDataTable.vue', () => {
 
     // Verify pagination is before the scroller (header position)
     const wrapperEl = wrapper.find('[data-id="table-wrapper"]').element;
-    const pagination = wrapper.find('[data-cy="table-pagination"]').element;
+    const pagination = wrapper.find('[data-id="table-pagination"]').element;
     const scroller = wrapper.find('[data-id="table-scroller"]').element;
     const children = Array.from(wrapperEl.children);
     expect(children.indexOf(pagination)).toBeLessThan(children.indexOf(scroller));
@@ -1159,7 +1159,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const copyButton = wrapper.find('tr[data-id="row-group"] [data-cy="group-copy-button"]');
+      const copyButton = wrapper.find('tr[data-id="row-group"] [data-id="group-copy-button"]');
       expect(copyButton.exists()).toBe(true);
       await copyButton.trigger('click');
       expect(onCopyGroup).toHaveBeenCalled();
@@ -1180,10 +1180,10 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      const firstRowCheckbox = wrapper.find('tr [data-cy=table-toggle-check-0] input');
+      const firstRowCheckbox = wrapper.find('tr [data-id=table-toggle-check-0] input');
       expect(firstRowCheckbox.attributes('disabled')).toBeDefined();
 
-      await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(true);
+      await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(true);
 
       expect(wrapper.props().modelValue).toHaveLength(9);
       expect(wrapper.props().modelValue).not.toContain(disabledRow!.id);
@@ -1202,7 +1202,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(false);
+      await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(false);
 
       expect(wrapper.props().modelValue).toContain(disabledRow!.id);
     });
@@ -1221,14 +1221,14 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(true);
+      await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(true);
       expect(wrapper.props().modelValue).toHaveLength(10);
 
       await wrapper.setProps({ pagination: { limit: 10, page: 2, total: 50 } });
 
       expect(wrapper.props().modelValue).toHaveLength(10);
 
-      await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(true);
+      await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(true);
 
       expect(wrapper.props().modelValue).toHaveLength(20);
     });
@@ -1247,7 +1247,7 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
       });
 
-      await wrapper.find('thead tr [data-cy=table-toggle-check-all] input').setValue(true);
+      await wrapper.find('thead tr [data-id=table-toggle-check-all] input').setValue(true);
       expect(wrapper.props().modelValue).toHaveLength(10);
 
       const paginator = wrapper.findComponent(RuiTablePagination);
@@ -1343,12 +1343,12 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
         slots: {
           'item.name': `<template #item.name="{ row, column, index }">
-            <span data-cy="custom-name">{{ row.name }} - {{ column.key }} - {{ index }}</span>
+            <span data-id="custom-name">{{ row.name }} - {{ column.key }} - {{ index }}</span>
           </template>`,
         },
       });
 
-      const customCell = wrapper.find('[data-cy=custom-name]');
+      const customCell = wrapper.find('[data-id=custom-name]');
       expect(customCell.exists()).toBeTruthy();
       expect(customCell.text()).toContain('Lindsay Walton 0');
       expect(customCell.text()).toContain('name');
@@ -1364,12 +1364,12 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
         slots: {
           'header.name': `<template #header.name="{ column }">
-            <span data-cy="custom-header">Custom: {{ column.label }}</span>
+            <span data-id="custom-header">Custom: {{ column.label }}</span>
           </template>`,
         },
       });
 
-      const customHeader = wrapper.find('[data-cy=custom-header]');
+      const customHeader = wrapper.find('[data-id=custom-header]');
       expect(customHeader.exists()).toBeTruthy();
       expect(customHeader.text()).toBe('Custom: Full name');
     });
@@ -1383,12 +1383,12 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
         slots: {
           'body.prepend': `<template #body.prepend="{ colspan }">
-            <tr data-cy="prepend-row"><td :colspan="colspan">Prepended content</td></tr>
+            <tr data-id="prepend-row"><td :colspan="colspan">Prepended content</td></tr>
           </template>`,
         },
       });
 
-      const prependRow = wrapper.find('[data-cy=prepend-row]');
+      const prependRow = wrapper.find('[data-id=prepend-row]');
       expect(prependRow.exists()).toBeTruthy();
       expect(prependRow.text()).toBe('Prepended content');
     });
@@ -1402,12 +1402,12 @@ describe('components/tables/RuiDataTable.vue', () => {
         },
         slots: {
           'body.append': `<template #body.append="{ colspan }">
-            <tr data-cy="append-row"><td :colspan="colspan">Appended content</td></tr>
+            <tr data-id="append-row"><td :colspan="colspan">Appended content</td></tr>
           </template>`,
         },
       });
 
-      const appendRow = wrapper.find('[data-cy=append-row]');
+      const appendRow = wrapper.find('[data-id=append-row]');
       expect(appendRow.exists()).toBeTruthy();
       expect(appendRow.text()).toBe('Appended content');
     });
@@ -1420,11 +1420,11 @@ describe('components/tables/RuiDataTable.vue', () => {
           rows: [],
         },
         slots: {
-          'no-data': '<div data-cy="custom-no-data">Custom empty state</div>',
+          'no-data': '<div data-id="custom-no-data">Custom empty state</div>',
         },
       });
 
-      const customNoData = wrapper.find('[data-cy=custom-no-data]');
+      const customNoData = wrapper.find('[data-id=custom-no-data]');
       expect(customNoData.exists()).toBeTruthy();
       expect(customNoData.text()).toBe('Custom empty state');
     });
@@ -1460,11 +1460,11 @@ describe('components/tables/RuiDataTable.vue', () => {
           rows: [],
         },
         slots: {
-          'empty-description': '<span data-cy="custom-description">Custom description content</span>',
+          'empty-description': '<span data-id="custom-description">Custom description content</span>',
         },
       });
 
-      const customDescription = wrapper.find('[data-cy=custom-description]');
+      const customDescription = wrapper.find('[data-id=custom-description]');
       expect(customDescription.exists()).toBeTruthy();
       expect(customDescription.text()).toBe('Custom description content');
     });
@@ -1477,11 +1477,11 @@ describe('components/tables/RuiDataTable.vue', () => {
           rows: data.slice(0, 3),
         },
         slots: {
-          tfoot: '<tr data-cy="custom-tfoot"><td>Footer content</td></tr>',
+          tfoot: '<tr data-id="custom-tfoot"><td>Footer content</td></tr>',
         },
       });
 
-      const customTfoot = wrapper.find('tfoot [data-cy=custom-tfoot]');
+      const customTfoot = wrapper.find('tfoot [data-id=custom-tfoot]');
       expect(customTfoot.exists()).toBeTruthy();
       expect(customTfoot.text()).toBe('Footer content');
     });

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -331,7 +331,7 @@ onMounted(() => {
       :dense="dense"
       :loading="loading"
       :disable-per-page="disablePerPage"
-      data-cy="table-pagination"
+      data-id="table-pagination"
       @update:model-value="onPaginate()"
     />
     <div
@@ -442,7 +442,7 @@ onMounted(() => {
                         size="sm"
                         variant="text"
                         icon
-                        data-cy="group-copy-button"
+                        data-id="group-copy-button"
                         @click="onCopyGroup({ key: groupKey, value: row.group })"
                       >
                         <RuiIcon
@@ -460,7 +460,7 @@ onMounted(() => {
                           size="sm"
                           variant="text"
                           icon
-                          data-cy="group-ungroup-button"
+                          data-id="group-ungroup-button"
                           @click="onUngroup()"
                         >
                           <RuiIcon
@@ -498,7 +498,7 @@ onMounted(() => {
                   rowspan="1"
                 >
                   <RuiCheckbox
-                    :data-cy="`table-toggle-check-${index}`"
+                    :data-id="`table-toggle-check-${index}`"
                     :model-value="isSelected(row[rowAttr])"
                     :disabled="isDisabledRow(row[rowAttr])"
                     :size="dense ? 'sm' : undefined"
@@ -647,7 +647,7 @@ onMounted(() => {
       :dense="dense"
       :loading="loading"
       :disable-per-page="disablePerPage"
-      data-cy="table-pagination"
+      data-id="table-pagination"
       @update:model-value="onPaginate()"
     />
   </div>

--- a/packages/ui-library/src/components/tables/RuiExpandButton.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiExpandButton.spec.ts
@@ -80,12 +80,12 @@ describe('components/tables/RuiExpandButton.vue', () => {
         expanded: false,
       },
       slots: {
-        default: '<span data-cy="custom-icon">Custom</span>',
+        default: '<span data-id="custom-icon">Custom</span>',
       },
     });
 
-    expect(wrapper.find('[data-cy=custom-icon]').exists()).toBeTruthy();
-    expect(wrapper.find('[data-cy=custom-icon]').text()).toBe('Custom');
+    expect(wrapper.find('[data-id=custom-icon]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id=custom-icon]').text()).toBe('Custom');
   });
 
   it('should pass through additional attributes', () => {

--- a/packages/ui-library/src/components/tables/RuiTableHead.vue
+++ b/packages/ui-library/src/components/tables/RuiTableHead.vue
@@ -157,7 +157,7 @@ function getSortDirection(key: TableColumn<T>['key']): 'asc' | 'desc' | undefine
           :model-value="isAllSelected"
           :size="dense ? 'sm' : undefined"
           color="primary"
-          data-cy="table-toggle-check-all"
+          data-id="table-toggle-check-all"
           hide-details
           @update:model-value="onToggleAll($event)"
         />

--- a/packages/ui-library/src/components/tables/RuiTablePagination.vue
+++ b/packages/ui-library/src/components/tables/RuiTablePagination.vue
@@ -132,7 +132,7 @@ function onLast(): void {
         text-attr="limit"
         hide-details
         dense
-        data-cy="table-pagination-limit"
+        data-id="table-pagination-limit"
       />
     </div>
     <div :class="$style.ranges">
@@ -148,7 +148,7 @@ function onLast(): void {
         text-attr="text"
         hide-details
         dense
-        data-cy="table-pagination-ranges"
+        data-id="table-pagination-ranges"
       />
       <span :class="$style.indicator">
         {{ indicatorText }}
@@ -156,14 +156,14 @@ function onLast(): void {
     </div>
     <div
       :class="$style.navigation"
-      data-cy="table-pagination-navigation"
+      data-id="table-pagination-navigation"
     >
       <RuiButton
         :size="dense ? 'sm' : undefined"
         :disabled="!hasPrev || loading"
         variant="text"
         icon
-        data-cy="table-pagination-first"
+        data-id="table-pagination-first"
         @click="onFirst()"
       >
         <RuiIcon name="lu-chevrons-left" />
@@ -173,7 +173,7 @@ function onLast(): void {
         :disabled="!hasPrev || loading"
         variant="text"
         icon
-        data-cy="table-pagination-prev"
+        data-id="table-pagination-prev"
         @click="onPrev()"
       >
         <RuiIcon name="lu-chevron-left" />
@@ -183,7 +183,7 @@ function onLast(): void {
         :disabled="!hasNext || loading"
         variant="text"
         icon
-        data-cy="table-pagination-next"
+        data-id="table-pagination-next"
         @click="onNext()"
       >
         <RuiIcon name="lu-chevron-right" />
@@ -193,7 +193,7 @@ function onLast(): void {
         :disabled="!hasNext || loading"
         variant="text"
         icon
-        data-cy="table-pagination-last"
+        data-id="table-pagination-last"
         @click="onLast()"
       >
         <RuiIcon name="lu-chevrons-right" />


### PR DESCRIPTION
## Summary

- Rename all `data-cy` attributes to `data-id` across components, example app views, and e2e tests (786 occurrences in 103 files)
- Rename `getItemDataCy` prop to `getItemDataId` in `ComponentGroup.vue`
- Configure Playwright with `testIdAttribute: 'data-id'` to enable `page.getByTestId()` usage
- Update CLAUDE.md locator best practices to recommend `getByTestId()`

This is a prerequisite for the Tailwind inline refactor (#465–#473), standardizing the test attribute convention before component style blocks are modified.

## Test plan

- [x] All 960 unit tests pass
- [x] All 262 e2e tests pass
- [x] Lint: 0 errors
- [x] Typecheck: clean (library)
- [x] Zero remaining `data-cy` occurrences in codebase