### PR TITLE
fix(auto-complete): apply highlighted option on Enter when custom-value is enabled

### DIFF
--- a/apps/example/e2e/forms/autocomplete.spec.ts
+++ b/apps/example/e2e/forms/autocomplete.spec.ts
@@ -266,6 +266,26 @@ test.describe('auto-complete - search', () => {
     await expect(ac.locator('input')).toHaveValue('MyCustomEntry');
   });
 
+  test('should commit highlighted option on Enter after arrow navigation with custom-value', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-search-custom-value]');
+    const activator = ac.locator('[data-id=activator]');
+
+    await activator.click();
+    // Type a partial query that uniquely matches "Lorem".
+    await ac.locator('input').fill('Lor');
+
+    // Wait for the filtered menu to settle (internal search is debounced).
+    await expect(page.locator('div[role=menu] button')).toHaveCount(3);
+
+    // Arrow down past the prepended custom-value row to highlight the real "Lorem" option.
+    await activator.press('ArrowDown');
+    await activator.press('ArrowDown');
+    await activator.press('Enter');
+
+    // Expected: highlighted option wins over typed text.
+    await expect(ac.locator('input')).toHaveValue('Lorem');
+  });
+
   test('should hide custom value option from menu', async ({ page }) => {
     const ac = page.locator('[data-id=ac-search-custom-hide]');
     const activator = ac.locator('[data-id=activator]');

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -374,6 +374,64 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     ]]);
   });
 
+  it('should apply highlighted option instead of typed text when user arrow-navigates with custom-value enabled', async () => {
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: document.body,
+      props: {
+        customValue: true,
+        hideCustomValue: true,
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    await wrapper.find('[data-id=activator]').trigger('click');
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('input').setValue('Ger');
+    await vi.runAllTimersAsync();
+    expect(queryByRole('menu')).toBeTruthy();
+
+    // User explicitly arrow-navigates down to the real "Germany" row.
+    await wrapper.find('[data-id=activator]').trigger('keydown.down');
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('[data-id=activator]').trigger('keydown.enter');
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+    // Must emit Germany's id ('1'), NOT the typed custom text 'Ger'.
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['1']);
+  });
+
+  it('should still commit typed custom value on Enter when user has not arrow-navigated', async () => {
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: document.body,
+      props: {
+        autoSelectFirst: true,
+        customValue: true,
+        hideCustomValue: true,
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    await wrapper.find('input').setValue('Ger');
+    await vi.advanceTimersToNextTimerAsync();
+
+    // No arrow navigation — autoSelectFirst auto-highlights, but user expects
+    // their typed text to be committed as a custom value.
+    await wrapper.find('[data-id=activator]').trigger('keydown.enter');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['Ger']);
+  });
+
   it('should hide selected value when search input focused in single select', async () => {
     wrapper = createWrapper<string, SelectOption>({
       attachTo: document.body,

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -212,6 +212,7 @@ const {
   moveHighlight,
   applyHighlighted,
   optionsWithSelectedHidden,
+  userNavigated,
 } = useDropdownMenu<TValue, TItem>({
   itemHeight: resolvedItemHeight,
   keyAttr,
@@ -253,6 +254,7 @@ const {
     removeValue: (item: TItem): void => { setValue(item); },
     searchInputFocused,
     setSearchAsValue,
+    userNavigated,
     value,
   },
 );

--- a/packages/ui-library/src/composables/dropdown-menu.ts
+++ b/packages/ui-library/src/composables/dropdown-menu.ts
@@ -136,6 +136,7 @@ export function useDropdownMenu<TValue, TItem>({
   });
 
   const highlightedIndex: Ref<number> = ref(get(autoSelectFirst) ? 0 : -1);
+  const userNavigated = ref<boolean>(false);
 
   const optionWidthBounds = computed<{ min: number; max: number }>(() => {
     let min = 0;
@@ -219,6 +220,7 @@ export function useDropdownMenu<TValue, TItem>({
   watch(highlightedIndex, () => adjustScrollByHighlightedIndex());
 
   watch(options, () => {
+    set(userNavigated, false);
     if (get(highlightedIndex) !== -1) {
       if (get(autoSelectFirst)) {
         set(highlightedIndex, 0);
@@ -234,11 +236,18 @@ export function useDropdownMenu<TValue, TItem>({
     }
   });
 
+  watch(isOpen, (open) => {
+    if (!open)
+      set(userNavigated, false);
+  });
+
   const moveHighlight = (up: boolean): void => {
     if (!get(isOpen)) {
       toggle(true);
       return;
     }
+
+    set(userNavigated, true);
 
     let position = get(highlightedIndex);
     const move = up ? -1 : 1;
@@ -281,6 +290,7 @@ export function useDropdownMenu<TValue, TItem>({
     optionsWithSelectedHidden: options,
     renderedData,
     toggle,
+    userNavigated,
     valueKey,
     wrapperProps,
   };

--- a/packages/ui-library/src/composables/forms/auto-complete/keyboard-navigation.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/keyboard-navigation.ts
@@ -16,6 +16,7 @@ export interface UseAutoCompleteKeyboardNavigationDeps<TItem> {
   filteredOptions: Ref<TItem[]>;
   isOpen: Ref<boolean>;
   highlightedIndex: Ref<number>;
+  userNavigated: Ref<boolean>;
   searchInputFocused: Ref<boolean>;
   applyHighlighted: () => void;
   clear: () => void;
@@ -106,6 +107,14 @@ export function useAutoCompleteKeyboardNavigation<TItem>(
     const customValue = toValue(options.customValue);
     const multiple = toValue(options.multiple);
     const internalSearch = get(deps.internalSearch);
+
+    const userNavigated = get(deps.userNavigated);
+
+    if (userNavigated && highlightedIndex > -1 && filteredOptions.length > 0) {
+      deps.applyHighlighted();
+      event.preventDefault();
+      return true;
+    }
 
     if (customValue && internalSearch && !highlightedMatchesSearch(filteredOptions, highlightedIndex, internalSearch)) {
       applyCustomValue(event, multiple);


### PR DESCRIPTION
## Summary

- When `custom-value` is enabled and the user arrow-navigates to a filtered option, pressing Enter now commits the highlighted option instead of the typed search text.
- Tracks explicit user navigation via a new `userNavigated` flag on the dropdown menu composable, so auto-highlighted rows (e.g. `autoSelectFirst`) still preserve the existing typed-text-wins behavior.

Closes #493

## Test plan

- [x] New unit test: arrow-navigates to a real option with `custom-value` on → Enter commits the option's id
- [x] New unit test: `autoSelectFirst` without user navigation → Enter still commits the typed custom value
- [x] New e2e test: `Lor` → ArrowDown×2 → Enter → input value is `Lorem`
- [x] Full unit suite (1020 tests) passes
- [x] Full autocomplete e2e suite (46 tests) passes
- [x] `pnpm typecheck` and `pnpm lint` pass