### PR TITLE
fix(build): externalize runtime deps and guard dist output

### DIFF
--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -85,6 +85,7 @@
     "build:web-types": "tsx scripts/build-web-types.mjs",
     "generate-icons": "tsx scripts/generate-icons.mjs",
     "resolve:alias": "tsc-alias --replacer ./scripts/tsc-alias-replacer.cjs -p tsconfig.build.json --dir dist",
+    "verify:dist": "tsx scripts/verify-dist.ts",
     "dev": "vite",
     "prepare": "node scripts/prepare.mjs",
     "storybook": "storybook dev -p 6006",
@@ -103,7 +104,13 @@
   },
   "peerDependencies": {
     "dayjs": ">=1.11.13 <12",
-    "vue": ">=3.5.0"
+    "vue": ">=3.5.0",
+    "vue-router": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vue-router": {
+      "optional": true
+    }
   },
   "web-types": "dist/web-types.json",
   "dependencies": {

--- a/packages/ui-library/scripts/dist-build.mjs
+++ b/packages/ui-library/scripts/dist-build.mjs
@@ -16,4 +16,6 @@ consola.info('resolving aliases');
 execSync('pnpm run resolve:alias', { stdio: 'inherit' });
 consola.info('build web-types.json');
 execSync('pnpm run build:web-types', { stdio: 'inherit' });
+consola.info('verifying dist');
+execSync('pnpm run verify:dist', { stdio: 'inherit' });
 consola.success('build done');

--- a/packages/ui-library/scripts/verify-dist.ts
+++ b/packages/ui-library/scripts/verify-dist.ts
@@ -1,0 +1,50 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import process from 'node:process';
+
+const DIST = join(import.meta.dirname, '..', 'dist');
+
+// Any of these markers in shipped code means a runtime dependency got bundled
+// with pnpm peer-hash paths baked in, instead of being left as a bare specifier.
+// That breaks consumers whose peer resolution produces a different hash (e.g.
+// a different yaml version in the tailwindcss chain).
+const FORBIDDEN: readonly string[] = [
+  'node_modules/.pnpm/',
+  '../node_modules/.pnpm/',
+];
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory())
+      yield* walk(full);
+    else if (/\.(?:js|mjs|cjs|d\.ts)$/.test(entry.name))
+      yield full;
+  }
+}
+
+interface Offender { file: string; marker: string }
+
+const offenders: Offender[] = [];
+for await (const file of walk(DIST)) {
+  const content = await readFile(file, 'utf8');
+  for (const marker of FORBIDDEN) {
+    if (content.includes(marker)) {
+      offenders.push({ file: relative(DIST, file), marker });
+      break;
+    }
+  }
+}
+
+if (offenders.length > 0) {
+  console.error('\n❌ dist verification failed: pnpm-internal paths leaked into shipped code.\n');
+  console.error('This means a runtime dependency was bundled instead of externalized.');
+  console.error('Add it to `dependencies` (or `peerDependencies`) in package.json — the');
+  console.error('rolldown `external` function picks those up automatically.\n');
+  for (const { file, marker } of offenders)
+    console.error(`  • dist/${file}  →  contains "${marker}"`);
+  console.error('');
+  process.exit(1);
+}
+
+console.log('✓ dist verified: no pnpm-internal paths leaked.');

--- a/packages/ui-library/vite.config.ts
+++ b/packages/ui-library/vite.config.ts
@@ -1,7 +1,19 @@
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import vue from '@vitejs/plugin-vue';
 import AutoImport from 'unplugin-auto-import/vite';
 import { defineConfig } from 'vitest/config';
+
+const require = createRequire(import.meta.url);
+const pkg = require('./package.json') as {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+const declaredDeps: string[] = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
 
 export default defineConfig({
   resolve: {
@@ -35,31 +47,16 @@ export default defineConfig({
     },
     rolldownOptions: {
       external: (id: string) => {
-        // Externalize all peer dependencies and their subpaths
-        const peerDeps = [
-          'vue',
-          'vue-router',
-          'dayjs',
-        ];
-
-        // Externalize regular dependencies (installed with the library but not bundled)
-        const dependencies = [
+        // Anything declared in package.json (deps + peerDeps) is always externalized —
+        // runtime deps must be installed by the consumer and resolved from their
+        // node_modules, never bundled with pnpm peer-hash paths baked in.
+        const extraExternals = [
+          // Transitive runtime deps not listed in package.json but referenced directly
           '@floating-ui/core',
-          '@floating-ui/dom',
           '@floating-ui/utils',
-          '@vueuse/core',
-          '@vueuse/shared',
-          'scule',
-          'tinycolor2',
-        ];
-
-        // Externalize build-time only dependencies
-        const buildOnlyDeps = [
+          // Build-time only deps
           'tailwindcss',
-        ];
-
-        // Externalize Node.js built-ins (for vite-plugin)
-        const nodeBuiltins = [
+          // Node.js built-ins (for vite-plugin)
           'node:fs',
           'node:path',
           'node:url',
@@ -69,9 +66,9 @@ export default defineConfig({
           'vite',
         ];
 
-        const allExternal = [...peerDeps, ...dependencies, ...buildOnlyDeps, ...nodeBuiltins];
+        const allExternal = [...declaredDeps, ...extraExternals];
 
-        // Check if the import matches any external dependency (including subpaths like dayjs/plugin/utc)
+        // Match bare id or subpaths (e.g., dayjs/plugin/utc)
         return allExternal.some(dep => id === dep || id.startsWith(`${dep}/`));
       },
       output: {


### PR DESCRIPTION
## Summary

- `rolldown` was bundling `tailwind-variants` and `tailwind-merge`, embedding pnpm peer-hash paths (e.g. `node_modules/.pnpm/tailwind-variants@3.2.2_tailwind-merge@2.6.1_tailwindcss@3.4.19_tsx@4.21.0_yaml@2.8.2_/...`) directly into `dist/utils/tv.js`. Consumers whose peer resolution produces a different hash (different `yaml` version, different lockfile) can't resolve those paths and fail with `does not provide an export named 'createTV'`.
- Fix: derive the `external` list from `package.json` `dependencies` + `peerDependencies` so any runtime dep is always externalized. The explicit list is now only for Node built-ins, build-time-only deps (`tailwindcss`), and transitive direct references (`@floating-ui/core`, `@floating-ui/utils`).
- Declared `vue-router` as an optional peer dependency (previously hardcoded in the externals list, not in `package.json`).
- Added `verify:dist` post-build guard: scans `dist/**/*.{js,mjs,cjs,d.ts}` for `node_modules/.pnpm/` markers and fails the build if any leak. Wired into `build:prod`.

## Test plan

- [x] `pnpm run build:prod` passes with `✓ dist verified: no pnpm-internal paths leaked.`
- [x] `dist/utils/tv.js` now imports `tailwind-variants` as a bare specifier
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run test:run` — 1020/1020 tests pass
- [ ] Consumer smoke test (rotki/rotki frontend) loads without `createTV` error