### PR TITLE
fix(tables): swap pagination dropdown for input on large page counts

### DIFF
--- a/apps/example/e2e/data-table.spec.ts
+++ b/apps/example/e2e/data-table.spec.ts
@@ -168,8 +168,9 @@ test.describe('data tables - pagination', () => {
     const perPageSelect = container.locator('[data-id=table-pagination-limit] [data-id=activator]').first();
     await perPageSelect.click();
 
-    // Select a different limit (e.g., 10)
-    const option = page.getByRole('button', { name: '10', exact: true });
+    // Select a different limit (e.g., 10) — scope to the opened menu content,
+    // otherwise the activator buttons of sibling pagination sections collide.
+    const option = page.getByTestId('content').getByRole('button', { name: '10', exact: true });
     await option.click();
 
     // Row count should change
@@ -253,6 +254,58 @@ test.describe('data tables - pagination', () => {
     // The table thead should have sticky class (library uses absolute/fixed positioning for sticky behavior)
     const thead = table.locator('table thead[data-id="head-main"]');
     await expect(thead).toHaveClass(/absolute/);
+  });
+
+  test('should swap dropdown for jump-to-page input when pages exceed rangesThreshold', async ({ page }) => {
+    const container = page.locator('[data-id=table-pagination-large-total]');
+    const table = container.locator('[data-id=table]');
+    await expect(table).toBeVisible();
+
+    // Dropdown must not render above the threshold
+    await expect(container.locator('[data-id=table-pagination-ranges]')).toHaveCount(0);
+
+    // Input must be present (one per header/footer pagination instance)
+    const inputs = container.locator('[data-id=table-pagination-ranges-input] input');
+    await expect(inputs.first()).toBeVisible();
+
+    const input = inputs.first();
+    await expect(input).toHaveValue('1');
+
+    // Typing a page and pressing Enter should commit
+    await input.fill('4242');
+    await input.press('Enter');
+    await expect(input).toHaveValue('4242');
+
+    // The other pagination instance should sync
+    await expect(inputs.nth(1)).toHaveValue('4242');
+  });
+
+  test('should clamp out-of-range page input to the last page', async ({ page }) => {
+    const container = page.locator('[data-id=table-pagination-large-total]');
+    const input = container.locator('[data-id=table-pagination-ranges-input] input').first();
+
+    // 100_000 / 10 = 10_000 pages
+    await input.fill('999999999');
+    await input.press('Enter');
+    await expect(input).toHaveValue('10000');
+
+    // Negative / zero should clamp to 1
+    await input.fill('0');
+    await input.press('Enter');
+    await expect(input).toHaveValue('1');
+  });
+
+  test('should keep the ranges dropdown when rangesThreshold is 0 even for large totals', async ({ page }) => {
+    const container = page.locator('[data-id=table-pagination-large-total-dropdown]');
+    const table = container.locator('[data-id=table]');
+    await expect(table).toBeVisible();
+
+    // Input must not render when escape hatch is active
+    await expect(container.locator('[data-id=table-pagination-ranges-input]')).toHaveCount(0);
+
+    // Dropdown activator must still be present
+    const activator = container.locator('[data-id=table-pagination-ranges] [data-id=activator]').first();
+    await expect(activator).toBeVisible();
   });
 
   test('should produce consistent header widths after resize cycle', async ({ page }) => {

--- a/apps/example/src/views/data-tables/DataTablePaginationView.vue
+++ b/apps/example/src/views/data-tables/DataTablePaginationView.vue
@@ -36,6 +36,18 @@ const paginationSticky = ref<TablePaginationData>({
   page: 1,
   total: fixedRows.length,
 });
+
+const paginationLargeTotal = ref<TablePaginationData>({
+  limit: 10,
+  page: 1,
+  total: 100_000,
+});
+
+const paginationLargeTotalDropdown = ref<TablePaginationData>({
+  limit: 10,
+  page: 1,
+  total: 100_000,
+});
 </script>
 
 <template>
@@ -171,6 +183,47 @@ const paginationSticky = ref<TablePaginationData>({
             </RuiButton>
           </template>
         </RuiDataTable>
+      </div>
+
+      <!-- Large total (jump-to-page input mode) -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-pagination-large-total"
+      >
+        <h4>Large Total (jump-to-page input)</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Simulated server-side pagination with total = 100,000 and limit = 10 →
+          10,000 pages. The ranges dropdown is replaced by a numeric input.
+        </p>
+        <RuiDataTable
+          v-model:pagination.external="paginationLargeTotal"
+          :rows="fixedRows"
+          :cols="fixedColumns"
+          row-attr="id"
+          outlined
+          data-id="table"
+        />
+      </div>
+
+      <!-- Large total with dropdown forced via rangesThreshold=0 -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-pagination-large-total-dropdown"
+      >
+        <h4>Large Total (dropdown forced)</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Same total as above but with <code>rangesThreshold = 0</code> — the
+          dropdown stays, so you can confirm the escape hatch works.
+        </p>
+        <RuiDataTable
+          v-model:pagination.external="paginationLargeTotalDropdown"
+          :rows="fixedRows"
+          :cols="fixedColumns"
+          :ranges-threshold="0"
+          row-attr="id"
+          outlined
+          data-id="table"
+        />
       </div>
 
       <!-- Sticky header -->

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -73,6 +73,11 @@ export interface Props<T, K extends keyof T> {
   loading?: boolean;
   disablePerPage?: boolean;
   /**
+   * Maximum number of pages before the jump-to-page dropdown is replaced with
+   * a numeric input. Defaults to `500`. Forwarded to `RuiTablePagination`.
+   */
+  rangesThreshold?: number;
+  /**
    * data to display for empty state
    * text and icon
    * @example :empty="{ icon: 'transactions-line', label: 'No transactions found' }"
@@ -139,6 +144,7 @@ const {
   striped = false,
   loading = false,
   disablePerPage = false,
+  rangesThreshold = 500,
   empty = { label: 'No item found' },
   hideDefaultHeader = false,
   hideDefaultFooter = false,
@@ -335,6 +341,7 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
       :dense="dense"
       :loading="loading"
       :disable-per-page="disablePerPage"
+      :ranges-threshold="rangesThreshold"
       data-id="table-pagination"
       @update:model-value="onPaginate()"
     />
@@ -638,6 +645,7 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
       :dense="dense"
       :loading="loading"
       :disable-per-page="disablePerPage"
+      :ranges-threshold="rangesThreshold"
       data-id="table-pagination"
       @update:model-value="onPaginate()"
     />

--- a/packages/ui-library/src/components/tables/RuiTablePagination.vue
+++ b/packages/ui-library/src/components/tables/RuiTablePagination.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiMenuSelect from '@/components/forms/select/RuiMenuSelect.vue';
+import RuiTextField from '@/components/forms/text-field/RuiTextField.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { type TablePaginationData, usePaginationNavigation } from '@/components/tables/use-pagination-navigation';
 import { useTable } from '@/composables/defaults/table';
@@ -12,17 +13,30 @@ export interface Props {
   dense?: boolean;
   disablePerPage?: boolean;
   loading?: boolean;
+  /**
+   * Maximum number of pages before the jump-to-page dropdown is replaced
+   * with a numeric input. Set to `0` to always use the input, or a very
+   * large number to always use the dropdown. Defaults to `500` — past that
+   * materialising the full range list stalls the main thread.
+   */
+  rangesThreshold?: number;
 }
 
 const modelValue = defineModel<TablePaginationData>({ required: true });
 
-const { dense = false, loading = false, disablePerPage = false } = defineProps<Props>();
+const {
+  dense = false,
+  loading = false,
+  disablePerPage = false,
+  rangesThreshold = 500,
+} = defineProps<Props>();
 
 const paginationStyles = tv({
   slots: {
     wrapper: 'relative flex flex-wrap items-center justify-end gap-x-4 gap-y-0',
     limit: 'flex items-center space-x-2 text-caption',
     ranges: 'flex items-center space-x-2 text-caption pr-2',
+    pageInput: 'w-20',
     sectionLabel: 'text-rui-text-secondary whitespace-nowrap py-3',
     indicator: 'text-rui-text text-caption whitespace-nowrap',
     navigation: 'flex items-center',
@@ -43,16 +57,37 @@ const tableDefaults = useTable();
 const {
   limits,
   currentLimit,
+  pages,
   ranges,
   indicatorText,
   currentRange,
+  useInputJump,
   hasPrev,
   hasNext,
   onPrev,
   onNext,
   onFirst,
   onLast,
-} = usePaginationNavigation(modelValue, tableDefaults);
+} = usePaginationNavigation(modelValue, tableDefaults, () => rangesThreshold);
+
+const pageDraft = ref<string>(String(get(currentRange)));
+
+watch(currentRange, (value) => {
+  set(pageDraft, String(value));
+});
+
+function commitPageInput(): void {
+  const parsed = Number.parseInt(get(pageDraft), 10);
+  const maxPage = get(pages);
+  if (!Number.isFinite(parsed) || maxPage === 0) {
+    set(pageDraft, String(get(currentRange)));
+    return;
+  }
+  const clamped = Math.min(Math.max(parsed, 1), maxPage);
+  if (clamped !== get(currentRange))
+    set(currentRange, clamped);
+  set(pageDraft, String(clamped));
+}
 </script>
 
 <template>
@@ -79,9 +114,25 @@ const {
       :class="ui.ranges()"
       data-id="table-pagination-ranges-section"
     >
-      <span :class="ui.sectionLabel()">Items #</span>
+      <span :class="ui.sectionLabel()">{{ useInputJump ? 'Page' : 'Items #' }}</span>
+      <RuiTextField
+        v-if="useInputJump"
+        v-model="pageDraft"
+        :disabled="loading"
+        :class="ui.pageInput()"
+        type="number"
+        min="1"
+        :max="pages"
+        inputmode="numeric"
+        hide-details
+        dense
+        variant="outlined"
+        data-id="table-pagination-ranges-input"
+        @blur="commitPageInput()"
+        @keydown.enter="commitPageInput()"
+      />
       <RuiMenuSelect
-        v-if="ranges.length > 0"
+        v-else-if="ranges.length > 0"
         v-model="currentRange"
         :options="ranges"
         :disabled="loading"

--- a/packages/ui-library/src/components/tables/use-pagination-navigation.spec.ts
+++ b/packages/ui-library/src/components/tables/use-pagination-navigation.spec.ts
@@ -7,6 +7,7 @@ import { createTableDefaults, type TableOptions } from '@/composables/defaults/t
 function withSetup(
   initialData: TablePaginationData,
   tableOptions?: Partial<TableOptions>,
+  rangesThreshold?: number,
 ) {
   const modelValue = ref<TablePaginationData>(initialData) as Ref<TablePaginationData>;
   const defaults = createTableDefaults(tableOptions);
@@ -14,7 +15,7 @@ function withSetup(
   let result!: ReturnType<typeof usePaginationNavigation>;
   const TestComponent = defineComponent({
     setup() {
-      result = usePaginationNavigation(modelValue, defaults);
+      result = usePaginationNavigation(modelValue, defaults, rangesThreshold);
       return {};
     },
     template: '<div></div>',
@@ -147,6 +148,53 @@ describe('components/tables/use-pagination-navigation', () => {
     });
   });
 
+  describe('useInputJump / rangesThreshold', () => {
+    it('should stay on the dropdown when pages fit within the default threshold', () => {
+      const { result, unmount: u } = withSetup({ page: 1, total: 5000, limit: 10 });
+      unmount = u;
+
+      expect(result.useInputJump.value).toBe(false);
+      expect(result.ranges.value).toHaveLength(500);
+    });
+
+    it('should flip to input mode and skip range materialisation above the threshold', () => {
+      const { result, unmount: u } = withSetup({ page: 1, total: 5010, limit: 10 });
+      unmount = u;
+
+      expect(result.pages.value).toBe(501);
+      expect(result.useInputJump.value).toBe(true);
+      expect(result.ranges.value).toEqual([]);
+    });
+
+    it('should respect a custom threshold', () => {
+      const { result, unmount: u } = withSetup({ page: 1, total: 120, limit: 10 }, undefined, 5);
+      unmount = u;
+
+      expect(result.useInputJump.value).toBe(true);
+      expect(result.ranges.value).toEqual([]);
+    });
+
+    it('should disable the input-mode switch when threshold is 0', () => {
+      const { result, unmount: u } = withSetup(
+        { page: 1, total: 100_000, limit: 10 },
+        undefined,
+        0,
+      );
+      unmount = u;
+
+      expect(result.useInputJump.value).toBe(false);
+    });
+
+    it('should avoid materialising millions of ranges when total is huge', () => {
+      const { result, unmount: u } = withSetup({ page: 1, total: 4_015_386, limit: 10 });
+      unmount = u;
+
+      expect(result.pages.value).toBe(401_539);
+      expect(result.useInputJump.value).toBe(true);
+      expect(result.ranges.value).toEqual([]);
+    });
+  });
+
   describe('indicatorText', () => {
     it('should show total count', () => {
       const { result, unmount: u } = withSetup({ page: 1, total: 100, limit: 10 });
@@ -163,9 +211,18 @@ describe('components/tables/use-pagination-navigation', () => {
     });
 
     it('should format large totals', () => {
-      const { result, unmount: u } = withSetup({ page: 1, total: 10000, limit: 10 });
+      const { result, unmount: u } = withSetup({ page: 1, total: 10000, limit: 100 });
       unmount = u;
 
+      expect(result.useInputJump.value).toBe(false);
+      expect(result.indicatorText.value).toBe('of 10,000');
+    });
+
+    it('should switch to page count in input mode', () => {
+      const { result, unmount: u } = withSetup({ page: 1, total: 100_000, limit: 10 });
+      unmount = u;
+
+      expect(result.useInputJump.value).toBe(true);
       expect(result.indicatorText.value).toBe('of 10,000');
     });
   });

--- a/packages/ui-library/src/components/tables/use-pagination-navigation.ts
+++ b/packages/ui-library/src/components/tables/use-pagination-navigation.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
 import type { TableOptions } from '@/composables/defaults/table';
 import { formatInteger } from '@/utils/helpers';
 
@@ -20,6 +20,7 @@ export interface UsePaginationNavigationReturn {
   ranges: ComputedRef<PageRange[]>;
   indicatorText: ComputedRef<string>;
   currentRange: WritableComputedRef<number>;
+  useInputJump: ComputedRef<boolean>;
   hasPrev: ComputedRef<boolean>;
   hasNext: ComputedRef<boolean>;
   onPrev: () => void;
@@ -32,6 +33,7 @@ export function usePaginationNavigation(
   // eslint-disable-next-line @rotki/composable-input-flexibility
   modelValue: Ref<TablePaginationData>,
   tableDefaults: TableOptions,
+  rangesThreshold: MaybeRefOrGetter<number> = 500,
 ): UsePaginationNavigationReturn {
   const limits = computed<LimitEntry[]>(() =>
     (get(modelValue).limits ?? get(tableDefaults.limits)).map(limit => ({ limit })),
@@ -62,15 +64,26 @@ export function usePaginationNavigation(
     return `${formatInteger(start)} - ${formatInteger(end)}`;
   }
 
-  const ranges = computed<PageRange[]>(() =>
-    Array.from({ length: get(pages) }, (_, i) => {
+  const useInputJump = computed<boolean>(() => {
+    const threshold = toValue(rangesThreshold);
+    return threshold > 0 && get(pages) > threshold;
+  });
+
+  const ranges = computed<PageRange[]>(() => {
+    if (get(useInputJump))
+      return [];
+
+    return Array.from({ length: get(pages) }, (_, i) => {
       const page = i + 1;
       return { page, text: pageRangeText(page) };
-    }),
-  );
+    });
+  });
 
   const indicatorText = computed<string>(() => {
     const { total } = get(modelValue);
+    if (get(useInputJump))
+      return `of ${formatInteger(get(pages))}`;
+
     return total ? `of ${formatInteger(total)}` : `0 of 0`;
   });
 
@@ -117,6 +130,7 @@ export function usePaginationNavigation(
     ranges,
     indicatorText,
     currentRange,
+    useInputJump,
     hasPrev,
     hasNext,
     onPrev,


### PR DESCRIPTION
## Summary

- When `RuiDataTable` is fed a very large `total` (e.g. ~4M rows at `limit: 10` → ~401k pages as in #494), `usePaginationNavigation` eagerly materialised a `{ page, text }` entry for every page and handed the whole array to `RuiMenuSelect`. That stalled the main thread; opening the dropdown was effectively impossible.
- Introduce a `rangesThreshold` prop (default `500`) on `RuiTablePagination`, forwarded from `RuiDataTable`. Above the threshold `ranges` short-circuits to `[]` and the template renders a numeric "Go to page" input instead, matching the MUI / PrimeVue pattern.
- The indicator text and section label switch to page semantics in input mode ("Page N of 10,000") so the surrounding UI stays consistent.
- `rangesThreshold="0"` keeps the original dropdown regardless of size as an escape hatch.

Closes #494

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new errors)
- [x] `pnpm --filter @rotki/ui-library test:run` — 1018 unit tests pass (6 new composable tests covering threshold / input-mode / huge-total behaviour)
- [x] `pnpm --filter example exec playwright test data-table.spec.ts` — 13 pagination e2e tests pass, including:
  - swap dropdown → input when pages exceed `rangesThreshold`
  - clamp out-of-range page input to `[1, pages]`
  - keep dropdown when `rangesThreshold="0"` even for huge totals
- [x] Manual: example app now has two new sections (`table-pagination-large-total`, `table-pagination-large-total-dropdown`) using `v-model:pagination.external` with `total: 100_000` for visual verification.