### PR TITLE
refactor(tables): decompose RuiDataTable into sub-components with per-concern context

### DIFF
--- a/apps/example/e2e/data-table.spec.ts
+++ b/apps/example/e2e/data-table.spec.ts
@@ -840,6 +840,66 @@ test.describe('data tables - empty states', () => {
   });
 });
 
+test.describe('data tables - custom slots', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/data-tables/custom-slots');
+  });
+
+  test('should render a custom column header via header.<key> slot', async ({ page }) => {
+    const table = page.locator('[data-id=table-custom-header] [data-id=table]');
+    await expect(table).toBeVisible();
+
+    const customHeader = table.locator('thead [data-id=custom-header-name]');
+    await expect(customHeader).toBeVisible();
+    await expect(customHeader).toContainText('Full name');
+  });
+
+  test('should render body.prepend and body.append rows', async ({ page }) => {
+    const tbody = page.locator('[data-id=table-custom-header] [data-id=table] tbody');
+    await expect(tbody).toBeVisible();
+
+    // Prepend row is the first row, append row is the last.
+    await expect(tbody.locator('tr').first()).toHaveAttribute('data-id', 'body-prepend-row');
+    await expect(tbody.locator('tr').last()).toHaveAttribute('data-id', 'body-append-row');
+
+    await expect(tbody.locator('[data-id=body-prepend-row]')).toContainText('Prepended body row');
+    await expect(tbody.locator('[data-id=body-append-row]')).toContainText('Appended body row');
+  });
+
+  test('should override group.header.content while keeping default group controls', async ({ page }) => {
+    const table = page.locator('[data-id=table-group-header-content] [data-id=table]');
+    await expect(table).toBeVisible();
+
+    // Custom content is rendered inside the group header.
+    const content = table.locator('[data-id=row-group] [data-id=custom-group-content]').first();
+    await expect(content).toBeVisible();
+    await expect(content).toContainText('username');
+
+    // Default ungroup control is still present because only the content slot was overridden.
+    await expect(table.locator('[data-id=row-group] [data-id=group-ungroup-button]').first()).toBeVisible();
+  });
+
+  test('should override the whole group.header row and toggle via the slot', async ({ page }) => {
+    const table = page.locator('[data-id=table-group-header-full] [data-id=table]');
+    await expect(table).toBeVisible();
+
+    const toggle = table.locator('[data-id=row-group] [data-id=custom-group-toggle]').first();
+    await expect(toggle).toBeVisible();
+
+    // Default controls are gone because the entire group.header row was replaced.
+    await expect(table.locator('[data-id=row-group] [data-id=group-ungroup-button]')).toHaveCount(0);
+
+    // Group starts open, so the slot reflects isOpen === true.
+    const header = table.locator('[data-id=row-group] [data-id=custom-group-header]').first();
+    await expect(header).toContainText('Hide');
+
+    await toggle.click();
+
+    // Toggling collapse flips isOpen, proving the slot scope is reactive.
+    await expect(header).toContainText('Show');
+  });
+});
+
 test.describe('data tables - index', () => {
   test('should render index page with navigation links', async ({ page }) => {
     await page.goto('/data-tables');
@@ -856,6 +916,7 @@ test.describe('data tables - index', () => {
     await expect(page.locator('[data-id="link-/data-tables/expandable"]')).toBeVisible();
     await expect(page.locator('[data-id="link-/data-tables/grouping"]')).toBeVisible();
     await expect(page.locator('[data-id="link-/data-tables/empty"]')).toBeVisible();
+    await expect(page.locator('[data-id="link-/data-tables/custom-slots"]')).toBeVisible();
   });
 
   test('should navigate to sub-pages', async ({ page }) => {

--- a/apps/example/src/pages/data-tables/custom-slots.vue
+++ b/apps/example/src/pages/data-tables/custom-slots.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import DataTableCustomSlotsView from '@/views/data-tables/DataTableCustomSlotsView.vue';
+</script>
+
+<template>
+  <DataTableCustomSlotsView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -195,6 +195,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/data-tables/custom-slots': RouteRecordInfo<
+      '/data-tables/custom-slots',
+      '/data-tables/custom-slots',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/data-tables/empty': RouteRecordInfo<
       '/data-tables/empty',
       '/data-tables/empty',
@@ -594,6 +601,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/data-tables/basic.vue': {
       routes:
         | '/data-tables/basic'
+      views:
+        | never
+    }
+    'src/pages/data-tables/custom-slots.vue': {
+      routes:
+        | '/data-tables/custom-slots'
       views:
         | never
     }

--- a/apps/example/src/views/data-tables/DataTableCustomSlotsView.vue
+++ b/apps/example/src/views/data-tables/DataTableCustomSlotsView.vue
@@ -1,0 +1,156 @@
+<script lang="ts" setup>
+import type { ExtendedUser } from '@/data/tables';
+import {
+  type DataTableColumn,
+  RuiButton,
+  RuiDataTable,
+  RuiIcon,
+} from '@rotki/ui-library/components';
+import { fixedColumns as baseColumns, fixedRows } from '@/data/table-configs';
+
+// Cast columns to ExtendedUser type for proper typing
+const fixedColumns = baseColumns as DataTableColumn<ExtendedUser>[];
+
+const groupContent = ref<keyof ExtendedUser | (keyof ExtendedUser)[]>(['username']);
+const collapsedContent = ref<ExtendedUser[]>([]);
+
+const groupFull = ref<keyof ExtendedUser | (keyof ExtendedUser)[]>(['username']);
+const collapsedFull = ref<ExtendedUser[]>([]);
+</script>
+
+<template>
+  <div data-id="data-tables-custom-slots">
+    <h2 class="text-2xl font-bold mb-6">
+      Custom Slots
+    </h2>
+
+    <div class="grid grid-cols-1 gap-12">
+      <!-- Custom column header + body prepend/append slots -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-custom-header"
+      >
+        <h4>Custom Column Header &amp; Body Slots</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Overrides the <code>header.name</code> column header and adds
+          <code>body.prepend</code> / <code>body.append</code> rows
+        </p>
+        <RuiDataTable
+          :rows="fixedRows"
+          :cols="fixedColumns"
+          row-attr="id"
+          outlined
+          data-id="table"
+        >
+          <template #header.name="{ column }">
+            <span
+              class="inline-flex items-center gap-1 text-rui-primary"
+              data-id="custom-header-name"
+            >
+              <RuiIcon
+                name="lu-user"
+                size="16"
+              />
+              {{ column.label }}
+            </span>
+          </template>
+          <template #body.prepend="{ colspan }">
+            <tr data-id="body-prepend-row">
+              <td
+                :colspan="colspan"
+                class="p-2 text-sm font-medium text-rui-text-secondary"
+              >
+                Prepended body row
+              </td>
+            </tr>
+          </template>
+          <template #body.append="{ colspan }">
+            <tr data-id="body-append-row">
+              <td
+                :colspan="colspan"
+                class="p-2 text-sm font-medium text-rui-text-secondary"
+              >
+                Appended body row
+              </td>
+            </tr>
+          </template>
+        </RuiDataTable>
+      </div>
+
+      <!-- Custom group.header.content slot -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-group-header-content"
+      >
+        <h4>Custom Group Header Content</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Overrides <code>group.header.content</code> while keeping the default
+          expand and ungroup controls
+        </p>
+        <RuiDataTable
+          v-model:group="groupContent"
+          v-model:collapsed="collapsedContent"
+          :rows="fixedRows"
+          :cols="fixedColumns"
+          row-attr="id"
+          outlined
+          data-id="table"
+        >
+          <template #group.header.content="{ header, groupKey }">
+            <span
+              class="inline-flex items-center gap-2"
+              data-id="custom-group-content"
+            >
+              <RuiIcon
+                name="lu-users"
+                size="16"
+                color="primary"
+              />
+              <strong>{{ groupKey }}</strong>
+              <span class="text-rui-text-secondary">{{ header.identifier }}</span>
+            </span>
+          </template>
+        </RuiDataTable>
+      </div>
+
+      <!-- Full group.header slot override -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-group-header-full"
+      >
+        <h4>Full Group Header Override</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Replaces the entire <code>group.header</code> row with a custom cell
+          and toggle
+        </p>
+        <RuiDataTable
+          v-model:group="groupFull"
+          v-model:collapsed="collapsedFull"
+          :rows="fixedRows"
+          :cols="fixedColumns"
+          row-attr="id"
+          outlined
+          data-id="table"
+        >
+          <template #group.header="{ header, isOpen, toggle, colspan }">
+            <td
+              :colspan="colspan"
+              class="p-2 bg-rui-grey-100 dark:bg-rui-grey-800"
+            >
+              <RuiButton
+                size="sm"
+                variant="text"
+                data-id="custom-group-toggle"
+                @click="toggle()"
+              >
+                <span data-id="custom-group-header">
+                  {{ isOpen ? 'Hide' : 'Show' }} {{ header.identifier }}
+                </span>
+              </RuiButton>
+            </td>
+          </template>
+        </RuiDataTable>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/example/src/views/data-tables/index.vue
+++ b/apps/example/src/views/data-tables/index.vue
@@ -51,6 +51,12 @@ const sections = [
     route: '/data-tables/empty',
     icon: 'lu-inbox',
   },
+  {
+    title: 'Custom Slots',
+    description: 'Custom column headers, group headers, and body slots',
+    route: '/data-tables/custom-slots',
+    icon: 'lu-square-dashed-bottom-code',
+  },
 ];
 </script>
 

--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -228,6 +228,45 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(wrapper.find('tbody tr:nth-child(4) div[data-id=expanded-content]').exists()).toBeFalsy();
   });
 
+  it('should not render an expanded row when no expanded-item slot is provided', async () => {
+    wrapper = createWrapper({
+      props: {
+        'expanded': [data[0]!],
+        'modelValue': [],
+        'onUpdate:expanded': (e: any) => wrapper.setProps({ expanded: e }),
+        'rowAttr': 'id',
+        'rows': data,
+      },
+    });
+
+    await nextTick();
+
+    // Row is expanded and `expandable` is true (expanded model is bound), but with no
+    // `expanded-item` slot there is nothing to show, so no expanded row should render.
+    expect(wrapper.find('tr[data-id=row-expanded]').exists()).toBeFalsy();
+
+    // Providing the slot restores the expanded row.
+    wrapper = createWrapper({
+      props: {
+        'expanded': [data[0]!],
+        'modelValue': [],
+        'onUpdate:expanded': (e: any) => wrapper.setProps({ expanded: e }),
+        'rowAttr': 'id',
+        'rows': data,
+      },
+      slots: {
+        'expanded-item': {
+          template: '<div data-id="expanded-content">Expanded content</div>',
+        },
+      },
+    });
+
+    await nextTick();
+
+    expect(wrapper.find('tr[data-id=row-expanded]').exists()).toBeTruthy();
+    expect(wrapper.find('tr[data-id=row-expanded] div[data-id=expanded-content]').exists()).toBeTruthy();
+  });
+
   it('should sticky header behaves as expected', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
@@ -20,8 +20,13 @@ interface User {
 
 type DataTableProps = ComponentPropsAndSlots<typeof RuiDataTable<User>>;
 
-type DataTableMetaArgs = Required<Pick<DataTableProps, 'columnAttr' | 'dense' | 'loading' | 'outlined' | 'rounded' | 'rowAttr' | 'rows' | 'striped'>>
-  & Partial<Pick<DataTableProps, 'modelValue'>>;
+type DataTableMetaArgs = Required<
+  Pick<
+    DataTableProps,
+    'columnAttr' | 'dense' | 'loading' | 'outlined' | 'rounded' | 'rowAttr' | 'rows' | 'striped'
+  >
+> &
+Partial<Pick<DataTableProps, 'modelValue'>>;
 
 function render(args: DataTableProps) {
   return {

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -1,12 +1,8 @@
 <script lang="ts" setup generic="T extends object, IdType extends keyof T = keyof T">
-import RuiButton from '@/components/buttons/button/RuiButton.vue';
-import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
-import RuiIcon from '@/components/icons/RuiIcon.vue';
-import RuiTooltip from '@/components/overlays/tooltip/RuiTooltip.vue';
-import RuiProgress from '@/components/progress/RuiProgress.vue';
-import { dataTableStyles, getAlignClass } from '@/components/tables/data-table-styles';
-import RuiExpandButton from '@/components/tables/RuiExpandButton.vue';
-import RuiTableEmptyState from '@/components/tables/RuiTableEmptyState.vue';
+import type { GroupHeader } from '@/composables/tables/data-table/types';
+import { dataTableStyles } from '@/components/tables/data-table-styles';
+import { type DataTableClasses, provideDataTableContext } from '@/components/tables/data-table/context';
+import RuiDataTableBody from '@/components/tables/data-table/RuiDataTableBody.vue';
 import RuiTableHead, {
   type GroupData,
   type TableColumn,
@@ -16,6 +12,7 @@ import RuiTableHead, {
 import RuiTablePagination, {
   type TablePaginationData,
 } from '@/components/tables/RuiTablePagination.vue';
+import { GroupExpandButtonPosition } from '@/components/tables/table-props';
 import { useTable } from '@/composables/defaults/table';
 import { useStickyTableHeader } from '@/composables/sticky-header';
 import { useTableColumns } from '@/composables/tables/data-table/columns';
@@ -24,7 +21,6 @@ import { useTableGrouping } from '@/composables/tables/data-table/grouping';
 import { useTablePagination } from '@/composables/tables/data-table/pagination';
 import { useTableSelection } from '@/composables/tables/data-table/selection';
 import { useTableSort } from '@/composables/tables/data-table/sort';
-import { type GroupHeader, isRow } from '@/composables/tables/data-table/types';
 
 export type { GroupedTableRow, GroupHeader, TableOptions } from '@/composables/tables/data-table/types';
 
@@ -110,7 +106,7 @@ export interface Props<T, K extends keyof T> {
    * When true, changing the items per page setting in one table will affect other tables.
    */
   globalItemsPerPage?: boolean;
-  groupExpandButtonPosition?: 'start' | 'end';
+  groupExpandButtonPosition?: GroupExpandButtonPosition;
   disabledRows?: readonly T[];
   multiPageSelect?: boolean;
   itemClass?: ((item: T) => string) | string;
@@ -153,7 +149,7 @@ const {
   stickyHeader = false,
   stickyOffset,
   globalItemsPerPage = undefined,
-  groupExpandButtonPosition = 'start',
+  groupExpandButtonPosition = GroupExpandButtonPosition.start,
   disabledRows,
   multiPageSelect = false,
   itemClass = '',
@@ -229,14 +225,12 @@ const {
   isHiddenRow,
   onToggleExpandGroup,
   onUngroup,
-  onCopyGroup,
 } = useTableGrouping<T, IdType>(
   { rowAttr },
   {
     group,
     collapsed,
     sorted,
-    emitCopyGroup: (value: GroupData<T>) => emit('copy:group', value),
   },
 );
 
@@ -271,7 +265,17 @@ const { columns, colspan, headerSlots, cellValue } = useTableColumns<T, IdType>(
   groupKeys,
   selectedData,
   slots,
+  tdResolver: options => get(ui).td(options),
 });
+
+const ITEM_SLOT_PREFIX = 'item.';
+
+// Slot keys are static for the component lifetime — no reactivity needed
+const itemSlotKeys: Set<string> = new Set(
+  Object.keys(slots)
+    .filter((key): key is `item.${string}` => key.startsWith(ITEM_SLOT_PREFIX))
+    .map(key => key.slice(ITEM_SLOT_PREFIX.length)),
+);
 
 const {
   isAllSelected,
@@ -297,7 +301,8 @@ function onSort(payload: Parameters<typeof applySort>[0]): void {
 }
 
 function onPaginate(): void {
-  set(expanded, []);
+  if ((get(expanded)?.length ?? 0) > 0)
+    set(expanded, []);
   if (!multiPageSelect)
     onToggleAll(false);
   resetCheckboxShiftState();
@@ -326,6 +331,49 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
   dense,
   striped,
 }));
+
+const classes = computed<DataTableClasses>(() => {
+  const s = get(ui);
+  return {
+    td: s.td(),
+    tr: s.tr(),
+    trSelected: s.tr({ rowVariant: 'selected' }),
+    trExpandable: s.tr({ rowVariant: 'expandable' }),
+    trGroup: s.tr({ rowVariant: 'group' }),
+    trEmpty: s.tr({ rowVariant: 'empty' }),
+    checkbox: s.checkbox(),
+    tbody: s.tbody(),
+    tbodyLoader: s.tbodyLoader(),
+    tbodyLoaderContent: s.tbodyLoaderContent(),
+  };
+});
+
+provideDataTableContext<T, IdType>({
+  // Reactive (ComputedRef/Ref) — destructuring preserves reactivity via Vue template auto-unwrap
+  classes,
+  columns,
+  colspan,
+  expandable,
+  groupKey,
+  selectedData,
+  // Static values
+  cellValue,
+  dense,
+  getRowId: (row: T) => row[rowAttr],
+  itemSlotKeys,
+  groupExpandButtonPosition,
+  isDisabledRow,
+  isExpanded,
+  isExpandedGroup,
+  isSelected,
+  itemClass,
+  onCheckboxClick,
+  onCopyGroup: (header: GroupHeader<T>) => emit('copy:group', { key: get(groupKey) ?? '', value: header.group }),
+  onSelect,
+  onToggleExpand,
+  onToggleExpandGroup,
+  onUngroup,
+});
 </script>
 
 <template>
@@ -363,7 +411,6 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
           :dense="dense"
           :disable-check-all="!filtered?.length"
           :is-all-selected="isAllSelected"
-          :no-data="noData"
           :selectable="!!selectedData"
           :sort-data="sortData"
           :sorted-map="sortedMap"
@@ -390,7 +437,6 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
           :column-attr="columnAttr"
           :columns="columns"
           :dense="dense"
-          :no-data="noData"
           :selectable="!!selectedData"
           :sort-data="sortData"
           :sorted-map="sortedMap"
@@ -407,230 +453,87 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
             />
           </template>
         </RuiTableHead>
-        <tbody :class="ui.tbody()">
-          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-          <slot
+        <RuiDataTableBody
+          :filtered="filtered"
+          :loading="loading"
+          :no-data="noData"
+          :empty="empty"
+        >
+          <template
             v-if="slots['body.prepend']"
-            :colspan="colspan"
-            name="body.prepend"
-          />
-          <template v-for="(row, index) in filtered">
-            <tr
-              v-if="!isRow(row)"
-              :key="`row-${index}`"
-              :class="[ui.tr({ rowVariant: 'group' })]"
-              data-id="row-group"
-            >
-              <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-              <slot
-                name="group.header"
-                :colspan="colspan"
-                :header="row"
-                :is-open="isExpandedGroup(row.group)"
-                :toggle="() => onToggleExpandGroup(row.group, row.identifier)"
-              >
-                <td
-                  :class="[ui.td()]"
-                  class="!p-2"
-                  :colspan="colspan"
-                >
-                  <div class="flex items-center gap-2">
-                    <RuiExpandButton
-                      v-if="groupExpandButtonPosition === 'start'"
-                      :expanded="isExpandedGroup(row.group)"
-                      @click="onToggleExpandGroup(row.group, row.identifier)"
-                    />
-                    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                    <slot
-                      :group-key="groupKey"
-                      name="group.header.content"
-                      :header="row"
-                    >
-                      <span>{{ groupKey }}: {{ row.identifier }}</span>
-                      <RuiButton
-                        size="sm"
-                        variant="text"
-                        icon
-                        data-id="group-copy-button"
-                        @click="onCopyGroup({ key: groupKey, value: row.group })"
-                      >
-                        <RuiIcon
-                          name="lu-copy"
-                          size="16"
-                        />
-                      </RuiButton>
-                    </slot>
-                    <RuiTooltip
-                      :options="{ placement: 'top' }"
-                      class="ml-auto mr-2"
-                    >
-                      <template #activator>
-                        <RuiButton
-                          size="sm"
-                          variant="text"
-                          icon
-                          data-id="group-ungroup-button"
-                          @click="onUngroup()"
-                        >
-                          <RuiIcon
-                            name="lu-trash-2"
-                            size="14"
-                          />
-                        </RuiButton>
-                      </template>
-                      Ungroup
-                    </RuiTooltip>
-                    <RuiExpandButton
-                      v-if="groupExpandButtonPosition === 'end'"
-                      :expanded="isExpandedGroup(row.group)"
-                      @click="onToggleExpandGroup(row.group, row.identifier)"
-                    />
-                  </div>
-                </td>
-              </slot>
-            </tr>
-            <template v-else>
-              <tr
-                :key="`row-${index}`"
-                :class="[
-                  ui.tr({ rowVariant: isSelected(row[rowAttr]) ? 'selected' : undefined }),
-                  typeof itemClass === 'string' ? itemClass : itemClass(row),
-                ]"
-                :aria-selected="selectedData ? isSelected(row[rowAttr]) : undefined"
-                data-id="row"
-              >
-                <td
-                  v-if="selectedData"
-                  :class="ui.checkbox()"
-                  colspan="1"
-                  rowspan="1"
-                >
-                  <RuiCheckbox
-                    :data-id="`table-toggle-check-${index}`"
-                    :model-value="isSelected(row[rowAttr])"
-                    :disabled="isDisabledRow(row[rowAttr])"
-                    :size="dense ? 'sm' : undefined"
-                    color="primary"
-                    class="select-none"
-                    hide-details
-                    @update:model-value="onSelect($event, row[rowAttr], true)"
-                    @click="onCheckboxClick($event, row[rowAttr], index)"
-                  />
-                </td>
-
-                <td
-                  v-for="(column, subIndex) in columns"
-                  :key="subIndex"
-                  :class="[
-                    ui.td({ class: getAlignClass(column.align) }),
-                    column.cellClass,
-                  ]"
-                  :colspan="column.colspan ?? 1"
-                  :rowspan="column.rowspan ?? 1"
-                >
-                  <slot
-                    v-if="column.key === 'expand'"
-                    :name="`item.${column.key.toString()}`"
-                    :column="column"
-                    :row="row"
-                    :index="index"
-                  >
-                    <RuiExpandButton
-                      v-if="!slots['item.expand']"
-                      :expanded="isExpanded(row[rowAttr])"
-                      @click="onToggleExpand(row)"
-                    />
-                  </slot>
-                  <slot
-                    v-else
-                    :column="column"
-                    :index="index"
-                    :name="`item.${column.key.toString()}`"
-                    :row="row"
-                  >
-                    {{ cellValue(row, column.key) }}
-                  </slot>
-                </td>
-              </tr>
-
-              <tr
-                v-if="expandable && !!$slots['expanded-item'] && isExpanded(row[rowAttr])"
-                :key="`row-expand-${index}`"
-                :class="ui.tr({ rowVariant: 'expandable' })"
-                data-id="row-expanded"
-              >
-                <td
-                  :colspan="colspan"
-                  :class="[ui.td()]"
-                >
-                  <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                  <slot
-                    name="expanded-item"
-                    :row="row"
-                    :index="index"
-                  />
-                </td>
-              </tr>
-            </template>
-          </template>
-          <tr v-if="loading && noData">
-            <td
-              :class="ui.tbodyLoader()"
-              :colspan="colspan"
-              data-id="tbody-loader"
-            >
-              <div :class="ui.tbodyLoaderContent()">
-                <RuiProgress
-                  color="primary"
-                  variant="indeterminate"
-                  circular
-                />
-              </div>
-            </td>
-          </tr>
-          <tr
-            v-if="noData && empty && !loading"
-            :class="ui.tr({ rowVariant: 'empty' })"
-            data-id="row-empty"
+            #body.prepend="slotData"
           >
-            <Transition
-              appear
-              enter-active-class="transition ease-out duration-200 delay-200"
-              enter-from-class="opacity-0 translate-y-1"
-              enter-to-class="opacity-100 translate-y-0"
-              leave-active-class="transition ease-in duration-150"
-              leave-from-class="opacity-100 translate-y-0"
-              leave-to-class="opacity-0 translate-y-1"
-            >
-              <td
-                :class="ui.td()"
-                :colspan="colspan"
-              >
-                <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                <slot name="no-data">
-                  <RuiTableEmptyState
-                    :label="empty.label"
-                    :description="empty.description"
-                  >
-                    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                    <template
-                      v-if="slots['empty-description']"
-                      #description
-                    >
-                      <slot name="empty-description" />
-                    </template>
-                  </RuiTableEmptyState>
-                </slot>
-              </td>
-            </Transition>
-          </tr>
-          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-          <slot
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="body.prepend"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['group.header']"
+            #group.header="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="group.header"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['group.header.content']"
+            #group.header.content="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="group.header.content"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-for="key in itemSlotKeys"
+            #[`item.${key}`]="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              :name="`item.${key}`"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['expanded-item']"
+            #expanded-item="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="expanded-item"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['no-data']"
+            #no-data
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot name="no-data" />
+          </template>
+          <template
+            v-if="slots['empty-description']"
+            #empty-description
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot name="empty-description" />
+          </template>
+          <template
             v-if="slots['body.append']"
-            :colspan="colspan"
-            name="body.append"
-          />
-        </tbody>
+            #body.append="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="body.append"
+              v-bind="slotData"
+            />
+          </template>
+        </RuiDataTableBody>
         <tfoot>
           <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
           <slot name="tfoot" />

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -1,12 +1,8 @@
 <script lang="ts" setup generic="T extends object, IdType extends keyof T = keyof T">
-import RuiButton from '@/components/buttons/button/RuiButton.vue';
-import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
-import RuiIcon from '@/components/icons/RuiIcon.vue';
-import RuiTooltip from '@/components/overlays/tooltip/RuiTooltip.vue';
-import RuiProgress from '@/components/progress/RuiProgress.vue';
-import { dataTableStyles, getAlignClass } from '@/components/tables/data-table-styles';
-import RuiExpandButton from '@/components/tables/RuiExpandButton.vue';
-import RuiTableEmptyState from '@/components/tables/RuiTableEmptyState.vue';
+import type { GroupHeader } from '@/composables/tables/data-table/types';
+import { dataTableStyles } from '@/components/tables/data-table-styles';
+import { type DataTableClasses, provideDataTableContext } from '@/components/tables/data-table/context';
+import RuiDataTableBody from '@/components/tables/data-table/RuiDataTableBody.vue';
 import RuiTableHead, {
   type GroupData,
   type TableColumn,
@@ -16,6 +12,7 @@ import RuiTableHead, {
 import RuiTablePagination, {
   type TablePaginationData,
 } from '@/components/tables/RuiTablePagination.vue';
+import { GroupExpandButtonPosition } from '@/components/tables/table-props';
 import { useTable } from '@/composables/defaults/table';
 import { useStickyTableHeader } from '@/composables/sticky-header';
 import { useTableColumns } from '@/composables/tables/data-table/columns';
@@ -24,7 +21,6 @@ import { useTableGrouping } from '@/composables/tables/data-table/grouping';
 import { useTablePagination } from '@/composables/tables/data-table/pagination';
 import { useTableSelection } from '@/composables/tables/data-table/selection';
 import { useTableSort } from '@/composables/tables/data-table/sort';
-import { type GroupHeader, isRow } from '@/composables/tables/data-table/types';
 
 export type { GroupedTableRow, GroupHeader, TableOptions } from '@/composables/tables/data-table/types';
 
@@ -110,7 +106,7 @@ export interface Props<T, K extends keyof T> {
    * When true, changing the items per page setting in one table will affect other tables.
    */
   globalItemsPerPage?: boolean;
-  groupExpandButtonPosition?: 'start' | 'end';
+  groupExpandButtonPosition?: GroupExpandButtonPosition;
   disabledRows?: readonly T[];
   multiPageSelect?: boolean;
   itemClass?: ((item: T) => string) | string;
@@ -153,7 +149,7 @@ const {
   stickyHeader = false,
   stickyOffset,
   globalItemsPerPage = undefined,
-  groupExpandButtonPosition = 'start',
+  groupExpandButtonPosition = GroupExpandButtonPosition.start,
   disabledRows,
   multiPageSelect = false,
   itemClass = '',
@@ -229,14 +225,12 @@ const {
   isHiddenRow,
   onToggleExpandGroup,
   onUngroup,
-  onCopyGroup,
 } = useTableGrouping<T, IdType>(
   { rowAttr },
   {
     group,
     collapsed,
     sorted,
-    emitCopyGroup: (value: GroupData<T>) => emit('copy:group', value),
   },
 );
 
@@ -271,7 +265,17 @@ const { columns, colspan, headerSlots, cellValue } = useTableColumns<T, IdType>(
   groupKeys,
   selectedData,
   slots,
+  tdResolver: options => get(ui).td(options),
 });
+
+const ITEM_SLOT_PREFIX = 'item.';
+
+// Slot keys are static for the component lifetime — no reactivity needed
+const itemSlotKeys: Set<string> = new Set(
+  Object.keys(slots)
+    .filter((key): key is `item.${string}` => key.startsWith(ITEM_SLOT_PREFIX))
+    .map(key => key.slice(ITEM_SLOT_PREFIX.length)),
+);
 
 const {
   isAllSelected,
@@ -297,7 +301,7 @@ function onSort(payload: Parameters<typeof applySort>[0]): void {
 }
 
 function onPaginate(): void {
-  if (get(expanded))
+  if ((get(expanded)?.length ?? 0) > 0)
     set(expanded, []);
   if (!multiPageSelect)
     onToggleAll(false);
@@ -327,6 +331,49 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
   dense,
   striped,
 }));
+
+const classes = computed<DataTableClasses>(() => {
+  const s = get(ui);
+  return {
+    td: s.td(),
+    tr: s.tr(),
+    trSelected: s.tr({ rowVariant: 'selected' }),
+    trExpandable: s.tr({ rowVariant: 'expandable' }),
+    trGroup: s.tr({ rowVariant: 'group' }),
+    trEmpty: s.tr({ rowVariant: 'empty' }),
+    checkbox: s.checkbox(),
+    tbody: s.tbody(),
+    tbodyLoader: s.tbodyLoader(),
+    tbodyLoaderContent: s.tbodyLoaderContent(),
+  };
+});
+
+provideDataTableContext<T, IdType>({
+  // Reactive (ComputedRef/Ref) — destructuring preserves reactivity via Vue template auto-unwrap
+  classes,
+  columns,
+  colspan,
+  expandable,
+  groupKey,
+  selectedData,
+  // Static values
+  cellValue,
+  dense,
+  getRowId: (row: T) => row[rowAttr],
+  itemSlotKeys,
+  groupExpandButtonPosition,
+  isDisabledRow,
+  isExpanded,
+  isExpandedGroup,
+  isSelected,
+  itemClass,
+  onCheckboxClick,
+  onCopyGroup: (header: GroupHeader<T>) => emit('copy:group', { key: get(groupKey) ?? '', value: header.group }),
+  onSelect,
+  onToggleExpand,
+  onToggleExpandGroup,
+  onUngroup,
+});
 </script>
 
 <template>
@@ -364,7 +411,6 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
           :dense="dense"
           :disable-check-all="!filtered?.length"
           :is-all-selected="isAllSelected"
-          :no-data="noData"
           :selectable="!!selectedData"
           :sort-data="sortData"
           :sorted-map="sortedMap"
@@ -391,7 +437,6 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
           :column-attr="columnAttr"
           :columns="columns"
           :dense="dense"
-          :no-data="noData"
           :selectable="!!selectedData"
           :sort-data="sortData"
           :sorted-map="sortedMap"
@@ -408,230 +453,87 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
             />
           </template>
         </RuiTableHead>
-        <tbody :class="ui.tbody()">
-          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-          <slot
+        <RuiDataTableBody
+          :filtered="filtered"
+          :loading="loading"
+          :no-data="noData"
+          :empty="empty"
+        >
+          <template
             v-if="slots['body.prepend']"
-            :colspan="colspan"
-            name="body.prepend"
-          />
-          <template v-for="(row, index) in filtered">
-            <tr
-              v-if="!isRow(row)"
-              :key="`row-${index}`"
-              :class="[ui.tr({ rowVariant: 'group' })]"
-              data-id="row-group"
-            >
-              <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-              <slot
-                name="group.header"
-                :colspan="colspan"
-                :header="row"
-                :is-open="isExpandedGroup(row.group)"
-                :toggle="() => onToggleExpandGroup(row.group, row.identifier)"
-              >
-                <td
-                  :class="[ui.td()]"
-                  class="!p-2"
-                  :colspan="colspan"
-                >
-                  <div class="flex items-center gap-2">
-                    <RuiExpandButton
-                      v-if="groupExpandButtonPosition === 'start'"
-                      :expanded="isExpandedGroup(row.group)"
-                      @click="onToggleExpandGroup(row.group, row.identifier)"
-                    />
-                    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                    <slot
-                      :group-key="groupKey"
-                      name="group.header.content"
-                      :header="row"
-                    >
-                      <span>{{ groupKey }}: {{ row.identifier }}</span>
-                      <RuiButton
-                        size="sm"
-                        variant="text"
-                        icon
-                        data-id="group-copy-button"
-                        @click="onCopyGroup({ key: groupKey, value: row.group })"
-                      >
-                        <RuiIcon
-                          name="lu-copy"
-                          size="16"
-                        />
-                      </RuiButton>
-                    </slot>
-                    <RuiTooltip
-                      :options="{ placement: 'top' }"
-                      class="ml-auto mr-2"
-                    >
-                      <template #activator>
-                        <RuiButton
-                          size="sm"
-                          variant="text"
-                          icon
-                          data-id="group-ungroup-button"
-                          @click="onUngroup()"
-                        >
-                          <RuiIcon
-                            name="lu-trash-2"
-                            size="14"
-                          />
-                        </RuiButton>
-                      </template>
-                      Ungroup
-                    </RuiTooltip>
-                    <RuiExpandButton
-                      v-if="groupExpandButtonPosition === 'end'"
-                      :expanded="isExpandedGroup(row.group)"
-                      @click="onToggleExpandGroup(row.group, row.identifier)"
-                    />
-                  </div>
-                </td>
-              </slot>
-            </tr>
-            <template v-else>
-              <tr
-                :key="`row-${index}`"
-                :class="[
-                  ui.tr({ rowVariant: isSelected(row[rowAttr]) ? 'selected' : undefined }),
-                  typeof itemClass === 'string' ? itemClass : itemClass(row),
-                ]"
-                :aria-selected="selectedData ? isSelected(row[rowAttr]) : undefined"
-                data-id="row"
-              >
-                <td
-                  v-if="selectedData"
-                  :class="ui.checkbox()"
-                  colspan="1"
-                  rowspan="1"
-                >
-                  <RuiCheckbox
-                    :data-id="`table-toggle-check-${index}`"
-                    :model-value="isSelected(row[rowAttr])"
-                    :disabled="isDisabledRow(row[rowAttr])"
-                    :size="dense ? 'sm' : undefined"
-                    color="primary"
-                    class="select-none"
-                    hide-details
-                    @update:model-value="onSelect($event, row[rowAttr], true)"
-                    @click="onCheckboxClick($event, row[rowAttr], index)"
-                  />
-                </td>
-
-                <td
-                  v-for="(column, subIndex) in columns"
-                  :key="subIndex"
-                  :class="[
-                    ui.td({ class: getAlignClass(column.align) }),
-                    column.cellClass,
-                  ]"
-                  :colspan="column.colspan ?? 1"
-                  :rowspan="column.rowspan ?? 1"
-                >
-                  <slot
-                    v-if="column.key === 'expand'"
-                    :name="`item.${column.key.toString()}`"
-                    :column="column"
-                    :row="row"
-                    :index="index"
-                  >
-                    <RuiExpandButton
-                      v-if="!slots['item.expand']"
-                      :expanded="isExpanded(row[rowAttr])"
-                      @click="onToggleExpand(row)"
-                    />
-                  </slot>
-                  <slot
-                    v-else
-                    :column="column"
-                    :index="index"
-                    :name="`item.${column.key.toString()}`"
-                    :row="row"
-                  >
-                    {{ cellValue(row, column.key) }}
-                  </slot>
-                </td>
-              </tr>
-
-              <tr
-                v-if="expandable && !!$slots['expanded-item'] && isExpanded(row[rowAttr])"
-                :key="`row-expand-${index}`"
-                :class="ui.tr({ rowVariant: 'expandable' })"
-                data-id="row-expanded"
-              >
-                <td
-                  :colspan="colspan"
-                  :class="[ui.td()]"
-                >
-                  <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                  <slot
-                    name="expanded-item"
-                    :row="row"
-                    :index="index"
-                  />
-                </td>
-              </tr>
-            </template>
-          </template>
-          <tr v-if="loading && noData">
-            <td
-              :class="ui.tbodyLoader()"
-              :colspan="colspan"
-              data-id="tbody-loader"
-            >
-              <div :class="ui.tbodyLoaderContent()">
-                <RuiProgress
-                  color="primary"
-                  variant="indeterminate"
-                  circular
-                />
-              </div>
-            </td>
-          </tr>
-          <tr
-            v-if="noData && empty && !loading"
-            :class="ui.tr({ rowVariant: 'empty' })"
-            data-id="row-empty"
+            #body.prepend="slotData"
           >
-            <Transition
-              appear
-              enter-active-class="transition ease-out duration-200 delay-200"
-              enter-from-class="opacity-0 translate-y-1"
-              enter-to-class="opacity-100 translate-y-0"
-              leave-active-class="transition ease-in duration-150"
-              leave-from-class="opacity-100 translate-y-0"
-              leave-to-class="opacity-0 translate-y-1"
-            >
-              <td
-                :class="ui.td()"
-                :colspan="colspan"
-              >
-                <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                <slot name="no-data">
-                  <RuiTableEmptyState
-                    :label="empty.label"
-                    :description="empty.description"
-                  >
-                    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-                    <template
-                      v-if="slots['empty-description']"
-                      #description
-                    >
-                      <slot name="empty-description" />
-                    </template>
-                  </RuiTableEmptyState>
-                </slot>
-              </td>
-            </Transition>
-          </tr>
-          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
-          <slot
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="body.prepend"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['group.header']"
+            #group.header="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="group.header"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['group.header.content']"
+            #group.header.content="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="group.header.content"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-for="key in itemSlotKeys"
+            #[`item.${key}`]="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              :name="`item.${key}`"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['expanded-item']"
+            #expanded-item="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="expanded-item"
+              v-bind="slotData"
+            />
+          </template>
+          <template
+            v-if="slots['no-data']"
+            #no-data
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot name="no-data" />
+          </template>
+          <template
+            v-if="slots['empty-description']"
+            #empty-description
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot name="empty-description" />
+          </template>
+          <template
             v-if="slots['body.append']"
-            :colspan="colspan"
-            name="body.append"
-          />
-        </tbody>
+            #body.append="slotData"
+          >
+            <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+            <slot
+              name="body.append"
+              v-bind="slotData"
+            />
+          </template>
+        </RuiDataTableBody>
         <tfoot>
           <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
           <slot name="tfoot" />

--- a/packages/ui-library/src/components/tables/RuiTableEmptyState.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiTableEmptyState.spec.ts
@@ -1,0 +1,99 @@
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiTableEmptyState from '@/components/tables/RuiTableEmptyState.vue';
+
+function createWrapper(
+  options?: ComponentMountingOptions<typeof RuiTableEmptyState>,
+) {
+  return mount(RuiTableEmptyState, options);
+}
+
+describe('components/tables/RuiTableEmptyState.vue', () => {
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should render placeholder image', () => {
+    wrapper = createWrapper();
+
+    const img = wrapper.find('img');
+    expect(img.exists()).toBeTruthy();
+    expect(img.attributes('src')).toBeTruthy();
+    expect(img.classes()).toContain('h-32');
+  });
+
+  it('should render label text when label prop is provided', () => {
+    wrapper = createWrapper({
+      props: {
+        label: 'No data available',
+      },
+    });
+
+    const label = wrapper.find('[data-id="empty-label"]');
+    expect(label.exists()).toBeTruthy();
+    expect(label.text()).toBe('No data available');
+  });
+
+  it('should not render label when no label prop is provided', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-id="empty-label"]').exists()).toBeFalsy();
+  });
+
+  it('should render description text when description prop is provided', () => {
+    wrapper = createWrapper({
+      props: {
+        description: 'Try adjusting your filters',
+      },
+    });
+
+    const description = wrapper.find('[data-id="empty-description"]');
+    expect(description.exists()).toBeTruthy();
+    expect(description.text()).toBe('Try adjusting your filters');
+  });
+
+  it('should not render description when no description prop is provided', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find('[data-id="empty-description"]').exists()).toBeFalsy();
+  });
+
+  it('should render description slot content when slot is provided', () => {
+    wrapper = createWrapper({
+      slots: {
+        description: '<span data-id="custom-description">Custom description content</span>',
+      },
+    });
+
+    const customDescription = wrapper.find('[data-id="custom-description"]');
+    expect(customDescription.exists()).toBeTruthy();
+    expect(customDescription.text()).toBe('Custom description content');
+  });
+
+  it('should prefer description slot over description prop', () => {
+    wrapper = createWrapper({
+      props: {
+        description: 'Prop description',
+      },
+      slots: {
+        description: '<span data-id="slot-description">Slot description</span>',
+      },
+    });
+
+    expect(wrapper.find('[data-id="empty-description"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-id="slot-description"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="slot-description"]').text()).toBe('Slot description');
+  });
+
+  it('should use label as image alt text', () => {
+    wrapper = createWrapper({
+      props: {
+        label: 'No results',
+      },
+    });
+
+    expect(wrapper.find('img').attributes('alt')).toBe('No results');
+  });
+});

--- a/packages/ui-library/src/components/tables/RuiTableHead.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiTableHead.spec.ts
@@ -1,0 +1,232 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiTableHead, { type TableColumn } from '@/components/tables/RuiTableHead.vue';
+import { SortDirection } from '@/components/tables/table-props';
+
+interface TestItem {
+  id: number;
+  name: string;
+  title: string;
+}
+
+const columns: TableColumn<TestItem>[] = [
+  { key: 'id', label: 'ID' },
+  { key: 'name', label: 'Name', sortable: true },
+  { key: 'title', label: 'Title', sortable: true },
+];
+
+function createWrapper(
+  options?: { props?: Record<string, unknown> },
+): ReturnType<typeof mount> {
+  return mount(RuiTableHead, {
+    ...options,
+    attachTo: (() => {
+      const table = document.createElement('table');
+      document.body.appendChild(table);
+      return table;
+    })(),
+  });
+}
+
+describe('components/tables/RuiTableHead.vue', () => {
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  afterEach(() => {
+    wrapper.unmount();
+    document.querySelectorAll('table').forEach(el => el.remove());
+  });
+
+  it('renders column headers from columns prop', () => {
+    wrapper = createWrapper({
+      props: { columns },
+    });
+
+    const headers = wrapper.findAll('th');
+    expect(headers).toHaveLength(3);
+
+    const texts = wrapper.findAll('[data-id="column-text"]');
+    expect(texts).toHaveLength(3);
+    expect(texts[0]?.text()).toBe('ID');
+    expect(texts[1]?.text()).toBe('Name');
+    expect(texts[2]?.text()).toBe('Title');
+  });
+
+  it('shows checkbox when selectable is true', () => {
+    wrapper = createWrapper({
+      props: { columns, selectable: true },
+    });
+
+    expect(wrapper.find('[data-id="table-toggle-check-all"]').exists()).toBeTruthy();
+  });
+
+  it('hides checkbox when selectable is false', () => {
+    wrapper = createWrapper({
+      props: { columns, selectable: false },
+    });
+
+    expect(wrapper.find('[data-id="table-toggle-check-all"]').exists()).toBeFalsy();
+  });
+
+  it('shows loading progress bar when loading is true', () => {
+    wrapper = createWrapper({
+      props: { columns, loading: true, colspan: 3 },
+    });
+
+    expect(wrapper.find('[data-id="thead-loader"]').exists()).toBeTruthy();
+  });
+
+  it('hides loading progress bar when loading is false', () => {
+    wrapper = createWrapper({
+      props: { columns, loading: false },
+    });
+
+    expect(wrapper.find('[data-id="thead-loader"]').exists()).toBeFalsy();
+  });
+
+  it('renders sort buttons for sortable columns', () => {
+    wrapper = createWrapper({
+      props: { columns },
+    });
+
+    const sortableHeaders = wrapper.findAll('[data-id="column-sortable"]');
+    expect(sortableHeaders).toHaveLength(2);
+  });
+
+  it('shows sort icon with correct direction when column is sorted ascending', () => {
+    wrapper = createWrapper({
+      props: {
+        columns,
+        sortedMap: {
+          name: { column: 'name', direction: SortDirection.asc },
+        },
+      },
+    });
+
+    const sortButtons = wrapper.findAll('[data-sorted]');
+    expect(sortButtons).toHaveLength(1);
+    expect(sortButtons[0]?.attributes('data-direction')).toBe('asc');
+  });
+
+  it('shows sort icon with correct direction when column is sorted descending', () => {
+    wrapper = createWrapper({
+      props: {
+        columns,
+        sortedMap: {
+          name: { column: 'name', direction: SortDirection.desc },
+        },
+      },
+    });
+
+    const sortButtons = wrapper.findAll('[data-sorted]');
+    expect(sortButtons).toHaveLength(1);
+    expect(sortButtons[0]?.attributes('data-direction')).toBe('desc');
+  });
+
+  it('shows badge with sort index for multi-sort', () => {
+    const sortData = [
+      { column: 'name' as const, direction: SortDirection.asc },
+      { column: 'title' as const, direction: SortDirection.desc },
+    ];
+
+    wrapper = createWrapper({
+      props: {
+        columns,
+        sortData,
+        sortedMap: {
+          name: sortData[0],
+          title: sortData[1],
+        },
+      },
+    });
+
+    const sortButtons = wrapper.findAll('[data-sorted]');
+    expect(sortButtons).toHaveLength(2);
+  });
+
+  it('emits sort event when sort button is clicked', async () => {
+    wrapper = createWrapper({
+      props: { columns },
+    });
+
+    const sortableHeaders = wrapper.findAll('[data-id="column-sortable"]');
+    const sortButton = sortableHeaders[0]?.find('button');
+    expect(sortButton).toBeDefined();
+    await sortButton?.trigger('click');
+
+    const emitted = wrapper.emitted('sort');
+    expect(emitted).toBeTruthy();
+    expect(emitted).toHaveLength(1);
+    expect(emitted?.[0]).toEqual([{ key: 'name', direction: SortDirection.asc }]);
+  });
+
+  it('emits select:all event when header checkbox is toggled', async () => {
+    wrapper = createWrapper({
+      props: { columns, selectable: true },
+    });
+
+    const checkbox = wrapper.find('[data-id="table-toggle-check-all"]');
+    const input = checkbox.find('input');
+    await input.setValue(true);
+
+    const emitted = wrapper.emitted('select:all');
+    expect(emitted).toBeTruthy();
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('applies sticky class when stickyHeader is true and stick is false', () => {
+    wrapper = createWrapper({
+      props: { columns, stickyHeader: true },
+    });
+
+    const thead = wrapper.find('[data-id="head-main"]');
+    expect(thead.classes()).toContain('top-0');
+    expect(thead.classes()).toContain('absolute');
+  });
+
+  it('applies fixed class when stickyHeader and stick are both true', () => {
+    wrapper = createWrapper({
+      props: { columns, stickyHeader: true, stick: true },
+    });
+
+    const thead = wrapper.find('[data-id="head-main"]');
+    expect(thead.classes()).toContain('top-0');
+    expect(thead.classes()).toContain('fixed');
+  });
+
+  it('does not apply sticky or fixed classes by default', () => {
+    wrapper = createWrapper({
+      props: { columns },
+    });
+
+    const thead = wrapper.find('[data-id="head-main"]');
+    expect(thead.classes()).not.toContain('absolute');
+    expect(thead.classes()).not.toContain('fixed');
+  });
+
+  it('applies dense variant class', () => {
+    wrapper = createWrapper({
+      props: { columns, dense: true },
+    });
+
+    const th = wrapper.find('th');
+    expect(th.classes()).toContain('py-[0.38rem]');
+  });
+
+  it('uses custom columnAttr for header text', () => {
+    const customColumns: TableColumn<TestItem>[] = [
+      { key: 'id', label: 'ID', description: 'Identifier' },
+      { key: 'name', label: 'Name', description: 'Full Name' },
+    ];
+
+    wrapper = createWrapper({
+      props: {
+        columns: customColumns,
+        columnAttr: 'description',
+      },
+    });
+
+    const texts = wrapper.findAll('[data-id="column-text"]');
+    expect(texts[0]?.text()).toBe('Identifier');
+    expect(texts[1]?.text()).toBe('Full Name');
+  });
+});

--- a/packages/ui-library/src/components/tables/RuiTableHead.vue
+++ b/packages/ui-library/src/components/tables/RuiTableHead.vue
@@ -21,6 +21,7 @@ export interface BaseTableColumn<T> {
   align?: TableAlign;
   class?: string;
   cellClass?: string;
+  tdClass?: string;
   colspan?: string | number;
   rowspan?: string | number;
 
@@ -74,7 +75,6 @@ export interface Props<T> {
   stick?: boolean;
   selectable?: boolean;
   disableCheckAll?: boolean;
-  noData?: boolean;
   colspan?: number;
   columns?: TableColumn<T>[];
   capitalizeHeaders?: boolean;

--- a/packages/ui-library/src/components/tables/RuiTablePagination.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiTablePagination.spec.ts
@@ -1,0 +1,131 @@
+import type { TablePaginationData } from '@/components/tables/use-pagination-navigation';
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiTablePagination from '@/components/tables/RuiTablePagination.vue';
+import { createTableDefaults, TableSymbol } from '@/composables/defaults/table';
+
+function createWrapper(
+  modelValue: TablePaginationData,
+  options?: Partial<ComponentMountingOptions<typeof RuiTablePagination>>,
+) {
+  return mount(RuiTablePagination, {
+    props: {
+      modelValue,
+      ...options?.props,
+    },
+    global: {
+      provide: {
+        [TableSymbol.valueOf()]: createTableDefaults({ limits: [5, 10, 25] }),
+      },
+      ...options?.global,
+    },
+  });
+}
+
+describe('components/tables/RuiTablePagination.vue', () => {
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('renders the pagination limit section', () => {
+    wrapper = createWrapper({ page: 1, total: 50, limit: 10 });
+
+    expect(wrapper.find('[data-id="table-pagination-limit-section"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="table-pagination-limit-section"]').text()).toContain('Rows per page:');
+  });
+
+  it('renders the pagination ranges section', () => {
+    wrapper = createWrapper({ page: 1, total: 50, limit: 10 });
+
+    expect(wrapper.find('[data-id="table-pagination-ranges-section"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="table-pagination-ranges-section"]').text()).toContain('Items #');
+  });
+
+  it('renders all navigation buttons', () => {
+    wrapper = createWrapper({ page: 2, total: 50, limit: 10 });
+
+    expect(wrapper.find('[data-id="table-pagination-first"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="table-pagination-prev"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="table-pagination-next"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="table-pagination-last"]').exists()).toBeTruthy();
+  });
+
+  it('disables prev and first buttons on the first page', () => {
+    wrapper = createWrapper({ page: 1, total: 50, limit: 10 });
+
+    const firstBtn = wrapper.find('[data-id="table-pagination-first"]');
+    const prevBtn = wrapper.find('[data-id="table-pagination-prev"]');
+
+    expect(firstBtn.attributes('disabled')).toBeDefined();
+    expect(prevBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('disables next and last buttons on the last page', () => {
+    wrapper = createWrapper({ page: 5, total: 50, limit: 10 });
+
+    const nextBtn = wrapper.find('[data-id="table-pagination-next"]');
+    const lastBtn = wrapper.find('[data-id="table-pagination-last"]');
+
+    expect(nextBtn.attributes('disabled')).toBeDefined();
+    expect(lastBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('enables all navigation buttons on a middle page', () => {
+    wrapper = createWrapper({ page: 3, total: 50, limit: 10 });
+
+    const firstBtn = wrapper.find('[data-id="table-pagination-first"]');
+    const prevBtn = wrapper.find('[data-id="table-pagination-prev"]');
+    const nextBtn = wrapper.find('[data-id="table-pagination-next"]');
+    const lastBtn = wrapper.find('[data-id="table-pagination-last"]');
+
+    expect(firstBtn.attributes('disabled')).toBeUndefined();
+    expect(prevBtn.attributes('disabled')).toBeUndefined();
+    expect(nextBtn.attributes('disabled')).toBeUndefined();
+    expect(lastBtn.attributes('disabled')).toBeUndefined();
+  });
+
+  it('shows correct indicator text', () => {
+    wrapper = createWrapper({ page: 1, total: 50, limit: 10 });
+
+    const rangesSection = wrapper.find('[data-id="table-pagination-ranges-section"]');
+    expect(rangesSection.text()).toContain('of 50');
+  });
+
+  it('shows "0 of 0" when total is zero', () => {
+    wrapper = createWrapper({ page: 1, total: 0, limit: 10 });
+
+    const rangesSection = wrapper.find('[data-id="table-pagination-ranges-section"]');
+    expect(rangesSection.text()).toContain('0 of 0');
+  });
+
+  it('applies dense mode styles to the wrapper', () => {
+    wrapper = createWrapper(
+      { page: 1, total: 50, limit: 10 },
+      { props: { modelValue: { page: 1, total: 50, limit: 10 }, dense: true } },
+    );
+
+    const wrapperEl = wrapper.find('[data-id="table-pagination-navigation"]').element.parentElement;
+    expect(wrapperEl?.className).toContain('gap-x-2');
+  });
+
+  it('does not apply dense gap class by default', () => {
+    wrapper = createWrapper({ page: 1, total: 50, limit: 10 });
+
+    const wrapperEl = wrapper.find('[data-id="table-pagination-navigation"]').element.parentElement;
+    expect(wrapperEl?.className).toContain('gap-x-4');
+  });
+
+  it('disables all navigation buttons when loading', () => {
+    wrapper = createWrapper(
+      { page: 3, total: 50, limit: 10 },
+      { props: { modelValue: { page: 3, total: 50, limit: 10 }, loading: true } },
+    );
+
+    expect(wrapper.find('[data-id="table-pagination-first"]').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-id="table-pagination-prev"]').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-id="table-pagination-next"]').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-id="table-pagination-last"]').attributes('disabled')).toBeDefined();
+  });
+});

--- a/packages/ui-library/src/components/tables/data-table-styles.ts
+++ b/packages/ui-library/src/components/tables/data-table-styles.ts
@@ -1,7 +1,5 @@
 import { tv } from '@/utils/tv';
 
-export { getAlignClass } from '@/components/tables/table-props';
-
 export const dataTableStyles = tv({
   slots: {
     wrapper: 'relative divide-y divide-black/[0.12] dark:divide-white/[0.12] overflow-hidden',

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableBody.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableBody.vue
@@ -1,0 +1,129 @@
+<script lang="ts" setup generic="T extends object">
+import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
+import { useDataTableColumns, useDataTableRowIdentity, useDataTableStyling } from '@/components/tables/data-table/context';
+import RuiDataTableEmptyRow from '@/components/tables/data-table/RuiDataTableEmptyRow.vue';
+import RuiDataTableGroupRow from '@/components/tables/data-table/RuiDataTableGroupRow.vue';
+import RuiDataTableLoadingRow from '@/components/tables/data-table/RuiDataTableLoadingRow.vue';
+import RuiDataTableRow from '@/components/tables/data-table/RuiDataTableRow.vue';
+import { type GroupHeader, isRow } from '@/composables/tables/data-table/types';
+
+defineProps<{
+  filtered: (T | GroupHeader<T>)[];
+  loading: boolean;
+  noData: boolean;
+  empty: { label?: string; description?: string };
+}>();
+
+defineSlots<Partial<
+  Record<`item.${string}`, (props: { column: TableColumn<T>; row: T; index: number }) => any> & {
+    'body.prepend'?: (props: { colspan: number }) => any;
+    'body.append'?: (props: { colspan: number }) => any;
+    'group.header'?: (props: {
+      colspan: number;
+      header: GroupHeader<T>;
+      isOpen: boolean;
+      toggle: () => void;
+    }) => any;
+    'group.header.content'?: (props: { header: GroupHeader<T>; groupKey: string }) => any;
+    'expanded-item'?: (props: { row: T; index: number }) => any;
+    'no-data'?: () => any;
+    'empty-description'?: () => any;
+  }
+>>();
+
+const { classes, colspan } = useDataTableStyling();
+const { itemSlotKeys } = useDataTableColumns<T>();
+const { getRowId } = useDataTableRowIdentity<T>();
+</script>
+
+<template>
+  <tbody :class="classes.tbody">
+    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+    <slot
+      v-if="$slots['body.prepend']"
+      :colspan="colspan"
+      name="body.prepend"
+    />
+    <template v-for="(row, index) in filtered">
+      <RuiDataTableGroupRow
+        v-if="!isRow(row)"
+        :key="`group-${row.identifier}`"
+        :row="row"
+      >
+        <template
+          v-if="$slots['group.header']"
+          #group.header="slotData"
+        >
+          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+          <slot
+            name="group.header"
+            v-bind="slotData"
+          />
+        </template>
+        <template
+          v-if="$slots['group.header.content']"
+          #group.header.content="slotData"
+        >
+          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+          <slot
+            name="group.header.content"
+            v-bind="slotData"
+          />
+        </template>
+      </RuiDataTableGroupRow>
+      <RuiDataTableRow
+        v-else
+        :key="`row-${getRowId(row)}`"
+        :row="row"
+        :index="index"
+      >
+        <template
+          v-for="key in itemSlotKeys"
+          #[`item.${key}`]="slotData"
+        >
+          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+          <slot
+            :name="`item.${key}`"
+            v-bind="slotData"
+          />
+        </template>
+        <template
+          v-if="$slots['expanded-item']"
+          #expanded-item="slotData"
+        >
+          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+          <slot
+            name="expanded-item"
+            v-bind="slotData"
+          />
+        </template>
+      </RuiDataTableRow>
+    </template>
+    <RuiDataTableLoadingRow v-if="loading && noData" />
+    <RuiDataTableEmptyRow
+      v-if="noData && empty && !loading"
+      :empty="empty"
+    >
+      <template
+        v-if="$slots['no-data']"
+        #no-data
+      >
+        <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+        <slot name="no-data" />
+      </template>
+      <template
+        v-if="$slots['empty-description']"
+        #empty-description
+      >
+        <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+        <slot name="empty-description" />
+      </template>
+    </RuiDataTableEmptyRow>
+    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+    <slot
+      v-if="$slots['body.append']"
+      :colspan="colspan"
+      name="body.append"
+    />
+  </tbody>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableCell.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableCell.vue
@@ -1,0 +1,45 @@
+<script lang="ts" setup generic="T extends object">
+import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
+import { useDataTableColumns, useDataTableExpansion } from '@/components/tables/data-table/context';
+import RuiExpandButton from '@/components/tables/RuiExpandButton.vue';
+
+defineProps<{
+  column: TableColumn<T>;
+  row: T;
+  index: number;
+  rowId?: T[keyof T];
+}>();
+
+defineSlots<{
+  default?: (props: { column: TableColumn<T>; row: T; index: number }) => any;
+}>();
+
+const { cellValue } = useDataTableColumns<T>();
+const { isExpanded, onToggleExpand } = useDataTableExpansion<T>();
+</script>
+
+<template>
+  <td
+    :class="[
+      column.tdClass,
+      column.cellClass,
+    ]"
+    :colspan="column.colspan ?? 1"
+    :rowspan="column.rowspan ?? 1"
+  >
+    <slot
+      :column="column"
+      :row="row"
+      :index="index"
+    >
+      <RuiExpandButton
+        v-if="column.key === 'expand'"
+        :expanded="rowId !== undefined && isExpanded(rowId)"
+        @click="onToggleExpand(row)"
+      />
+      <template v-else>
+        {{ cellValue(row, column.key) }}
+      </template>
+    </slot>
+  </td>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableEmptyRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableEmptyRow.vue
@@ -1,0 +1,51 @@
+<script lang="ts" setup>
+import { useDataTableStyling } from '@/components/tables/data-table/context';
+import RuiTableEmptyState from '@/components/tables/RuiTableEmptyState.vue';
+
+defineProps<{
+  empty: { label?: string; description?: string };
+}>();
+
+defineSlots<{
+  'no-data'?: () => any;
+  'empty-description'?: () => any;
+}>();
+
+const { classes, colspan } = useDataTableStyling();
+</script>
+
+<template>
+  <tr
+    :class="classes.trEmpty"
+    data-id="row-empty"
+  >
+    <Transition
+      appear
+      enter-active-class="transition ease-out duration-200 delay-200"
+      enter-from-class="opacity-0 translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition ease-in duration-150"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 translate-y-1"
+    >
+      <td
+        :class="classes.td"
+        :colspan="colspan"
+      >
+        <slot name="no-data">
+          <RuiTableEmptyState
+            :label="empty.label"
+            :description="empty.description"
+          >
+            <template
+              v-if="$slots['empty-description']"
+              #description
+            >
+              <slot name="empty-description" />
+            </template>
+          </RuiTableEmptyState>
+        </slot>
+      </td>
+    </Transition>
+  </tr>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableExpandedRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableExpandedRow.vue
@@ -1,0 +1,32 @@
+<script lang="ts" setup generic="T extends object">
+import { useDataTableStyling } from '@/components/tables/data-table/context';
+
+defineProps<{
+  row: T;
+  index: number;
+}>();
+
+defineSlots<{
+  'expanded-item': (props: { row: T; index: number }) => any;
+}>();
+
+const { classes, colspan } = useDataTableStyling();
+</script>
+
+<template>
+  <tr
+    :class="classes.trExpandable"
+    data-id="row-expanded"
+  >
+    <td
+      :colspan="colspan"
+      :class="classes.td"
+    >
+      <slot
+        name="expanded-item"
+        :row="row"
+        :index="index"
+      />
+    </td>
+  </tr>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableGroupRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableGroupRow.vue
@@ -1,0 +1,110 @@
+<script lang="ts" setup generic="T extends object">
+import type { GroupHeader } from '@/composables/tables/data-table/types';
+import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
+import RuiTooltip from '@/components/overlays/tooltip/RuiTooltip.vue';
+import { useDataTableGrouping, useDataTableStyling } from '@/components/tables/data-table/context';
+import RuiExpandButton from '@/components/tables/RuiExpandButton.vue';
+import { GroupExpandButtonPosition } from '@/components/tables/table-props';
+
+const { row } = defineProps<{
+  row: GroupHeader<T>;
+}>();
+
+defineSlots<{
+  'group.header'?: (props: {
+    colspan: number;
+    header: GroupHeader<T>;
+    isOpen: boolean;
+    toggle: () => void;
+  }) => any;
+  'group.header.content'?: (props: { header: GroupHeader<T>; groupKey: string }) => any;
+}>();
+
+const { classes, colspan } = useDataTableStyling();
+const {
+  groupExpandButtonPosition,
+  groupKey,
+  isExpandedGroup,
+  onCopyGroup,
+  onToggleExpandGroup,
+  onUngroup,
+} = useDataTableGrouping<T>();
+
+const isOpen = computed<boolean>(() => isExpandedGroup(row.group));
+</script>
+
+<template>
+  <tr
+    :class="classes.trGroup"
+    data-id="row-group"
+  >
+    <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+    <slot
+      name="group.header"
+      :colspan="colspan"
+      :header="row"
+      :is-open="isOpen"
+      :toggle="() => onToggleExpandGroup(row.group, row.identifier)"
+    >
+      <td
+        :class="classes.td"
+        class="!p-2"
+        :colspan="colspan"
+      >
+        <div class="flex items-center gap-2">
+          <RuiExpandButton
+            v-if="groupExpandButtonPosition === GroupExpandButtonPosition.start"
+            :expanded="isOpen"
+            @click="onToggleExpandGroup(row.group, row.identifier)"
+          />
+          <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+          <slot
+            :group-key="groupKey ?? ''"
+            name="group.header.content"
+            :header="row"
+          >
+            <span>{{ groupKey }}: {{ row.identifier }}</span>
+            <RuiButton
+              size="sm"
+              variant="text"
+              icon
+              data-id="group-copy-button"
+              @click="onCopyGroup(row)"
+            >
+              <RuiIcon
+                name="lu-copy"
+                size="16"
+              />
+            </RuiButton>
+          </slot>
+          <RuiTooltip
+            :options="{ placement: 'top' }"
+            class="ml-auto mr-2"
+          >
+            <template #activator>
+              <RuiButton
+                size="sm"
+                variant="text"
+                icon
+                data-id="group-ungroup-button"
+                @click="onUngroup()"
+              >
+                <RuiIcon
+                  name="lu-trash-2"
+                  size="14"
+                />
+              </RuiButton>
+            </template>
+            Ungroup
+          </RuiTooltip>
+          <RuiExpandButton
+            v-if="groupExpandButtonPosition === GroupExpandButtonPosition.end"
+            :expanded="isOpen"
+            @click="onToggleExpandGroup(row.group, row.identifier)"
+          />
+        </div>
+      </td>
+    </slot>
+  </tr>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableLoadingRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableLoadingRow.vue
@@ -1,0 +1,24 @@
+<script lang="ts" setup>
+import RuiProgress from '@/components/progress/RuiProgress.vue';
+import { useDataTableStyling } from '@/components/tables/data-table/context';
+
+const { classes, colspan } = useDataTableStyling();
+</script>
+
+<template>
+  <tr>
+    <td
+      :class="classes.tbodyLoader"
+      :colspan="colspan"
+      data-id="tbody-loader"
+    >
+      <div :class="classes.tbodyLoaderContent">
+        <RuiProgress
+          color="primary"
+          variant="indeterminate"
+          circular
+        />
+      </div>
+    </td>
+  </tr>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
@@ -1,0 +1,96 @@
+<script lang="ts" setup generic="T extends object">
+import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
+import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
+import { useDataTableColumns, useDataTableExpansion, useDataTableRowIdentity, useDataTableSelection, useDataTableStyling } from '@/components/tables/data-table/context';
+import RuiDataTableCell from '@/components/tables/data-table/RuiDataTableCell.vue';
+import RuiDataTableExpandedRow from '@/components/tables/data-table/RuiDataTableExpandedRow.vue';
+
+const {
+  row,
+  index,
+} = defineProps<{
+  row: T;
+  index: number;
+}>();
+
+const slots = defineSlots<Partial<
+  Record<`item.${string}`, (props: { column: TableColumn<T>; row: T; index: number }) => any> & {
+    'expanded-item'?: (props: { row: T; index: number }) => any;
+  }
+>>();
+
+const { classes, dense } = useDataTableStyling();
+const { columns, itemSlotKeys } = useDataTableColumns<T>();
+const { isDisabledRow, isSelected, onCheckboxClick, onSelect, selectedData } = useDataTableSelection<T>();
+const { expandable, isExpanded } = useDataTableExpansion<T>();
+const { getRowId, itemClass } = useDataTableRowIdentity<T>();
+
+const rowId = computed<T[keyof T]>(() => getRowId(row));
+const selected = computed<boolean>(() => isSelected(get(rowId)));
+const disabled = computed<boolean>(() => isDisabledRow(get(rowId)));
+const expanded = computed<boolean>(() => get(expandable) && isExpanded(get(rowId)));
+const rowClass = computed<string>(() => typeof itemClass === 'string' ? itemClass : itemClass(row));
+</script>
+
+<template>
+  <tr
+    :class="[selected ? classes.trSelected : classes.tr, rowClass]"
+    :aria-selected="selectedData ? selected : undefined"
+    data-id="row"
+  >
+    <td
+      v-if="selectedData"
+      :class="classes.checkbox"
+      colspan="1"
+      rowspan="1"
+    >
+      <RuiCheckbox
+        :data-id="`table-toggle-check-${index}`"
+        :model-value="selected"
+        :disabled="disabled"
+        :size="dense ? 'sm' : undefined"
+        color="primary"
+        class="select-none"
+        hide-details
+        @update:model-value="onSelect($event, rowId, true)"
+        @click="onCheckboxClick($event, rowId, index)"
+      />
+    </td>
+
+    <RuiDataTableCell
+      v-for="(column, subIndex) in columns"
+      :key="subIndex"
+      :column="column"
+      :row="row"
+      :index="index"
+      :row-id="rowId"
+    >
+      <template
+        v-if="itemSlotKeys.has(column.key.toString())"
+        #default="slotData"
+      >
+        <slot
+          :name="`item.${column.key.toString()}`"
+          v-bind="slotData"
+        />
+      </template>
+    </RuiDataTableCell>
+  </tr>
+
+  <RuiDataTableExpandedRow
+    v-if="expanded"
+    :row="row"
+    :index="index"
+  >
+    <template
+      v-if="slots['expanded-item']"
+      #expanded-item="slotData"
+    >
+      <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+      <slot
+        name="expanded-item"
+        v-bind="slotData"
+      />
+    </template>
+  </RuiDataTableExpandedRow>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
@@ -1,0 +1,96 @@
+<script lang="ts" setup generic="T extends object">
+import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
+import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
+import { useDataTableColumns, useDataTableExpansion, useDataTableRowIdentity, useDataTableSelection, useDataTableStyling } from '@/components/tables/data-table/context';
+import RuiDataTableCell from '@/components/tables/data-table/RuiDataTableCell.vue';
+import RuiDataTableExpandedRow from '@/components/tables/data-table/RuiDataTableExpandedRow.vue';
+
+const {
+  row,
+  index,
+} = defineProps<{
+  row: T;
+  index: number;
+}>();
+
+const slots = defineSlots<Partial<
+  Record<`item.${string}`, (props: { column: TableColumn<T>; row: T; index: number }) => any> & {
+    'expanded-item'?: (props: { row: T; index: number }) => any;
+  }
+>>();
+
+const { classes, dense } = useDataTableStyling();
+const { columns, itemSlotKeys } = useDataTableColumns<T>();
+const { isDisabledRow, isSelected, onCheckboxClick, onSelect, selectedData } = useDataTableSelection<T>();
+const { expandable, isExpanded } = useDataTableExpansion<T>();
+const { getRowId, itemClass } = useDataTableRowIdentity<T>();
+
+const rowId = computed<T[keyof T]>(() => getRowId(row));
+const selected = computed<boolean>(() => isSelected(get(rowId)));
+const disabled = computed<boolean>(() => isDisabledRow(get(rowId)));
+const expanded = computed<boolean>(() => get(expandable) && !!slots['expanded-item'] && isExpanded(get(rowId)));
+const rowClass = computed<string>(() => typeof itemClass === 'string' ? itemClass : itemClass(row));
+</script>
+
+<template>
+  <tr
+    :class="[selected ? classes.trSelected : classes.tr, rowClass]"
+    :aria-selected="selectedData ? selected : undefined"
+    data-id="row"
+  >
+    <td
+      v-if="selectedData"
+      :class="classes.checkbox"
+      colspan="1"
+      rowspan="1"
+    >
+      <RuiCheckbox
+        :data-id="`table-toggle-check-${index}`"
+        :model-value="selected"
+        :disabled="disabled"
+        :size="dense ? 'sm' : undefined"
+        color="primary"
+        class="select-none"
+        hide-details
+        @update:model-value="onSelect($event, rowId, true)"
+        @click="onCheckboxClick($event, rowId, index)"
+      />
+    </td>
+
+    <RuiDataTableCell
+      v-for="(column, subIndex) in columns"
+      :key="subIndex"
+      :column="column"
+      :row="row"
+      :index="index"
+      :row-id="rowId"
+    >
+      <template
+        v-if="itemSlotKeys.has(column.key.toString())"
+        #default="slotData"
+      >
+        <slot
+          :name="`item.${column.key.toString()}`"
+          v-bind="slotData"
+        />
+      </template>
+    </RuiDataTableCell>
+  </tr>
+
+  <RuiDataTableExpandedRow
+    v-if="expanded"
+    :row="row"
+    :index="index"
+  >
+    <template
+      v-if="slots['expanded-item']"
+      #expanded-item="slotData"
+    >
+      <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
+      <slot
+        name="expanded-item"
+        v-bind="slotData"
+      />
+    </template>
+  </RuiDataTableExpandedRow>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/context.spec.ts
+++ b/packages/ui-library/src/components/tables/data-table/context.spec.ts
@@ -1,0 +1,248 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { computed, defineComponent, ref } from 'vue';
+import {
+  type DataTableClasses,
+  type DataTableColumnsContext,
+  type DataTableContext,
+  type DataTableExpansionContext,
+  type DataTableGroupingContext,
+  type DataTableRowIdentityContext,
+  type DataTableSelectionContext,
+  type DataTableStylingContext,
+  provideDataTableColumns,
+  provideDataTableContext,
+  provideDataTableExpansion,
+  provideDataTableGrouping,
+  provideDataTableRowIdentity,
+  provideDataTableSelection,
+  provideDataTableStyling,
+  useDataTableColumns,
+  useDataTableContext,
+  useDataTableExpansion,
+  useDataTableGrouping,
+  useDataTableRowIdentity,
+  useDataTableSelection,
+  useDataTableStyling,
+} from '@/components/tables/data-table/context';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+function stubClasses(): DataTableClasses {
+  return {
+    td: '',
+    tr: '',
+    trSelected: '',
+    trExpandable: '',
+    trGroup: '',
+    trEmpty: '',
+    checkbox: '',
+    tbody: '',
+    tbodyLoader: '',
+    tbodyLoaderContent: '',
+  };
+}
+
+function stubFullContext(): DataTableContext<TestItem, 'id'> {
+  return {
+    classes: computed<DataTableClasses>(() => stubClasses()),
+    colspan: computed<number>(() => 0),
+    dense: false,
+    columns: computed<[]>(() => []),
+    cellValue: (_row, _key) => 0,
+    itemSlotKeys: new Set<string>(),
+    selectedData: ref<number[] | undefined>(undefined),
+    isSelected: () => false,
+    isDisabledRow: () => false,
+    onSelect: () => {},
+    onCheckboxClick: () => {},
+    expandable: computed<boolean>(() => false),
+    isExpanded: () => false,
+    onToggleExpand: () => {},
+    groupExpandButtonPosition: 'start',
+    groupKey: computed<string | undefined>(() => undefined),
+    isExpandedGroup: () => false,
+    onToggleExpandGroup: () => {},
+    onUngroup: () => {},
+    onCopyGroup: () => {},
+    getRowId: (row: TestItem) => row.id,
+    itemClass: '',
+  };
+}
+
+describe('dataTableContext', () => {
+  describe('facade', () => {
+    it('throws when useDataTableContext is called outside a provider', () => {
+      const spy = vi.fn();
+      const TestComponent = defineComponent({
+        setup() {
+          try {
+            useDataTableContext();
+          }
+          catch (error: unknown) {
+            spy(error);
+          }
+          return {};
+        },
+        template: '<div></div>',
+      });
+
+      mount(TestComponent);
+      expect(spy).toHaveBeenCalledOnce();
+      const thrownError = spy.mock.calls[0]?.[0];
+      expect(thrownError).toBeInstanceOf(Error);
+    });
+
+    it('round-trips context through provide and inject', () => {
+      const context = stubFullContext();
+      let injected: DataTableContext<TestItem, 'id'> | undefined;
+
+      const ChildComponent = defineComponent({
+        setup() {
+          injected = useDataTableContext<TestItem, 'id'>();
+          return {};
+        },
+        template: '<span></span>',
+      });
+
+      const ParentComponent = defineComponent({
+        components: { ChildComponent },
+        setup() {
+          provideDataTableContext<TestItem, 'id'>(context);
+          return {};
+        },
+        template: '<div><ChildComponent /></div>',
+      });
+
+      mount(ParentComponent);
+      expect(injected).toBeDefined();
+      expect(injected!.dense).toBe(context.dense);
+      expect(injected!.cellValue).toBe(context.cellValue);
+      expect(injected!.getRowId).toBe(context.getRowId);
+      expect(injected!.isSelected).toBe(context.isSelected);
+      expect(injected!.isExpanded).toBe(context.isExpanded);
+      expect(injected!.onUngroup).toBe(context.onUngroup);
+    });
+  });
+
+  describe('per-concern pairs', () => {
+    function roundTrip<C>(provideFn: (ctx: C) => void, useFn: () => C, context: C): C | undefined {
+      let injected: C | undefined;
+
+      const ChildComponent = defineComponent({
+        setup() {
+          injected = useFn();
+          return {};
+        },
+        template: '<span></span>',
+      });
+
+      const ParentComponent = defineComponent({
+        components: { ChildComponent },
+        setup() {
+          provideFn(context);
+          return {};
+        },
+        template: '<div><ChildComponent /></div>',
+      });
+
+      mount(ParentComponent);
+      return injected;
+    }
+
+    function expectThrowsOutsideProvider(useFn: () => unknown, name: string): void {
+      const spy = vi.fn();
+      const TestComponent = defineComponent({
+        setup() {
+          try {
+            useFn();
+          }
+          catch (error: unknown) {
+            spy(error);
+          }
+          return {};
+        },
+        template: '<div></div>',
+      });
+
+      mount(TestComponent);
+      expect(spy).toHaveBeenCalledOnce();
+      const thrownError = spy.mock.calls[0]?.[0];
+      expect(thrownError).toBeInstanceOf(Error);
+      expect(thrownError).toHaveProperty('message', `${name} must be used within a RuiDataTable`);
+    }
+
+    it('styling: round-trips and throws outside provider', () => {
+      const context: DataTableStylingContext = {
+        classes: computed<DataTableClasses>(() => stubClasses()),
+        colspan: computed<number>(() => 5),
+        dense: true,
+      };
+      const injected = roundTrip(provideDataTableStyling, useDataTableStyling, context);
+      expect(injected).toBe(context);
+      expectThrowsOutsideProvider(useDataTableStyling, 'useDataTableStyling');
+    });
+
+    it('columns: round-trips and throws outside provider', () => {
+      const context: DataTableColumnsContext<TestItem> = {
+        columns: computed<[]>(() => []),
+        cellValue: (_row, _key) => 0,
+        itemSlotKeys: new Set<string>(['name']),
+      };
+      const injected = roundTrip(provideDataTableColumns<TestItem>, useDataTableColumns<TestItem>, context);
+      expect(injected).toBe(context);
+      expectThrowsOutsideProvider(useDataTableColumns, 'useDataTableColumns');
+    });
+
+    it('selection: round-trips and throws outside provider', () => {
+      const context: DataTableSelectionContext<TestItem, 'id'> = {
+        selectedData: ref<number[] | undefined>(undefined),
+        isSelected: () => false,
+        isDisabledRow: () => false,
+        onSelect: () => {},
+        onCheckboxClick: () => {},
+      };
+      const injected = roundTrip(provideDataTableSelection<TestItem, 'id'>, useDataTableSelection<TestItem, 'id'>, context);
+      expect(injected).toBe(context);
+      expectThrowsOutsideProvider(useDataTableSelection, 'useDataTableSelection');
+    });
+
+    it('expansion: round-trips and throws outside provider', () => {
+      const context: DataTableExpansionContext<TestItem, 'id'> = {
+        expandable: computed<boolean>(() => false),
+        isExpanded: () => false,
+        onToggleExpand: () => {},
+      };
+      const injected = roundTrip(provideDataTableExpansion<TestItem, 'id'>, useDataTableExpansion<TestItem, 'id'>, context);
+      expect(injected).toBe(context);
+      expectThrowsOutsideProvider(useDataTableExpansion, 'useDataTableExpansion');
+    });
+
+    it('grouping: round-trips and throws outside provider', () => {
+      const context: DataTableGroupingContext<TestItem> = {
+        groupExpandButtonPosition: 'start',
+        groupKey: computed<string | undefined>(() => undefined),
+        isExpandedGroup: () => false,
+        onToggleExpandGroup: () => {},
+        onUngroup: () => {},
+        onCopyGroup: () => {},
+      };
+      const injected = roundTrip(provideDataTableGrouping<TestItem>, useDataTableGrouping<TestItem>, context);
+      expect(injected).toBe(context);
+      expectThrowsOutsideProvider(useDataTableGrouping, 'useDataTableGrouping');
+    });
+
+    it('row identity: round-trips and throws outside provider', () => {
+      const context: DataTableRowIdentityContext<TestItem, 'id'> = {
+        getRowId: (row: TestItem) => row.id,
+        itemClass: '',
+      };
+      const injected = roundTrip(provideDataTableRowIdentity<TestItem, 'id'>, useDataTableRowIdentity<TestItem, 'id'>, context);
+      expect(injected).toBe(context);
+      expectThrowsOutsideProvider(useDataTableRowIdentity, 'useDataTableRowIdentity');
+    });
+  });
+});

--- a/packages/ui-library/src/components/tables/data-table/context.ts
+++ b/packages/ui-library/src/components/tables/data-table/context.ts
@@ -1,0 +1,158 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
+import type { GroupExpandButtonPosition } from '@/components/tables/table-props';
+import type { GroupHeader } from '@/composables/tables/data-table/types';
+
+export interface DataTableClasses {
+  td: string;
+  tr: string;
+  trSelected: string;
+  trExpandable: string;
+  trGroup: string;
+  trEmpty: string;
+  checkbox: string;
+  tbody: string;
+  tbodyLoader: string;
+  tbodyLoaderContent: string;
+}
+
+// --- Per-concern context interfaces ---
+
+export interface DataTableStylingContext {
+  classes: ComputedRef<DataTableClasses>;
+  colspan: ComputedRef<number>;
+  dense: boolean;
+}
+
+export interface DataTableColumnsContext<T extends object = any> {
+  columns: ComputedRef<TableColumn<T>[]>;
+  cellValue: (row: T, key: TableColumn<T>['key']) => T[keyof T];
+  itemSlotKeys: Set<string>;
+}
+
+export interface DataTableSelectionContext<T extends object = any, IdType extends keyof T = keyof T> {
+  selectedData: Ref<T[IdType][] | undefined>;
+  isSelected: (id: T[IdType]) => boolean;
+  isDisabledRow: (id: T[IdType]) => boolean;
+  onSelect: (selected: boolean, id: T[IdType], userAction: boolean) => void;
+  onCheckboxClick: (event: MouseEvent, id: T[IdType], index: number) => void;
+}
+
+export interface DataTableExpansionContext<T extends object = any, IdType extends keyof T = keyof T> {
+  expandable: ComputedRef<boolean>;
+  isExpanded: (id: T[IdType]) => boolean;
+  onToggleExpand: (row: T) => void;
+}
+
+export interface DataTableGroupingContext<T extends object = any> {
+  groupExpandButtonPosition: GroupExpandButtonPosition;
+  groupKey: ComputedRef<string | undefined>;
+  isExpandedGroup: (group: Partial<T>) => boolean;
+  onToggleExpandGroup: (group: Partial<T>, identifier: string) => void;
+  onUngroup: () => void;
+  onCopyGroup: (header: GroupHeader<T>) => void;
+}
+
+export interface DataTableRowIdentityContext<T extends object = any, IdType extends keyof T = keyof T> {
+  getRowId: (row: T) => T[IdType];
+  itemClass: ((item: T) => string) | string;
+}
+
+// --- Backward-compatible merged type ---
+
+export type DataTableContext<T extends object = any, IdType extends keyof T = keyof T> =
+  DataTableStylingContext &
+  DataTableColumnsContext<T> &
+  DataTableSelectionContext<T, IdType> &
+  DataTableExpansionContext<T, IdType> &
+  DataTableGroupingContext<T> &
+  DataTableRowIdentityContext<T, IdType>;
+
+// --- Per-concern symbols ---
+
+const DATA_TABLE_STYLING = Symbol('data-table-styling');
+const DATA_TABLE_COLUMNS = Symbol('data-table-columns');
+const DATA_TABLE_SELECTION = Symbol('data-table-selection');
+const DATA_TABLE_EXPANSION = Symbol('data-table-expansion');
+const DATA_TABLE_GROUPING = Symbol('data-table-grouping');
+const DATA_TABLE_ROW_IDENTITY = Symbol('data-table-row-identity');
+
+// --- Per-concern provide/use pairs ---
+
+function injectOrThrow<C>(key: symbol, name: string): C {
+  const context = inject<C>(key);
+  if (context === undefined)
+    throw new Error(`${name} must be used within a RuiDataTable`);
+
+  return context;
+}
+
+export function provideDataTableStyling(context: DataTableStylingContext): void {
+  provide(DATA_TABLE_STYLING, context);
+}
+
+export function useDataTableStyling(): DataTableStylingContext {
+  return injectOrThrow<DataTableStylingContext>(DATA_TABLE_STYLING, 'useDataTableStyling');
+}
+
+export function provideDataTableColumns<T extends object>(context: DataTableColumnsContext<T>): void {
+  provide(DATA_TABLE_COLUMNS, context);
+}
+
+export function useDataTableColumns<T extends object = any>(): DataTableColumnsContext<T> {
+  return injectOrThrow<DataTableColumnsContext<T>>(DATA_TABLE_COLUMNS, 'useDataTableColumns');
+}
+
+export function provideDataTableSelection<T extends object, IdType extends keyof T>(context: DataTableSelectionContext<T, IdType>): void {
+  provide(DATA_TABLE_SELECTION, context);
+}
+
+export function useDataTableSelection<T extends object = any, IdType extends keyof T = keyof T>(): DataTableSelectionContext<T, IdType> {
+  return injectOrThrow<DataTableSelectionContext<T, IdType>>(DATA_TABLE_SELECTION, 'useDataTableSelection');
+}
+
+export function provideDataTableExpansion<T extends object, IdType extends keyof T>(context: DataTableExpansionContext<T, IdType>): void {
+  provide(DATA_TABLE_EXPANSION, context);
+}
+
+export function useDataTableExpansion<T extends object = any, IdType extends keyof T = keyof T>(): DataTableExpansionContext<T, IdType> {
+  return injectOrThrow<DataTableExpansionContext<T, IdType>>(DATA_TABLE_EXPANSION, 'useDataTableExpansion');
+}
+
+export function provideDataTableGrouping<T extends object>(context: DataTableGroupingContext<T>): void {
+  provide(DATA_TABLE_GROUPING, context);
+}
+
+export function useDataTableGrouping<T extends object = any>(): DataTableGroupingContext<T> {
+  return injectOrThrow<DataTableGroupingContext<T>>(DATA_TABLE_GROUPING, 'useDataTableGrouping');
+}
+
+export function provideDataTableRowIdentity<T extends object, IdType extends keyof T>(context: DataTableRowIdentityContext<T, IdType>): void {
+  provide(DATA_TABLE_ROW_IDENTITY, context);
+}
+
+export function useDataTableRowIdentity<T extends object = any, IdType extends keyof T = keyof T>(): DataTableRowIdentityContext<T, IdType> {
+  return injectOrThrow<DataTableRowIdentityContext<T, IdType>>(DATA_TABLE_ROW_IDENTITY, 'useDataTableRowIdentity');
+}
+
+// --- Backward-compatible facade ---
+
+export function provideDataTableContext<T extends object, IdType extends keyof T>(context: DataTableContext<T, IdType>): void {
+  provideDataTableStyling({ classes: context.classes, colspan: context.colspan, dense: context.dense });
+  provideDataTableColumns<T>({ columns: context.columns, cellValue: context.cellValue, itemSlotKeys: context.itemSlotKeys });
+  provideDataTableSelection<T, IdType>({ selectedData: context.selectedData, isSelected: context.isSelected, isDisabledRow: context.isDisabledRow, onSelect: context.onSelect, onCheckboxClick: context.onCheckboxClick });
+  provideDataTableExpansion<T, IdType>({ expandable: context.expandable, isExpanded: context.isExpanded, onToggleExpand: context.onToggleExpand });
+  provideDataTableGrouping<T>({ groupExpandButtonPosition: context.groupExpandButtonPosition, groupKey: context.groupKey, isExpandedGroup: context.isExpandedGroup, onToggleExpandGroup: context.onToggleExpandGroup, onUngroup: context.onUngroup, onCopyGroup: context.onCopyGroup });
+  provideDataTableRowIdentity<T, IdType>({ getRowId: context.getRowId, itemClass: context.itemClass });
+}
+
+export function useDataTableContext<T extends object, IdType extends keyof T = keyof T>(): DataTableContext<T, IdType> {
+  return {
+    ...useDataTableStyling(),
+    ...useDataTableColumns<T>(),
+    ...useDataTableSelection<T, IdType>(),
+    ...useDataTableExpansion<T, IdType>(),
+    ...useDataTableGrouping<T>(),
+    ...useDataTableRowIdentity<T, IdType>(),
+  };
+}

--- a/packages/ui-library/src/components/tables/table-props.ts
+++ b/packages/ui-library/src/components/tables/table-props.ts
@@ -6,6 +6,13 @@ export const TableAlign = {
 
 export type TableAlign = (typeof TableAlign)[keyof typeof TableAlign];
 
+export const GroupExpandButtonPosition = {
+  start: 'start',
+  end: 'end',
+} as const;
+
+export type GroupExpandButtonPosition = (typeof GroupExpandButtonPosition)[keyof typeof GroupExpandButtonPosition];
+
 export const SortDirection = {
   asc: 'asc',
   desc: 'desc',

--- a/packages/ui-library/src/composables/tables/data-table/columns.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/columns.spec.ts
@@ -1,26 +1,12 @@
 import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
-import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
-import { defineComponent } from 'vue';
 import { useTableColumns } from '@/composables/tables/data-table/columns';
+import { withSetup } from '~/tests/helpers/with-setup';
 
 interface TestItem {
   id: number;
   name: string;
   title: string;
-}
-
-function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
-  let result!: T;
-  const TestComponent = defineComponent({
-    setup() {
-      result = composable();
-      return {};
-    },
-    template: '<div></div>',
-  });
-  const wrapper = mount(TestComponent);
-  return { result, unmount: () => wrapper.unmount() };
 }
 
 describe('composables/tables/data-table/columns', () => {

--- a/packages/ui-library/src/composables/tables/data-table/columns.ts
+++ b/packages/ui-library/src/composables/tables/data-table/columns.ts
@@ -4,7 +4,8 @@ import type {
   TableColumn,
   TableRowKey,
 } from '@/components/tables/RuiTableHead.vue';
-import { isHeaderSlot } from '@/composables/tables/data-table/types';
+import { getAlignClass, TableAlign } from '@/components/tables/table-props';
+import { getObjectKeys, isHeaderSlot } from '@/composables/tables/data-table/types';
 
 export interface UseTableColumnsOptions<T extends object, IdType extends keyof T> {
   /** Column definitions for the table. When omitted, columns are inferred from row data. */
@@ -21,28 +22,38 @@ export interface UseTableColumnsOptions<T extends object, IdType extends keyof T
   selectedData: Ref<T[IdType][] | undefined>;
   /** Template slots provided to the table component. */
   slots: Record<string, any>;
+  /** Pre-computes td class per column to avoid per-cell tv() calls. */
+  tdResolver?: (options: { class?: string }) => string;
 }
 
 export interface UseTableColumnsReturn<T extends object> {
   columns: ComputedRef<TableColumn<T>[]>;
   colspan: ComputedRef<number>;
-  headerSlots: ComputedRef<`header.${string}`[]>;
+  headerSlots: `header.${string}`[];
   cellValue: (row: T, key: TableColumn<T>['key']) => T[TableRowKey<T>];
 }
 
 export function useTableColumns<T extends object, IdType extends keyof T>(
   options: UseTableColumnsOptions<T, IdType>,
 ): UseTableColumnsReturn<T> {
-  const { cols, columnAttr, expandable, groupKeys, rows, selectedData, slots } = options;
+  const { cols, columnAttr, expandable, groupKeys, rows, selectedData, slots, tdResolver } = options;
 
-  const getKeys = <O extends object>(t: O): TableRowKey<O>[] => Object.keys(t) as TableRowKey<O>[];
+  function attachTdClass(columnList: TableColumn<T>[]): TableColumn<T>[] {
+    if (!tdResolver)
+      return columnList;
+
+    return columnList.map(col => ({
+      ...col,
+      tdClass: tdResolver({ class: getAlignClass(col.align) }),
+    }));
+  }
 
   const columns = computed<TableColumn<T>[]>(() => {
     const currentCols = toValue(cols);
     const currentRows = toValue(rows);
     const data =
       currentCols ??
-      getKeys(currentRows[0] ?? {}).map(
+      getObjectKeys(currentRows[0] ?? {}).map(
         key =>
           ({
             key,
@@ -53,24 +64,24 @@ export function useTableColumns<T extends object, IdType extends keyof T>(
     const hasExpandColumn = data.some(row => row.key === 'expand');
 
     if (get(expandable) && !hasExpandColumn) {
-      return [
+      return attachTdClass([
         ...data,
         {
           key: 'expand' as TableRowKey<T>,
           sortable: false,
           class: 'w-16',
           cellClass: '!py-0 w-16',
-          align: 'end',
+          align: TableAlign.end,
         } satisfies NoneSortableTableColumn<T>,
-      ];
+      ]);
     }
 
     const groupByKeys = get(groupKeys);
 
     if (groupByKeys.length === 0)
-      return data;
+      return attachTdClass(data);
 
-    return data.filter(column => !groupByKeys.includes(column.key as TableRowKey<T>));
+    return attachTdClass(data.filter(column => !groupByKeys.includes(column.key as TableRowKey<T>)));
   });
 
   const colspan = computed<number>(() => {
@@ -81,7 +92,8 @@ export function useTableColumns<T extends object, IdType extends keyof T>(
     return columnLength;
   });
 
-  const headerSlots = computed<`header.${string}`[]>(() => Object.keys(slots).filter(isHeaderSlot));
+  // Slot keys are static for the component lifetime — no reactivity needed
+  const headerSlots: `header.${string}`[] = Object.keys(slots).filter(isHeaderSlot);
 
   function cellValue(row: T, key: TableColumn<T>['key']): T[TableRowKey<T>] {
     return row[key as TableRowKey<T>];

--- a/packages/ui-library/src/composables/tables/data-table/expansion.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/expansion.spec.ts
@@ -1,24 +1,10 @@
-import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
-import { defineComponent } from 'vue';
 import { useTableExpansion } from '@/composables/tables/data-table/expansion';
+import { withSetup } from '~/tests/helpers/with-setup';
 
 interface TestItem {
   id: number;
   name: string;
-}
-
-function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
-  let result!: T;
-  const TestComponent = defineComponent({
-    setup() {
-      result = composable();
-      return {};
-    },
-    template: '<div></div>',
-  });
-  const wrapper = mount(TestComponent);
-  return { result, unmount: () => wrapper.unmount() };
 }
 
 describe('composables/tables/data-table/expansion', () => {

--- a/packages/ui-library/src/composables/tables/data-table/grouping.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/grouping.spec.ts
@@ -1,25 +1,12 @@
-import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { defineComponent } from 'vue';
+import { afterEach, describe, expect, it } from 'vitest';
 import { useTableGrouping } from '@/composables/tables/data-table/grouping';
+import { GROUP_HEADER_BRAND } from '@/composables/tables/data-table/types';
+import { withSetup } from '~/tests/helpers/with-setup';
 
 interface TestItem {
   id: number;
   name: string;
   title: string;
-}
-
-function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
-  let result!: T;
-  const TestComponent = defineComponent({
-    setup() {
-      result = composable();
-      return {};
-    },
-    template: '<div></div>',
-  });
-  const wrapper = mount(TestComponent);
-  return { result, unmount: () => wrapper.unmount() };
 }
 
 describe('composables/tables/data-table/grouping', () => {
@@ -43,7 +30,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref(undefined),
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -61,7 +47,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -80,7 +65,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -89,7 +73,7 @@ describe('composables/tables/data-table/grouping', () => {
     const grouped = get(result.grouped);
     expect(grouped).toHaveLength(5);
 
-    const headers = grouped.filter(item => '__header__' in item);
+    const headers = grouped.filter(item => GROUP_HEADER_BRAND in item);
     expect(headers).toHaveLength(2);
   });
 
@@ -102,7 +86,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed,
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -131,7 +114,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: group as any,
           collapsed,
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -142,25 +124,6 @@ describe('composables/tables/data-table/grouping', () => {
     expect(get(collapsed)).toEqual([]);
   });
 
-  it('should call emitCopyGroup on copy', () => {
-    const emitCopyGroup = vi.fn();
-    const { result, unmount: u } = withSetup(() =>
-      useTableGrouping<TestItem, 'id'>(
-        { rowAttr: 'id' },
-        {
-          group: ref('title') as any,
-          collapsed: ref(undefined),
-          sorted: computed(() => rows),
-          emitCopyGroup,
-        },
-      ),
-    );
-    unmount = u;
-
-    result.onCopyGroup({ key: 'title', value: { title: 'Developer' } });
-    expect(emitCopyGroup).toHaveBeenCalledWith({ key: 'title', value: { title: 'Developer' } });
-  });
-
   it('should support array group keys', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableGrouping<TestItem, 'id'>(
@@ -169,7 +132,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref(['name', 'title']) as any,
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -189,7 +151,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed,
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -217,7 +178,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref(undefined),
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -235,14 +195,13 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed,
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
     unmount = u;
 
     const header = {
-      __header__: true as const,
+      [GROUP_HEADER_BRAND]: true as const,
       group: { title: 'Developer' },
       identifier: 'Developer',
     };
@@ -257,7 +216,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -280,7 +238,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref(undefined),
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -297,7 +254,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -316,7 +272,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref(undefined),
           collapsed: ref(undefined),
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -334,7 +289,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed,
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -356,7 +310,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: group as any,
           collapsed,
           sorted: computed(() => rows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -380,7 +333,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref('title') as any,
           collapsed: ref(undefined),
           sorted: computed(() => rowsWithEmpty),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -406,7 +358,6 @@ describe('composables/tables/data-table/grouping', () => {
           group: ref(['name', 'title']) as any,
           collapsed: ref(undefined),
           sorted: computed(() => multiRows),
-          emitCopyGroup: () => {},
         },
       ),
     );
@@ -419,5 +370,127 @@ describe('composables/tables/data-table/grouping', () => {
     const grouped = get(result.grouped);
     // 3 headers + 3 rows
     expect(grouped).toHaveLength(6);
+  });
+
+  it('should produce different group keys for multi-key grouping with partial undefined', () => {
+    interface PartialItem {
+      id: number;
+      name: string | undefined;
+      title: string | undefined;
+    }
+
+    const partialRows: PartialItem[] = [
+      { id: 1, name: 'foo', title: undefined },
+      { id: 2, name: undefined, title: 'foo' },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<PartialItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(['name', 'title']) as any,
+          collapsed: ref(undefined),
+          sorted: computed<readonly PartialItem[]>(() => partialRows),
+        },
+      ),
+    );
+    unmount = u;
+
+    const groups = get(result.mappedGroups);
+    // Two distinct group keys — no collision between { name: 'foo', title: undefined } and { name: undefined, title: 'foo' }
+    expect(Object.keys(groups)).toHaveLength(2);
+
+    const grouped = get(result.grouped);
+    // 2 headers + 2 rows
+    expect(grouped).toHaveLength(4);
+
+    const headers = grouped.filter(item => GROUP_HEADER_BRAND in item);
+    expect(headers).toHaveLength(2);
+  });
+
+  it('should not collapse unrelated multi-key group when collapsing another sharing a partial key', () => {
+    interface MultiKeyItem {
+      id: number;
+      category: string;
+      status: string;
+    }
+
+    const multiKeyRows: MultiKeyItem[] = [
+      { id: 1, category: 'A', status: 'active' },
+      { id: 2, category: 'A', status: 'inactive' },
+      { id: 3, category: 'B', status: 'active' },
+    ];
+
+    const collapsed = ref<MultiKeyItem[]>([]);
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<MultiKeyItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref(['category', 'status']) as any,
+          collapsed,
+          sorted: computed<readonly MultiKeyItem[]>(() => multiKeyRows),
+        },
+      ),
+    );
+    unmount = u;
+
+    // All groups start expanded
+    expect(result.isExpandedGroup({ category: 'A', status: 'active' })).toBe(true);
+    expect(result.isExpandedGroup({ category: 'A', status: 'inactive' })).toBe(true);
+    expect(result.isExpandedGroup({ category: 'B', status: 'active' })).toBe(true);
+
+    // Collapse the A+active group — find its key from the grouped output
+    const grouped = get(result.grouped);
+    const aActiveHeader = grouped.find(
+      item => GROUP_HEADER_BRAND in item && 'identifier' in item,
+    );
+    const aActiveKey = aActiveHeader && 'identifier' in aActiveHeader ? aActiveHeader.identifier : undefined;
+
+    result.onToggleExpandGroup({ category: 'A', status: 'active' }, aActiveKey);
+
+    // A+active is collapsed
+    expect(result.isExpandedGroup({ category: 'A', status: 'active' })).toBe(false);
+
+    // A+inactive and B+active should still be expanded
+    expect(result.isExpandedGroup({ category: 'A', status: 'inactive' })).toBe(true);
+    expect(result.isExpandedGroup({ category: 'B', status: 'active' })).toBe(true);
+  });
+
+  it('should exclude rows with empty rowAttr value from grouped output', () => {
+    interface EmptyIdItem {
+      id: number | string;
+      name: string;
+      title: string;
+    }
+
+    const rowsWithEmptyId: EmptyIdItem[] = [
+      { id: 1, name: 'Alice', title: 'Developer' },
+      { id: '', name: 'Ghost', title: 'None' },
+      { id: 3, name: 'Charlie', title: 'Developer' },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableGrouping<EmptyIdItem, 'id'>(
+        { rowAttr: 'id' },
+        {
+          group: ref('title') as any,
+          collapsed: ref(undefined),
+          sorted: computed<readonly EmptyIdItem[]>(() => rowsWithEmptyId),
+        },
+      ),
+    );
+    unmount = u;
+
+    const groups = get(result.mappedGroups);
+    // "None" group should not exist since the row has empty id
+    expect(groups.None).toBeUndefined();
+
+    // Only "Developer" group should exist
+    expect(Object.keys(groups)).toHaveLength(1);
+    expect(groups.Developer).toBeDefined();
+
+    const grouped = get(result.grouped);
+    // 1 header + 2 Developer rows (Ghost row excluded)
+    expect(grouped).toHaveLength(3);
   });
 });

--- a/packages/ui-library/src/composables/tables/data-table/grouping.ts
+++ b/packages/ui-library/src/composables/tables/data-table/grouping.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, Ref } from 'vue';
-import type { GroupData, TableRowKey, TableRowKeyData } from '@/components/tables/RuiTableHead.vue';
+import type { TableRowKey, TableRowKeyData } from '@/components/tables/RuiTableHead.vue';
 import {
+  GROUP_HEADER_BRAND,
   type GroupedTableRow,
   type GroupHeader,
   isRow,
@@ -15,16 +16,15 @@ export interface UseTableGroupingOptions<T extends object, IdType extends keyof 
 export interface UseTableGroupingDeps<T extends object> {
   group: Ref<TableRowKeyData<T>>;
   collapsed: Ref<T[] | undefined>;
-  sorted: ComputedRef<T[]>;
-  emitCopyGroup: (value: GroupData<T>) => void;
+  sorted: ComputedRef<readonly T[]>;
 }
 
 export interface UseTableGroupingReturn<T extends object> {
   groupKeys: ComputedRef<TableRowKey<T>[]>;
-  groupKey: ComputedRef<string>;
+  groupKey: ComputedRef<string | undefined>;
   isGrouped: ComputedRef<boolean>;
   mappedGroups: ComputedRef<Record<string, GroupedTableRow<T>[]>>;
-  grouped: ComputedRef<GroupedTableRow<T>[]>;
+  grouped: ComputedRef<readonly GroupedTableRow<T>[]>;
   getRowGroup: (row: T) => Partial<T>;
   getGroupRows: (groupVal: string) => T[];
   compareGroupsFn: (a: T, b: Partial<T>) => boolean;
@@ -32,7 +32,6 @@ export interface UseTableGroupingReturn<T extends object> {
   isHiddenRow: (row: GroupedTableRow<T>) => boolean;
   onToggleExpandGroup: (group: Partial<T>, value?: string) => void;
   onUngroup: () => void;
-  onCopyGroup: (value: GroupData<T>) => void;
 }
 
 // Null character separator prevents false collisions when group values contain commas
@@ -43,7 +42,7 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
   deps: UseTableGroupingDeps<T>,
 ): UseTableGroupingReturn<T> {
   const { rowAttr } = options;
-  const { group, collapsed, sorted, emitCopyGroup } = deps;
+  const { group, collapsed, sorted } = deps;
 
   const collapsedRows: Ref<T[]> = ref([]);
 
@@ -61,9 +60,12 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
     return groupBy;
   });
 
-  const groupKey = computed<string>(() => get(groupKeys).join(':'));
+  const groupKey = computed<string | undefined>(() => {
+    const key = get(groupKeys).join(':');
+    return key || undefined;
+  });
 
-  const isGrouped = computed<boolean>(() => !!get(groupKey));
+  const isGrouped = computed<boolean>(() => get(groupKey) !== undefined);
 
   const collapsedIdentifierSet = computed<Set<T[IdType]>>(
     () => new Set(get(collapsedRows).map(row => row[rowAttr])),
@@ -75,13 +77,8 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
       return new Set<string>();
 
     const seen = new Set<string>();
-    for (const row of get(collapsedRows)) {
-      const groupVal = grouping
-        .map(key => row[key])
-        .filter(isDefined)
-        .join(GROUP_KEY_SEPARATOR);
-      seen.add(groupVal);
-    }
+    for (const row of get(collapsedRows))
+      seen.add(computeGroupKey(row, grouping));
     return seen;
   });
 
@@ -102,7 +99,14 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
   }
 
   function isExpandedGroup(value: Partial<T>): boolean {
-    const groupVal = Object.values(value).filter(isDefined).join(GROUP_KEY_SEPARATOR);
+    const grouping = get(groupKeys);
+    let groupVal = '';
+    for (const gk of grouping) {
+      if (groupVal)
+        groupVal += GROUP_KEY_SEPARATOR;
+      const val = value[gk];
+      groupVal += isDefined(val) ? val : '';
+    }
     return !get(collapsedGroupKeySet).has(groupVal);
   }
 
@@ -114,43 +118,61 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
     return get(collapsedIdentifierSet).has(row[rowAttr]);
   }
 
+  function computeGroupKey(row: T, grouping: TableRowKey<T>[]): string {
+    let key = '';
+    for (const gk of grouping) {
+      if (key)
+        key += GROUP_KEY_SEPARATOR;
+      const val = row[gk];
+      key += isDefined(val) ? val : '';
+    }
+    return key;
+  }
+
   const mappedGroups = computed<Record<string, GroupedTableRow<T>[]>>(() => {
-    if (!get(isGrouped))
+    const grouping = get(groupKeys);
+    if (grouping.length === 0)
       return {};
 
     const result = get(sorted);
     const identifier = rowAttr;
+    const acc: Record<string, GroupedTableRow<T>[]> = {};
 
-    return result.reduce((acc: Record<string, GroupedTableRow<T>[]>, row) => {
+    for (const row of result) {
       if (!isDefined(row[identifier]) || row[identifier] === '')
-        return acc;
+        continue;
 
-      const rowGroup = getRowGroup(row);
-      const groupVal = Object.values(rowGroup).filter(isDefined).join(GROUP_KEY_SEPARATOR);
+      const groupVal = computeGroupKey(row, grouping);
       if (!acc[groupVal]) {
         acc[groupVal] = [
           {
-            __header__: true,
-            group: rowGroup,
+            [GROUP_HEADER_BRAND]: true,
+            group: getRowGroup(row),
             identifier: groupVal,
           } satisfies GroupHeader<T>,
         ];
       }
 
       acc[groupVal].push(row);
+    }
 
-      return acc;
-    }, {});
+    return acc;
   });
 
-  const grouped = computed<GroupedTableRow<T>[]>(() => {
+  const grouped = computed<readonly GroupedTableRow<T>[]>(() => {
     const result = get(sorted);
     const groupByKey = get(groupKey);
 
     if (!groupByKey)
       return result;
 
-    return Object.values(get(mappedGroups)).flat();
+    const groups = get(mappedGroups);
+    const out: GroupedTableRow<T>[] = [];
+    for (const items of Object.values(groups)) {
+      for (const item of items)
+        out.push(item);
+    }
+    return out;
   });
 
   function getGroupRows(groupVal: string): T[] {
@@ -189,10 +211,6 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
     set(group, Array.isArray(get(group)) ? [] : undefined);
   }
 
-  function onCopyGroup(value: GroupData<T>): void {
-    emitCopyGroup(value);
-  }
-
   return {
     groupKeys,
     groupKey,
@@ -206,6 +224,5 @@ export function useTableGrouping<T extends object, IdType extends keyof T>(
     isHiddenRow,
     onToggleExpandGroup,
     onUngroup,
-    onCopyGroup,
   };
 }

--- a/packages/ui-library/src/composables/tables/data-table/pagination.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/pagination.spec.ts
@@ -1,35 +1,23 @@
-import type { GroupedTableRow } from '@/composables/tables/data-table/types';
-import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { defineComponent } from 'vue';
 import { createTableDefaults, TableSymbol } from '@/composables/defaults/table';
 import { useTablePagination } from '@/composables/tables/data-table/pagination';
+import { GROUP_HEADER_BRAND, type GroupedTableRow } from '@/composables/tables/data-table/types';
+import { withSetup } from '~/tests/helpers/with-setup';
 
 interface TestItem {
   id: number;
   name: string;
 }
 
-function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
-  let result!: T;
-  const TestComponent = defineComponent({
-    setup() {
-      result = composable();
-      return {};
+const paginationMountOptions = {
+  global: {
+    provide: {
+      [TableSymbol.valueOf()]: createTableDefaults({
+        limits: [5, 10, 25],
+      }),
     },
-    template: '<div></div>',
-  });
-  const wrapper = mount(TestComponent, {
-    global: {
-      provide: {
-        [TableSymbol.valueOf()]: createTableDefaults({
-          limits: [5, 10, 25],
-        }),
-      },
-    },
-  });
-  return { result, unmount: () => wrapper.unmount() };
-}
+  },
+};
 
 describe('composables/tables/data-table/pagination', () => {
   let unmount: () => void;
@@ -56,8 +44,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     const pagination = get(result.paginationData);
@@ -83,8 +70,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -111,8 +97,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -139,8 +124,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     expect(get(result.filtered)).toHaveLength(25);
@@ -160,8 +144,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -183,8 +166,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions,
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     set(result.paginationData, { limit: 5, page: 1, total: 25 });
@@ -209,8 +191,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -241,8 +222,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     // Change pagination limit
@@ -272,8 +252,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -304,8 +283,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -321,10 +299,10 @@ describe('composables/tables/data-table/pagination', () => {
   it('should handle pagination with group headers', () => {
     const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
     const groupedData: GroupedTableRow<TestItem>[] = [
-      { __header__: true, group: { name: 'A' }, identifier: 'A' },
+      { [GROUP_HEADER_BRAND]: true, group: { name: 'A' }, identifier: 'A' },
       { id: 1, name: 'A' },
       { id: 2, name: 'A' },
-      { __header__: true, group: { name: 'B' }, identifier: 'B' },
+      { [GROUP_HEADER_BRAND]: true, group: { name: 'B' }, identifier: 'B' },
       { id: 3, name: 'B' },
     ];
 
@@ -344,8 +322,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(groupedData);
@@ -373,8 +350,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
@@ -404,8 +380,7 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     // 25 rows, first 5 hidden
@@ -425,11 +400,203 @@ describe('composables/tables/data-table/pagination', () => {
           emitUpdateOptions: () => {},
           tableDefaults,
         },
-      ),
-    );
+      ), paginationMountOptions);
     unmount = u;
 
     result.setInternalTotal(rows);
     expect(get(result.itemsLength)).toBe(0);
+  });
+
+  describe('grouped pagination algorithm', () => {
+    const groupedData: GroupedTableRow<TestItem>[] = [
+      { [GROUP_HEADER_BRAND]: true, group: { name: 'A' }, identifier: 'A' },
+      { id: 1, name: 'A' },
+      { id: 2, name: 'A' },
+      { id: 3, name: 'A' },
+      { [GROUP_HEADER_BRAND]: true, group: { name: 'B' }, identifier: 'B' },
+      { id: 4, name: 'B' },
+      { id: 5, name: 'B' },
+    ];
+
+    it('should prepend group header when page starts mid-group', () => {
+      const tableDefaults = createTableDefaults({ limits: [2, 5, 10] });
+      const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+        limit: 2,
+        page: 2,
+        total: 5,
+      });
+      const { result, unmount: u } = withSetup(() =>
+        useTablePagination<TestItem>(
+          { itemsPerPage: 2, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+          {
+            pagination,
+            grouped: computed<GroupedTableRow<TestItem>[]>(() => groupedData),
+            isHiddenRow: () => false,
+            sort: ref(undefined),
+            emitUpdateOptions: () => {},
+            tableDefaults,
+          },
+        ), paginationMountOptions);
+      unmount = u;
+
+      result.setInternalTotal(groupedData);
+
+      const filtered = get(result.filtered);
+      // Page 2 with limit 2: data rows 3 and 4
+      // Row 3 (id:3) belongs to group A, so group A header should be prepended
+      // Row 4 (id:4) belongs to group B, so group B header should also appear
+      expect(filtered).toHaveLength(4);
+      expect(filtered[0]).toHaveProperty('identifier', 'A');
+      expect(filtered[1]).toHaveProperty('id', 3);
+      expect(filtered[2]).toHaveProperty('identifier', 'B');
+      expect(filtered[3]).toHaveProperty('id', 4);
+    });
+
+    it('should remove trailing group header with no data rows after it', () => {
+      const tableDefaults = createTableDefaults({ limits: [3, 5, 10] });
+      const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+        limit: 3,
+        page: 1,
+        total: 5,
+      });
+      const { result, unmount: u } = withSetup(() =>
+        useTablePagination<TestItem>(
+          { itemsPerPage: 3, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+          {
+            pagination,
+            grouped: computed<GroupedTableRow<TestItem>[]>(() => groupedData),
+            isHiddenRow: () => false,
+            sort: ref(undefined),
+            emitUpdateOptions: () => {},
+            tableDefaults,
+          },
+        ), paginationMountOptions);
+      unmount = u;
+
+      result.setInternalTotal(groupedData);
+
+      const filtered = get(result.filtered);
+      // Page 1 with limit 3: data rows 1, 2, 3 (all group A)
+      // The algorithm collects group A header + rows 1,2,3, then group B header
+      // But group B header has no data rows on this page, so it should be removed
+      expect(filtered).toHaveLength(4);
+      expect(filtered[0]).toHaveProperty('identifier', 'A');
+      expect(filtered[1]).toHaveProperty('id', 1);
+      expect(filtered[2]).toHaveProperty('id', 2);
+      expect(filtered[3]).toHaveProperty('id', 3);
+      // Group B header should NOT be present
+      const hasTrailingBHeader = filtered.some(
+        item => 'identifier' in item && item.identifier === 'B',
+      );
+      expect(hasTrailingBHeader).toBe(false);
+    });
+
+    it('should handle group header exactly at page boundary start', () => {
+      const tableDefaults = createTableDefaults({ limits: [2, 5, 10] });
+      // Group A has 3 data rows, Group B has 2 data rows
+      // With limit 3, page 2 starts at data row index 3, which is id:4 (group B)
+      // The group B header sits exactly before data row 4
+      const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+        limit: 3,
+        page: 2,
+        total: 5,
+      });
+      const { result, unmount: u } = withSetup(() =>
+        useTablePagination<TestItem>(
+          { itemsPerPage: 3, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+          {
+            pagination,
+            grouped: computed<GroupedTableRow<TestItem>[]>(() => groupedData),
+            isHiddenRow: () => false,
+            sort: ref(undefined),
+            emitUpdateOptions: () => {},
+            tableDefaults,
+          },
+        ), paginationMountOptions);
+      unmount = u;
+
+      result.setInternalTotal(groupedData);
+
+      const filtered = get(result.filtered);
+      // Page 2: data rows 4 and 5 (group B)
+      // Group B header falls at exactly the page boundary (dataCount === start when header is seen)
+      // so it should be included naturally (not prepended)
+      expect(filtered).toHaveLength(3);
+      expect(filtered[0]).toHaveProperty('identifier', 'B');
+      expect(filtered[1]).toHaveProperty('id', 4);
+      expect(filtered[2]).toHaveProperty('id', 5);
+    });
+
+    it('should include multiple group headers when page spans two groups', () => {
+      const tableDefaults = createTableDefaults({ limits: [4, 5, 10] });
+      const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+        limit: 4,
+        page: 1,
+        total: 5,
+      });
+      const { result, unmount: u } = withSetup(() =>
+        useTablePagination<TestItem>(
+          { itemsPerPage: 4, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+          {
+            pagination,
+            grouped: computed<GroupedTableRow<TestItem>[]>(() => groupedData),
+            isHiddenRow: () => false,
+            sort: ref(undefined),
+            emitUpdateOptions: () => {},
+            tableDefaults,
+          },
+        ), paginationMountOptions);
+      unmount = u;
+
+      result.setInternalTotal(groupedData);
+
+      const filtered = get(result.filtered);
+      // Page 1 with limit 4: data rows 1, 2, 3, 4
+      // Group A header + rows 1,2,3 + Group B header + row 4
+      expect(filtered).toHaveLength(6);
+      expect(filtered[0]).toHaveProperty('identifier', 'A');
+      expect(filtered[1]).toHaveProperty('id', 1);
+      expect(filtered[2]).toHaveProperty('id', 2);
+      expect(filtered[3]).toHaveProperty('id', 3);
+      expect(filtered[4]).toHaveProperty('identifier', 'B');
+      expect(filtered[5]).toHaveProperty('id', 4);
+    });
+
+    it('should filter hidden rows from grouped pagination results', () => {
+      const tableDefaults = createTableDefaults({ limits: [5, 10, 25] });
+      const pagination = ref<{ limit: number; page: number; total: number } | undefined>({
+        limit: 5,
+        page: 1,
+        total: 5,
+      });
+      const { result, unmount: u } = withSetup(() =>
+        useTablePagination<TestItem>(
+          { itemsPerPage: 5, paginationModifiersExternal: false, globalItemsPerPage: undefined },
+          {
+            pagination,
+            grouped: computed<GroupedTableRow<TestItem>[]>(() => groupedData),
+            isHiddenRow: (row: GroupedTableRow<TestItem>): boolean => {
+              if ('id' in row)
+                return row.id <= 3;
+              return false;
+            },
+            sort: ref(undefined),
+            emitUpdateOptions: () => {},
+            tableDefaults,
+          },
+        ), paginationMountOptions);
+      unmount = u;
+
+      result.setInternalTotal(groupedData);
+
+      const filtered = get(result.filtered);
+      // All 5 data rows fit on page 1. isHiddenRow hides rows with id <= 3.
+      // Remaining visible: group A header, group B header, row 4, row 5
+      // Group A header stays because isHiddenRow returns false for headers
+      const dataRows = filtered.filter(item => 'id' in item);
+      expect(dataRows).toHaveLength(2);
+      expect(dataRows[0]).toHaveProperty('id', 4);
+      expect(dataRows[1]).toHaveProperty('id', 5);
+    });
   });
 });

--- a/packages/ui-library/src/composables/tables/data-table/pagination.ts
+++ b/packages/ui-library/src/composables/tables/data-table/pagination.ts
@@ -1,9 +1,8 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, DeepReadonly, Ref, ShallowRef } from 'vue';
 import type { TableSortData } from '@/components/tables/RuiTableHead.vue';
 import type { TablePaginationData } from '@/components/tables/RuiTablePagination.vue';
 import type { TableOptions as TableDefaultOptions } from '@/composables/defaults/table';
 import { type GroupedTableRow, isRow } from '@/composables/tables/data-table/types';
-import { assert } from '@/utils/assert';
 
 export interface UseTablePaginationOptions {
   /** The default number of items displayed per page. */
@@ -16,7 +15,7 @@ export interface UseTablePaginationOptions {
 
 export interface UseTablePaginationDeps<T extends object> {
   pagination: Ref<TablePaginationData | undefined>;
-  grouped: ComputedRef<GroupedTableRow<T>[]>;
+  grouped: ComputedRef<readonly GroupedTableRow<T>[]>;
   isHiddenRow: (row: GroupedTableRow<T>) => boolean;
   sort: Ref<TableSortData<T>>;
   emitUpdateOptions: (options: {
@@ -29,10 +28,87 @@ export interface UseTablePaginationDeps<T extends object> {
 export interface UseTablePaginationReturn<T extends object> {
   paginationData: Ref<TablePaginationData>;
   filtered: ComputedRef<GroupedTableRow<T>[]>;
-  itemsLength: Ref<number>;
+  itemsLength: DeepReadonly<ShallowRef<number>>;
   globalItemsPerPageSettings: ComputedRef<boolean>;
-  setInternalTotal: (items: GroupedTableRow<T>[]) => void;
+  setInternalTotal: (items: readonly GroupedTableRow<T>[]) => void;
   resetPagination: () => void;
+}
+
+/**
+ * Skip data rows until the page start offset, tracking the last group header seen.
+ * Returns the index where collection should begin and the last group header before the slice.
+ */
+function skipToPageStart<T extends object>(
+  result: readonly GroupedTableRow<T>[],
+  start: number,
+): { startIndex: number; dataCount: number; lastGroupHeader: GroupedTableRow<T> | undefined } {
+  let dataCount = 0;
+  let lastGroupHeader: GroupedTableRow<T> | undefined;
+
+  for (const [i, item] of result.entries()) {
+    if (isRow(item)) {
+      dataCount++;
+      if (dataCount > start)
+        return { startIndex: i, dataCount, lastGroupHeader };
+    }
+    else if (dataCount < start) {
+      lastGroupHeader = item;
+    }
+    else {
+      return { startIndex: i, dataCount, lastGroupHeader };
+    }
+  }
+
+  return { startIndex: result.length, dataCount, lastGroupHeader };
+}
+
+/**
+ * Collect data rows (and interleaved group headers) for the current page.
+ */
+function collectPageRows<T extends object>(
+  items: readonly GroupedTableRow<T>[],
+  limit: number,
+): GroupedTableRow<T>[] {
+  const data: GroupedTableRow<T>[] = [];
+  let collected = 0;
+
+  for (const item of items) {
+    data.push(item);
+
+    if (isRow(item)) {
+      collected++;
+      if (collected >= limit)
+        break;
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Single-pass pagination that counts only data rows while preserving group headers.
+ * Prepends the nearest group header when a page starts mid-group, and removes
+ * trailing group headers with no data rows after them.
+ */
+function paginateGroupedRows<T extends object>(
+  result: readonly GroupedTableRow<T>[],
+  start: number,
+  limit: number,
+): GroupedTableRow<T>[] {
+  const { startIndex, lastGroupHeader } = skipToPageStart(result, start);
+  const data = collectPageRows(result.slice(startIndex), limit);
+
+  // Prepend the nearest group header if the first item is a data row
+  const firstItem = data[0];
+  if (firstItem && isRow(firstItem) && lastGroupHeader)
+    data.unshift(lastGroupHeader);
+
+  // Remove trailing group header with no data rows after it
+  const lastItem = data.at(-1);
+  if (lastItem && !isRow(lastItem))
+    data.pop();
+
+  return data;
 }
 
 export function useTablePagination<T extends object>(
@@ -87,38 +163,24 @@ export function useTablePagination<T extends object>(
     const result = get(grouped);
 
     const paginated = get(paginationData);
-    const limit = paginated.limit;
     if (!paginationModifiersExternal) {
-      const start = (paginated.page - 1) * limit;
-      const end = start + limit;
-      const preGroups = result.slice(0, start + 1).filter(item => !isRow(item));
-      const postGroups = result
-        .slice(start + 1, end + preGroups.length)
-        .filter(item => !isRow(item));
-      const data = result.slice(
-        start + preGroups.length,
-        end + preGroups.length + postGroups.length,
-      );
-      const nearestGroup = preGroups.at(-1);
-      if (data.length > 0) {
-        const firstItem = data[0];
-        assert(firstItem);
-        if (isRow(firstItem) && nearestGroup)
-          data.unshift(nearestGroup);
-        const lastItem = data.at(-1);
-        if (lastItem && !isRow(lastItem))
-          data.pop();
-      }
-
+      const start = (paginated.page - 1) * paginated.limit;
+      const data = paginateGroupedRows(result, start, paginated.limit);
       return data.filter(row => !isHiddenRow(row));
     }
 
     return result.filter(row => !isHiddenRow(row));
   });
 
-  function setInternalTotal(items: GroupedTableRow<T>[]): void {
-    if (!paginationModifiersExternal)
-      set(itemsLength, items.filter(isRow).length);
+  function setInternalTotal(items: readonly GroupedTableRow<T>[]): void {
+    if (!paginationModifiersExternal) {
+      let count = 0;
+      for (const item of items) {
+        if (isRow(item))
+          count++;
+      }
+      set(itemsLength, count);
+    }
   }
 
   function resetPagination(): void {
@@ -168,7 +230,7 @@ export function useTablePagination<T extends object>(
   return {
     paginationData,
     filtered,
-    itemsLength,
+    itemsLength: readonly(itemsLength),
     globalItemsPerPageSettings,
     setInternalTotal,
     resetPagination,

--- a/packages/ui-library/src/composables/tables/data-table/selection.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/selection.spec.ts
@@ -1,24 +1,11 @@
-import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
-import { defineComponent } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useTableSelection } from '@/composables/tables/data-table/selection';
+import { GROUP_HEADER_BRAND, type GroupedTableRow, type GroupHeader } from '@/composables/tables/data-table/types';
+import { withSetup } from '~/tests/helpers/with-setup';
 
 interface TestItem {
   id: number;
   name: string;
-}
-
-function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
-  let result!: T;
-  const TestComponent = defineComponent({
-    setup() {
-      result = composable();
-      return {};
-    },
-    template: '<div></div>',
-  });
-  const wrapper = mount(TestComponent);
-  return { result, unmount: () => wrapper.unmount() };
 }
 
 describe('composables/tables/data-table/selection', () => {
@@ -490,5 +477,222 @@ describe('composables/tables/data-table/selection', () => {
     result.deselectRemovedRows();
     // All visible, nothing removed
     expect(get(selectedData)).toEqual([1, 2, 3]);
+  });
+
+  describe('onCheckboxClick shift-select', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      unmount?.();
+    });
+
+    function createMockCheckboxEvent(options: { shiftKey: boolean }): MouseEvent {
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      const wrapper = document.createElement('div');
+      wrapper.appendChild(input);
+
+      const target = document.createElement('div');
+      wrapper.appendChild(target);
+
+      const event = new MouseEvent('click', { shiftKey: options.shiftKey, bubbles: true });
+      Object.defineProperty(event, 'currentTarget', { value: wrapper });
+      Object.defineProperty(event, 'target', { value: target });
+      return event;
+    }
+
+    it('should select a contiguous range between last click and current click', () => {
+      const selectedData = ref<number[]>([]);
+      const extendedRows: TestItem[] = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+        { id: 4, name: 'Dave' },
+        { id: 5, name: 'Eve' },
+      ];
+      const { result, unmount: u } = withSetup(() =>
+        useTableSelection<TestItem, 'id'>(
+          { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+          {
+            selectedData,
+            filtered: computed<GroupedTableRow<TestItem>[]>(() => extendedRows),
+          },
+        ),
+      );
+      unmount = u;
+
+      // First click on row index 0 (non-shift to set anchor)
+      const normalEvent = createMockCheckboxEvent({ shiftKey: false });
+      result.onCheckboxClick(normalEvent, 1, 0);
+
+      // Select row 1 so it becomes the anchor's selected state
+      result.onSelect(true, 1, true);
+
+      // Shift-click on row index 3
+      const shiftEvent = createMockCheckboxEvent({ shiftKey: true });
+      result.onCheckboxClick(shiftEvent, 4, 3);
+
+      vi.advanceTimersByTime(2);
+
+      // Rows 0..3 (ids 1,2,3,4) should be selected
+      expect(get(selectedData)).toContain(1);
+      expect(get(selectedData)).toContain(2);
+      expect(get(selectedData)).toContain(3);
+      expect(get(selectedData)).toContain(4);
+      expect(get(selectedData)).not.toContain(5);
+    });
+
+    it('should deselect range when anchor row was deselected', () => {
+      const extendedRows: TestItem[] = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+        { id: 4, name: 'Dave' },
+      ];
+      const selectedData = ref<number[]>([1, 2, 3, 4]);
+      const { result, unmount: u } = withSetup(() =>
+        useTableSelection<TestItem, 'id'>(
+          { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+          {
+            selectedData,
+            filtered: computed<GroupedTableRow<TestItem>[]>(() => extendedRows),
+          },
+        ),
+      );
+      unmount = u;
+
+      // First click on row index 0 (non-shift to set anchor)
+      const normalEvent = createMockCheckboxEvent({ shiftKey: false });
+      result.onCheckboxClick(normalEvent, 1, 0);
+
+      // Deselect the anchor row so isSelected(1) is false
+      result.onSelect(false, 1, true);
+
+      // Shift-click on row index 3
+      const shiftEvent = createMockCheckboxEvent({ shiftKey: true });
+      result.onCheckboxClick(shiftEvent, 4, 3);
+
+      vi.advanceTimersByTime(2);
+
+      // All rows in the range should be deselected
+      expect(get(selectedData)).not.toContain(1);
+      expect(get(selectedData)).not.toContain(2);
+      expect(get(selectedData)).not.toContain(3);
+      expect(get(selectedData)).not.toContain(4);
+    });
+
+    it('should skip disabled rows within the range', () => {
+      const extendedRows: TestItem[] = [
+        { id: 1, name: 'Alice' },
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+        { id: 4, name: 'Dave' },
+      ];
+      const disabledRow: TestItem = { id: 2, name: 'Bob' };
+      const selectedData = ref<number[]>([]);
+      const { result, unmount: u } = withSetup(() =>
+        useTableSelection<TestItem, 'id'>(
+          { rowAttr: 'id', multiPageSelect: false, disabledRows: () => [disabledRow] },
+          {
+            selectedData,
+            filtered: computed<GroupedTableRow<TestItem>[]>(() => extendedRows),
+          },
+        ),
+      );
+      unmount = u;
+
+      // First click on row 0 (non-shift to set anchor)
+      const normalEvent = createMockCheckboxEvent({ shiftKey: false });
+      result.onCheckboxClick(normalEvent, 1, 0);
+
+      // Select row 1 so anchor is selected
+      result.onSelect(true, 1, true);
+
+      // Shift-click on row 3
+      const shiftEvent = createMockCheckboxEvent({ shiftKey: true });
+      result.onCheckboxClick(shiftEvent, 4, 3);
+
+      vi.advanceTimersByTime(2);
+
+      // Row 2 (disabled) should not be selected
+      expect(get(selectedData)).toContain(1);
+      expect(get(selectedData)).not.toContain(2);
+      expect(get(selectedData)).toContain(3);
+      expect(get(selectedData)).toContain(4);
+    });
+
+    it('should skip group headers in filtered data', () => {
+      const groupHeader: GroupHeader<TestItem> = {
+        [GROUP_HEADER_BRAND]: true,
+        identifier: 'group-1',
+        group: { name: 'Group 1' },
+      };
+      const mixedRows: GroupedTableRow<TestItem>[] = [
+        { id: 1, name: 'Alice' },
+        groupHeader,
+        { id: 2, name: 'Bob' },
+        { id: 3, name: 'Charlie' },
+      ];
+      const selectedData = ref<number[]>([]);
+      const { result, unmount: u } = withSetup(() =>
+        useTableSelection<TestItem, 'id'>(
+          { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+          {
+            selectedData,
+            filtered: computed<GroupedTableRow<TestItem>[]>(() => mixedRows),
+          },
+        ),
+      );
+      unmount = u;
+
+      // First click on index 0 (non-shift to set anchor)
+      const normalEvent = createMockCheckboxEvent({ shiftKey: false });
+      result.onCheckboxClick(normalEvent, 1, 0);
+
+      // Select row 1 so anchor is selected
+      result.onSelect(true, 1, true);
+
+      // Shift-click on index 3 (id: 3)
+      const shiftEvent = createMockCheckboxEvent({ shiftKey: true });
+      result.onCheckboxClick(shiftEvent, 3, 3);
+
+      vi.advanceTimersByTime(2);
+
+      // All real rows should be selected, group header skipped
+      expect(get(selectedData)).toContain(1);
+      expect(get(selectedData)).toContain(2);
+      expect(get(selectedData)).toContain(3);
+      expect(get(selectedData)).toHaveLength(3);
+    });
+
+    it('should select single row when no prior click exists', () => {
+      const selectedData = ref<number[]>([]);
+      const { result, unmount: u } = withSetup(() =>
+        useTableSelection<TestItem, 'id'>(
+          { rowAttr: 'id', multiPageSelect: false, disabledRows: () => undefined },
+          {
+            selectedData,
+            filtered: computed<GroupedTableRow<TestItem>[]>(() => rows),
+          },
+        ),
+      );
+      unmount = u;
+
+      // Shift-click without any prior click (lastSelectedIndex === -1)
+      const shiftEvent = createMockCheckboxEvent({ shiftKey: true });
+      result.onCheckboxClick(shiftEvent, 2, 1);
+
+      vi.advanceTimersByTime(2);
+
+      // When lastSelectedIndex is -1, it falls back to lastIndex = index,
+      // so it toggles just the single row at that index.
+      // Row at index 1 is id:2, and since it's not selected, isSelected returns false,
+      // so valueToApply is false, and it calls onSelect(!false, value) = onSelect(true, 2)
+      expect(get(selectedData)).toContain(2);
+      expect(get(selectedData)).toHaveLength(1);
+    });
   });
 });

--- a/packages/ui-library/src/composables/tables/data-table/selection.ts
+++ b/packages/ui-library/src/composables/tables/data-table/selection.ts
@@ -41,11 +41,11 @@ export function useTableSelection<T extends object, IdType extends keyof T>(
 
   const shiftClicked: Ref<boolean> = shallowRef(false);
   const lastSelectedIndex: Ref<number> = shallowRef(-1);
-  const internalSelectedData: Ref<T[IdType][]> = ref([]);
+  const internalSelectedData: Ref<T[IdType][]> = shallowRef([]);
   const { create: scheduleShiftSelect } = useTimeoutManager();
 
   // Sync external selection model to internal state
-  watch(selectedData, val => set(internalSelectedData, val), { immediate: true });
+  watch(selectedData, val => set(internalSelectedData, val ?? []), { immediate: true });
 
   const visibleIdentifiers = computed<T[IdType][]>(() =>
     get(filtered)
@@ -145,7 +145,7 @@ export function useTableSelection<T extends object, IdType extends keyof T>(
     else if (!checked && selected) {
       set(
         internalSelectedData,
-        [...selectedRows].filter(r => r !== value),
+        selectedRows.filter(r => r !== value),
       );
     }
 
@@ -185,11 +185,24 @@ export function useTableSelection<T extends object, IdType extends keyof T>(
               const from = Math.min(lastIndex, index);
               const to = Math.max(lastIndex, index);
 
+              // Batch: collect all IDs in range, then update once
+              const currentSelected = get(internalSelectedData);
+              const rangeIds: T[IdType][] = [];
               for (let i = from; i <= to; i++) {
                 const currSelectedData = tableData[i];
                 assert(currSelectedData);
                 if (isRow(currSelectedData) && !isDisabledRow(currSelectedData[rowAttr]))
-                  onSelect(valueToApply, currSelectedData[rowAttr]);
+                  rangeIds.push(currSelectedData[rowAttr]);
+              }
+
+              if (valueToApply) {
+                const existing = new Set(currentSelected);
+                const toAdd = rangeIds.filter(id => !existing.has(id));
+                set(internalSelectedData, [...currentSelected, ...toAdd]);
+              }
+              else {
+                const toRemove = new Set(rangeIds);
+                set(internalSelectedData, currentSelected.filter(id => !toRemove.has(id)));
               }
             }
 

--- a/packages/ui-library/src/composables/tables/data-table/sort.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/sort.spec.ts
@@ -1,25 +1,13 @@
-import { mount } from '@vue/test-utils';
+import type { TableSortData } from '@/components/tables/RuiTableHead.vue';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { defineComponent } from 'vue';
 import { useTableSort } from '@/composables/tables/data-table/sort';
+import { assert } from '@/utils/assert';
+import { withSetup } from '~/tests/helpers/with-setup';
 
 interface TestItem {
   id: number;
   name: string;
   title: string;
-}
-
-function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
-  let result!: T;
-  const TestComponent = defineComponent({
-    setup() {
-      result = composable();
-      return {};
-    },
-    template: '<div></div>',
-  });
-  const wrapper = mount(TestComponent);
-  return { result, unmount: () => wrapper.unmount() };
 }
 
 describe('composables/tables/data-table/sort', () => {
@@ -36,7 +24,7 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should filter rows based on search query', () => {
-    const sort = ref<{ column?: string; direction: 'asc' | 'desc' } | undefined>({
+    const sort = ref<TableSortData<TestItem>>({
       column: undefined,
       direction: 'asc',
     });
@@ -44,7 +32,7 @@ describe('composables/tables/data-table/sort', () => {
       useTableSort<TestItem>(
         { rows: () => rows, search: () => 'alice', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -57,12 +45,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should sort rows ascending', () => {
-    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -77,12 +65,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should sort rows descending', () => {
-    const sort = ref({ column: 'name', direction: 'desc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'desc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -96,12 +84,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should sort numeric values correctly', () => {
-    const sort = ref({ column: 'id', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'id', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -116,12 +104,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should not sort when sortModifiersExternal is true', () => {
-    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: true },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -134,12 +122,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should build sortedMap from single sort', () => {
-    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -152,13 +140,13 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should emit update:options when sort changes via onSort', () => {
-    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: undefined, direction: 'asc' });
     const emitUpdateOptions = vi.fn();
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions,
         },
@@ -171,12 +159,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should toggle single sort direction on same column', () => {
-    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -190,12 +178,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should clear single sort when toggling past desc', () => {
-    const sort = ref({ column: 'name', direction: 'desc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'desc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -209,12 +197,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should set new column when sorting unsorted column in single mode', () => {
-    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -227,12 +215,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should support explicit direction in onSort', () => {
-    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: undefined, direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -245,12 +233,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should add column in multi-sort mode', () => {
-    const sort = ref([{ column: 'name', direction: 'asc' as const }]);
+    const sort = ref<TableSortData<TestItem>>([{ column: 'name', direction: 'asc' }]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -265,12 +253,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should toggle direction in multi-sort mode', () => {
-    const sort = ref([{ column: 'name', direction: 'asc' as const }]);
+    const sort = ref<TableSortData<TestItem>>([{ column: 'name', direction: 'asc' }]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -280,21 +268,22 @@ describe('composables/tables/data-table/sort', () => {
 
     // asc → desc
     result.onSort({ key: 'name' });
-    const sortVal = get(result.sortData) as Array<{ column: string; direction: string }>;
+    const sortVal = get(result.sortData);
+    assert(Array.isArray(sortVal));
     expect(sortVal).toHaveLength(1);
     expect(sortVal[0]?.direction).toBe('desc');
   });
 
   it('should remove column in multi-sort when toggling past desc', () => {
-    const sort = ref([
-      { column: 'name', direction: 'desc' as const },
-      { column: 'title', direction: 'asc' as const },
+    const sort = ref<TableSortData<TestItem>>([
+      { column: 'name', direction: 'desc' },
+      { column: 'title', direction: 'asc' },
     ]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -304,21 +293,22 @@ describe('composables/tables/data-table/sort', () => {
 
     // desc → remove
     result.onSort({ key: 'name' });
-    const sortVal = get(result.sortData) as Array<{ column: string; direction: string }>;
+    const sortVal = get(result.sortData);
+    assert(Array.isArray(sortVal));
     expect(sortVal).toHaveLength(1);
     expect(sortVal[0]?.column).toBe('title');
   });
 
   it('should return sort index for multi-sort', () => {
-    const sort = ref([
-      { column: 'name', direction: 'asc' as const },
-      { column: 'title', direction: 'asc' as const },
+    const sort = ref<TableSortData<TestItem>>([
+      { column: 'name', direction: 'asc' },
+      { column: 'title', direction: 'asc' },
     ]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -332,12 +322,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should return -1 for getSortIndex in single sort mode', () => {
-    const sort = ref({ column: 'name', direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: 'name', direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -349,15 +339,15 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should build sortedMap from multi-sort array', () => {
-    const sort = ref([
-      { column: 'name', direction: 'asc' as const },
-      { column: 'id', direction: 'desc' as const },
+    const sort = ref<TableSortData<TestItem>>([
+      { column: 'name', direction: 'asc' },
+      { column: 'id', direction: 'desc' },
     ]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -371,12 +361,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should return empty sortedMap when single sort column is undefined', () => {
-    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: undefined, direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -389,15 +379,15 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should skip entries with falsy column in multi-sort sortedMap', () => {
-    const sort = ref([
-      { column: 'name', direction: 'asc' as const },
-      { column: undefined, direction: 'asc' as const },
+    const sort = ref<TableSortData<TestItem>>([
+      { column: 'name', direction: 'asc' },
+      { column: undefined, direction: 'asc' },
     ]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -411,12 +401,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should preserve row order when sort column is undefined', () => {
-    const sort = ref({ column: undefined, direction: 'asc' as const });
+    const sort = ref<TableSortData<TestItem>>({ column: undefined, direction: 'asc' });
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -432,12 +422,12 @@ describe('composables/tables/data-table/sort', () => {
   });
 
   it('should support explicit direction in multi-sort onSort', () => {
-    const sort = ref([{ column: 'name', direction: 'asc' as const }]);
+    const sort = ref<TableSortData<TestItem>>([{ column: 'name', direction: 'asc' }]);
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions: () => {},
         },
@@ -446,20 +436,21 @@ describe('composables/tables/data-table/sort', () => {
     unmount = u;
 
     result.onSort({ key: 'title', direction: 'desc' });
-    const sortVal = get(result.sortData) as Array<{ column: string; direction: string }>;
+    const sortVal = get(result.sortData);
+    assert(Array.isArray(sortVal));
     expect(sortVal).toHaveLength(2);
     expect(sortVal[1]?.column).toBe('title');
     expect(sortVal[1]?.direction).toBe('desc');
   });
 
   it('should do nothing when onSort is called with undefined sortData', () => {
-    const sort = ref(undefined);
+    const sort = ref<TableSortData<TestItem>>(undefined);
     const emitUpdateOptions = vi.fn();
     const { result, unmount: u } = withSetup(() =>
       useTableSort<TestItem>(
         { rows: () => rows, search: () => '', sortModifiersExternal: false },
         {
-          sort: sort as any,
+          sort,
           pagination: ref(undefined),
           emitUpdateOptions,
         },
@@ -469,5 +460,151 @@ describe('composables/tables/data-table/sort', () => {
 
     result.onSort({ key: 'name' });
     expect(emitUpdateOptions).not.toHaveBeenCalled();
+  });
+
+  it('should match rows with undefined field values when searching for "undefined"', () => {
+    interface PartialItem {
+      id: number;
+      name: string | undefined;
+      title: string;
+    }
+
+    const rowsWithUndefined: PartialItem[] = [
+      { id: 1, name: undefined, title: 'Developer' },
+      { id: 2, name: 'Bob', title: 'Designer' },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<PartialItem>(
+        { rows: () => rowsWithUndefined, search: () => 'undefined', sortModifiersExternal: false },
+        {
+          sort: ref<TableSortData<PartialItem>>({ column: undefined, direction: 'asc' }),
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.searchData)).toHaveLength(1);
+    expect(get(result.searchData)[0]?.id).toBe(1);
+  });
+
+  it('should return empty results when searching on empty rows', () => {
+    const emptyRows: TestItem[] = [];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TestItem>(
+        { rows: () => emptyRows, search: () => 'alice', sortModifiersExternal: false },
+        {
+          sort: ref<TableSortData<TestItem>>({ column: undefined, direction: 'asc' }),
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    expect(get(result.searchData)).toHaveLength(0);
+  });
+
+  it('should detect numeric column type by skipping null values', () => {
+    interface NullableItem {
+      id: number;
+      score: number | null;
+    }
+
+    const rowsWithNull: NullableItem[] = [
+      { id: 1, score: null },
+      { id: 2, score: 10 },
+      { id: 3, score: 2 },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<NullableItem>(
+        { rows: () => rowsWithNull, search: () => '', sortModifiersExternal: false },
+        {
+          sort: ref<TableSortData<NullableItem>>({ column: 'score', direction: 'asc' }),
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    // Numeric sort: null coerces to 0 via Number(null), so null < 2 < 10
+    expect(sorted[0]?.score).toBeNull();
+    expect(sorted[1]?.score).toBe(2);
+    expect(sorted[2]?.score).toBe(10);
+  });
+
+  it('should break ties with secondary sort in multi-column sort', () => {
+    interface TieItem {
+      id: number;
+      group: string;
+      rank: number;
+    }
+
+    const tieRows: TieItem[] = [
+      { id: 1, group: 'A', rank: 3 },
+      { id: 2, group: 'A', rank: 1 },
+      { id: 3, group: 'B', rank: 2 },
+      { id: 4, group: 'A', rank: 2 },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<TieItem>(
+        { rows: () => tieRows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: ref<TableSortData<TieItem>>([
+            { column: 'group', direction: 'asc' },
+            { column: 'rank', direction: 'asc' },
+          ]),
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    // Group A first (sorted by rank: 1, 2, 3), then group B (rank: 2)
+    expect(sorted[0]?.id).toBe(2);
+    expect(sorted[1]?.id).toBe(4);
+    expect(sorted[2]?.id).toBe(1);
+    expect(sorted[3]?.id).toBe(3);
+  });
+
+  it('should handle column with all null values without errors', () => {
+    interface AllNullItem {
+      id: number;
+      value: string | null;
+    }
+
+    const allNullRows: AllNullItem[] = [
+      { id: 1, value: null },
+      { id: 2, value: null },
+      { id: 3, value: null },
+    ];
+
+    const { result, unmount: u } = withSetup(() =>
+      useTableSort<AllNullItem>(
+        { rows: () => allNullRows, search: () => '', sortModifiersExternal: false },
+        {
+          sort: ref<TableSortData<AllNullItem>>({ column: 'value', direction: 'asc' }),
+          pagination: ref(undefined),
+          emitUpdateOptions: () => {},
+        },
+      ),
+    );
+    unmount = u;
+
+    const sorted = get(result.sorted);
+    // Should not throw; all null values treated as string comparison
+    expect(sorted).toHaveLength(3);
+    expect(sorted[0]?.id).toBe(1);
+    expect(sorted[1]?.id).toBe(2);
+    expect(sorted[2]?.id).toBe(3);
   });
 });

--- a/packages/ui-library/src/composables/tables/data-table/sort.ts
+++ b/packages/ui-library/src/composables/tables/data-table/sort.ts
@@ -1,9 +1,15 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { SortColumn, TableRowKey, TableSortData } from '@/components/tables/RuiTableHead.vue';
 import type { TablePaginationData } from '@/components/tables/RuiTablePagination.vue';
+import { SortDirection } from '@/components/tables/table-props';
+import { getObjectKeys } from '@/composables/tables/data-table/types';
 import { assert } from '@/utils/assert';
 
 const SORT_COLLATOR = new Intl.Collator(undefined, { sensitivity: 'accent', usage: 'sort' });
+
+function toggleDirection(direction: SortDirection): SortDirection {
+  return direction === SortDirection.asc ? SortDirection.desc : SortDirection.asc;
+}
 
 export interface UseTableSortOptions<T extends object> {
   /** The data rows to sort. */
@@ -26,11 +32,31 @@ export interface UseTableSortDeps<T extends object> {
 export interface UseTableSortReturn<T extends object> {
   sortData: ComputedRef<TableSortData<T>>;
   sortedMap: ComputedRef<Partial<Record<TableRowKey<T>, SortColumn<T>>>>;
-  searchData: ComputedRef<T[]>;
-  sorted: ComputedRef<T[]>;
+  searchData: ComputedRef<readonly T[]>;
+  sorted: ComputedRef<readonly T[]>;
   isSortedBy: (key: TableRowKey<T>) => boolean;
   getSortIndex: (key: TableRowKey<T>) => number;
-  onSort: (payload: { key: TableRowKey<T>; direction?: 'asc' | 'desc' }) => void;
+  onSort: (payload: { key: TableRowKey<T>; direction?: SortDirection }) => void;
+}
+
+/**
+ * Detect whether each column contains numeric data by sampling the first non-null value.
+ */
+function detectNumericColumns<T extends object>(
+  activeColumns: TableRowKey<T>[],
+  data: readonly T[],
+): Map<TableRowKey<T>, boolean> {
+  const isNumericCol = new Map<TableRowKey<T>, boolean>();
+  for (const key of activeColumns) {
+    for (const row of data) {
+      const val = row[key];
+      if (val != null) {
+        isNumericCol.set(key, !Number.isNaN(Number(val)));
+        break;
+      }
+    }
+  }
+  return isNumericCol;
 }
 
 export function useTableSort<T extends object>(
@@ -39,8 +65,6 @@ export function useTableSort<T extends object>(
 ): UseTableSortReturn<T> {
   const { rows, search, sortModifiersExternal } = options;
   const { sort, pagination, emitUpdateOptions } = deps;
-
-  const getKeys = <O extends object>(t: O): TableRowKey<O>[] => Object.keys(t) as TableRowKey<O>[];
 
   const sortData = computed<TableSortData<T>>({
     get(): TableSortData<T> {
@@ -77,46 +101,75 @@ export function useTableSort<T extends object>(
     }, mapped);
   });
 
-  const searchData = computed<T[]>(() => {
+  // Pre-compute a single lowercased searchable string per row, recomputed only when rows change
+  const searchIndex = computed<Map<T, string>>(() => {
+    if (!toValue(search))
+      return new Map<T, string>();
+
+    const currentRows = toValue(rows);
+    const index = new Map<T, string>();
+    for (const row of currentRows) {
+      const parts: string[] = [];
+      for (const key of getObjectKeys(row))
+        parts.push(`${row[key]}`);
+      index.set(row, parts.join('\0').toLocaleLowerCase());
+    }
+    return index;
+  });
+
+  const searchData = computed<readonly T[]>(() => {
     const currentRows = toValue(rows);
     const query = toValue(search)?.toLocaleLowerCase();
     if (!query)
-      return [...currentRows];
+      return currentRows;
 
-    return currentRows.filter(row =>
-      getKeys(row).some(key => `${row[key]}`.toLocaleLowerCase().includes(query)),
-    );
+    const index = get(searchIndex);
+    return currentRows.filter((row) => {
+      const searchStr = index.get(row);
+      return searchStr?.includes(query) ?? false;
+    });
   });
 
-  const sorted: ComputedRef<T[]> = computed(() => {
+  const sorted: ComputedRef<readonly T[]> = computed(() => {
     const sortBy = get(sortData);
     if (!sortBy || sortModifiersExternal)
       return get(searchData);
 
     const data = [...get(searchData)];
+    const sortColumns = Array.isArray(sortBy) ? sortBy : [sortBy];
+    const activeColumns = sortColumns
+      .map(col => col.column)
+      .filter((col): col is TableRowKey<T> => !!col);
 
-    const sortFn = (by: SortColumn<T>): void => {
-      data.sort((a, b) => {
-        const column = by.column;
-        if (!column)
-          return 0;
+    if (activeColumns.length === 0)
+      return data;
 
-        let [aValue, bValue] = [a[column], b[column]];
-        if (by.direction === 'desc')
-          [aValue, bValue] = [bValue, aValue];
+    const isNumericCol = detectNumericColumns(activeColumns, data);
 
-        const aNumber = Number(aValue);
-        const bNumber = Number(bValue);
-        if (!isNaN(aNumber) && !isNaN(bNumber))
-          return aNumber - bNumber;
+    // Build a lookup for direction per column
+    const directionMap = new Map<TableRowKey<T>, SortDirection>();
+    for (const col of sortColumns) {
+      if (col.column)
+        directionMap.set(col.column, col.direction ?? SortDirection.asc);
+    }
 
-        return SORT_COLLATOR.compare(`${aValue}`, `${bValue}`);
-      });
-    };
+    data.sort((a, b) => {
+      for (const key of activeColumns) {
+        let [aVal, bVal] = [a[key], b[key]];
+        if (directionMap.get(key) === SortDirection.desc)
+          [aVal, bVal] = [bVal, aVal];
 
-    if (!Array.isArray(sortBy))
-      sortFn(sortBy);
-    else [...sortBy].reverse().forEach(sortFn);
+        let result: number;
+        if (isNumericCol.get(key))
+          result = Number(aVal) - Number(bVal);
+        else
+          result = SORT_COLLATOR.compare(`${aVal}`, `${bVal}`);
+
+        if (result !== 0)
+          return result;
+      }
+      return 0;
+    });
 
     return data;
   });
@@ -134,56 +187,67 @@ export function useTableSort<T extends object>(
     return sortBy.findIndex(s => s.column === key);
   }
 
-  function onSort({ key, direction }: { key: TableRowKey<T>; direction?: 'asc' | 'desc' }): void {
-    const sortBy = get(sortData);
-    if (!sortBy)
-      return;
+  function onSortSingle(
+    sortBy: SortColumn<T>,
+    key: TableRowKey<T>,
+    direction?: SortDirection,
+  ): void {
+    if (isSortedBy(key)) {
+      const newDirection = toggleDirection(direction ?? SortDirection.asc);
 
-    if (!Array.isArray(sortBy)) {
-      if (isSortedBy(key)) {
-        const newDirection = !direction || direction === 'asc' ? 'desc' : 'asc';
-
-        if (sortBy.direction === newDirection) {
-          set(sortData, { ...sortBy, column: undefined, direction: 'asc' });
-        }
-        else {
-          set(sortData, {
-            ...sortBy,
-            direction: sortBy.direction === 'asc' ? 'desc' : 'asc',
-          });
-        }
+      if (sortBy.direction === newDirection) {
+        set(sortData, { ...sortBy, column: undefined, direction: SortDirection.asc });
       }
       else {
-        set(sortData, { column: key, direction: direction || 'asc' });
+        set(sortData, {
+          ...sortBy,
+          direction: toggleDirection(sortBy.direction),
+        });
       }
-      return;
     }
+    else {
+      set(sortData, { column: key, direction: direction ?? SortDirection.asc });
+    }
+  }
 
+  function onSortMulti(
+    sortBy: SortColumn<T>[],
+    key: TableRowKey<T>,
+    direction?: SortDirection,
+  ): void {
     if (isSortedBy(key)) {
-      const newDirection = !direction || direction === 'asc' ? 'desc' : 'asc';
+      const newDirection = toggleDirection(direction ?? SortDirection.asc);
 
       const index = getSortIndex(key);
       const sortByCol = sortBy[index];
       assert(sortByCol);
 
       if (sortByCol.direction === newDirection) {
-        set(
-          sortData,
-          sortBy.filter((_, i) => i !== index),
-        );
+        set(sortData, sortBy.filter((_, i) => i !== index));
       }
       else {
         set(
           sortData,
           sortBy.map((col, i) =>
-            i === index ? { ...col, direction: col.direction === 'asc' ? 'desc' : 'asc' } : col,
+            i === index ? { ...col, direction: toggleDirection(col.direction) } : col,
           ),
         );
       }
     }
     else {
-      set(sortData, [...sortBy, { column: key, direction: direction || 'asc' }]);
+      set(sortData, [...sortBy, { column: key, direction: direction ?? SortDirection.asc }]);
     }
+  }
+
+  function onSort({ key, direction }: { key: TableRowKey<T>; direction?: SortDirection }): void {
+    const sortBy = get(sortData);
+    if (!sortBy)
+      return;
+
+    if (Array.isArray(sortBy))
+      onSortMulti(sortBy, key, direction);
+    else
+      onSortSingle(sortBy, key, direction);
   }
 
   return {

--- a/packages/ui-library/src/composables/tables/data-table/types.ts
+++ b/packages/ui-library/src/composables/tables/data-table/types.ts
@@ -6,8 +6,10 @@ export interface TableOptions<T> {
   sort?: TableSortData<T>;
 }
 
+export const GROUP_HEADER_BRAND: unique symbol = Symbol('GroupHeader');
+
 export interface GroupHeader<T> {
-  __header__: true;
+  [GROUP_HEADER_BRAND]: true;
   identifier: string;
   group: Partial<T>;
 }
@@ -15,9 +17,13 @@ export interface GroupHeader<T> {
 export type GroupedTableRow<T> = T | GroupHeader<T>;
 
 export function isRow<T extends object>(item: GroupedTableRow<T>): item is T {
-  return !('__header__' in item);
+  return !(GROUP_HEADER_BRAND in item);
 }
 
 export function isHeaderSlot(slotName: string): slotName is `header.${string}` {
   return slotName.startsWith('header.');
+}
+
+export function getObjectKeys<O extends object>(obj: O): (string & keyof O)[] {
+  return Object.keys(obj).filter((key): key is string & keyof O => key in obj);
 }

--- a/packages/ui-library/tests/helpers/with-setup.ts
+++ b/packages/ui-library/tests/helpers/with-setup.ts
@@ -1,0 +1,26 @@
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+
+/**
+ * Mount a composable inside a minimal host component so that Vue's
+ * lifecycle (provide/inject, watchers, etc.) is available.
+ *
+ * @param composable — factory that calls the composable under test
+ * @param options    — optional Vue Test Utils mounting options (e.g. `global.provide`)
+ * @returns `{ result, unmount }` — the composable's return value and a teardown function
+ */
+export function withSetup<T>(
+  composable: () => T,
+  options?: ComponentMountingOptions<any>,
+): { result: T; unmount: () => void } {
+  let result!: T;
+  const TestComponent = defineComponent({
+    setup() {
+      result = composable();
+      return {};
+    },
+    template: '<div></div>',
+  });
+  const wrapper = mount(TestComponent, options);
+  return { result, unmount: () => wrapper.unmount() };
+}


### PR DESCRIPTION
## Summary

- Decompose the monolithic `RuiDataTable` template into 7 focused sub-components (`RuiDataTableBody`, `RuiDataTableRow`, `RuiDataTableCell`, `RuiDataTableGroupRow`, `RuiDataTableEmptyRow`, `RuiDataTableExpandedRow`, `RuiDataTableLoadingRow`)
- Split the single `DataTableContext` into 6 per-concern provide/inject pairs (`Styling`, `Columns`, `Selection`, `Expansion`, `Grouping`, `RowIdentity`), each sub-component now only injects what it needs
- Pre-compute per-column `tdClass` to eliminate per-cell `tv()` calls, move `itemSlotKeys` to context as `Set<string>` for O(1) lookups, and pass `rowId` from parent row to avoid redundant `getRowId` calls
- Fix story v-model reactivity bug for expanded/group/collapsed bindings, add 8 missing stories, and replace hardcoded test data with deterministic generated fixtures across stories and e2e tests

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test:run` — 1072 unit tests pass
- [x] `pnpm run test:e2e` — 262 e2e tests pass
- [ ] Verify stories render correctly in Storybook (`pnpm run storybook`)