### PR TITLE
fix: class-merge regressions across buttons, forms, overlays, tabs

### DIFF
--- a/packages/ui-library/src/components/accordions/accordion/RuiAccordion.vue
+++ b/packages/ui-library/src/components/accordions/accordion/RuiAccordion.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import type { VueClassValue } from '@/types/class-value';
 import Icon from '@/components/icons/RuiIcon.vue';
+import { cn, tv } from '@/utils/tv';
 
 export interface RuiAccordionClassNames {
   root?: VueClassValue;
@@ -60,14 +61,16 @@ function onKeydown(event: KeyboardEvent): void {
     toggle();
   }
 }
+
+const rootStyle = tv({ base: 'flex flex-col items-start' });
 </script>
 
 <template>
   <div
-    class="flex flex-col items-start"
+    :class="rootStyle({ class: cn(classNames?.root ?? $attrs.class) })"
     :data-state="open ? 'open' : 'closed'"
     data-accordion
-    v-bind="$attrs"
+    v-bind="{ ...$attrs, class: undefined }"
   >
     <div
       v-if="$slots.header"

--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
@@ -74,7 +74,7 @@ describe('components/buttons/button-group/RuiButtonGroup.vue', () => {
     await wrapper.setProps({ size: 'sm' });
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
-    expectWrapperToHaveClass(wrapper, 'button', /text-base/);
+    expect(wrapper.find('button').classes()).toContain('text-[1rem]');
   });
 
   it('should toggleable button group', async () => {

--- a/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
@@ -104,7 +104,7 @@ describe('components/buttons/button/RuiButton.vue', () => {
     await wrapper.setProps({ size: 'sm' });
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
-    expectWrapperToHaveClass(wrapper, 'button', /text-base/);
+    expect(wrapper.find('button').classes()).toContain('text-[1rem]');
   });
 
   it('should pass elevation props and set to correct classes based on the state', async () => {

--- a/packages/ui-library/src/components/buttons/button/RuiButton.vue
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.vue
@@ -3,6 +3,7 @@ import type { ContextColorsType } from '@/consts/colors';
 import { type ButtonSize, ButtonVariant, FAB_DEFAULT_ELEVATION, getButtonSpinnerSize, NO_ELEVATION } from '@/components/buttons/button/button-props';
 import { buttonStyles } from '@/components/buttons/button/button-styles';
 import RuiProgress from '@/components/progress/RuiProgress.vue';
+import { cn } from '@/utils/tv';
 
 export interface Props<T = undefined> {
   disabled?: boolean;
@@ -74,7 +75,7 @@ const ui = computed<ReturnType<typeof buttonStyles>>(() => buttonStyles({
   <Component
     :is="tag"
     :class="[
-      ui.root(),
+      ui.root({ class: cn($attrs.class) }),
       `shadow-${usedElevation}`,
     ]"
     :disabled="disabled || loading"
@@ -82,7 +83,7 @@ const ui = computed<ReturnType<typeof buttonStyles>>(() => buttonStyles({
     :data-variant="variant"
     :data-color="color"
     :data-active="active || undefined"
-    v-bind="$attrs"
+    v-bind="{ ...$attrs, class: undefined }"
     @click="emit('update:modelValue', btnValue)"
   >
     <slot name="prepend" />

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -65,12 +65,16 @@ export const buttonStyles = tv({
     { color: 'grey', variant: 'text', class: { root: 'text-rui-text-secondary' } },
 
     // === Context colors — outlined/text variants ===
-    { color: 'primary', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-primary-lighter/[.04] active:bg-rui-primary-lighter/10 text-rui-primary' } },
-    { color: 'secondary', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-secondary-lighter/[.04] active:bg-rui-secondary-lighter/10 text-rui-secondary' } },
-    { color: 'error', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-error-lighter/[.04] active:bg-rui-error-lighter/10 text-rui-error' } },
-    { color: 'warning', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-warning-lighter/[.04] active:bg-rui-warning-lighter/10 text-rui-warning' } },
-    { color: 'info', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-info-lighter/[.04] active:bg-rui-info-lighter/10 text-rui-info' } },
-    { color: 'success', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-success-lighter/[.04] active:bg-rui-success-lighter/10 text-rui-success' } },
+    // `dark:text-rui-<color>` is required to beat `dark:text-rui-text` set by
+    // the base color variant (meant for filled buttons where text sits on a
+    // colored bg). Without the override, outlined/text/list buttons in dark
+    // mode render white text against a themed outline/underline.
+    { color: 'primary', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-primary-lighter/[.04] active:bg-rui-primary-lighter/10 text-rui-primary dark:text-rui-primary' } },
+    { color: 'secondary', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-secondary-lighter/[.04] active:bg-rui-secondary-lighter/10 text-rui-secondary dark:text-rui-secondary' } },
+    { color: 'error', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-error-lighter/[.04] active:bg-rui-error-lighter/10 text-rui-error dark:text-rui-error' } },
+    { color: 'warning', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-warning-lighter/[.04] active:bg-rui-warning-lighter/10 text-rui-warning dark:text-rui-warning' } },
+    { color: 'info', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-info-lighter/[.04] active:bg-rui-info-lighter/10 text-rui-info dark:text-rui-info' } },
+    { color: 'success', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-rui-success-lighter/[.04] active:bg-rui-success-lighter/10 text-rui-success dark:text-rui-success' } },
 
     // === Context colors — active default ===
     { color: 'primary', active: true, class: { root: 'bg-rui-primary-darker' } },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -12,8 +12,8 @@ export const buttonStyles = tv({
       // end up as relative offsets, which misplaces FABs).
       'flex items-center justify-center gap-x-2',
       'px-6 py-2.5 rounded transition-all',
-      '!disabled:bg-black/[.12] dark:!disabled:bg-white/[.12] !disabled:text-rui-text-disabled !disabled:active:text-rui-text-disabled',
-      '!focus-visible:ring-2',
+      'disabled:!bg-black/[.12] dark:disabled:!bg-white/[.12] disabled:!text-rui-text-disabled disabled:active:!text-rui-text-disabled disabled:cursor-not-allowed',
+      'focus-visible:!ring-2',
     ].join(' '),
     label: 'inline-block text-nowrap',
     spinner: 'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
@@ -21,10 +21,10 @@ export const buttonStyles = tv({
   variants: {
     variant: {
       default: {},
-      outlined: { root: '!disabled:bg-transparent !disabled:active:bg-transparent disabled:outline-rui-text-disabled' },
-      text: { root: 'px-3 !disabled:bg-transparent !disabled:active:bg-transparent' },
+      outlined: { root: 'disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent disabled:outline-rui-text-disabled' },
+      text: { root: 'px-3 disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent' },
       fab: { root: 'rounded-full py-2' },
-      list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left !disabled:bg-transparent !disabled:active:bg-transparent', label: 'w-full' },
+      list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent', label: 'w-full' },
     },
     size: {
       sm: { root: 'px-4 py-1.5 text-[.8125rem] leading-5' },
@@ -53,7 +53,7 @@ export const buttonStyles = tv({
       true: { root: 'relative space-x-0 [&>*:not([data-spinner])]:opacity-0 [&>*:not([data-spinner])]:invisible' },
     },
     hideFocusIndicator: {
-      true: { root: '!focus-visible:ring-0' },
+      true: { root: 'focus-visible:!ring-0' },
     },
   },
   compoundVariants: [

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -12,7 +12,13 @@ export const buttonStyles = tv({
       // end up as relative offsets, which misplaces FABs).
       'flex items-center justify-center gap-x-2',
       'px-6 py-2.5 rounded transition-all',
-      'disabled:!bg-black/[.12] dark:disabled:!bg-white/[.12] disabled:!text-rui-text-disabled disabled:active:!text-rui-text-disabled disabled:cursor-not-allowed',
+      // `disabled` on the element covers two states: actually disabled and
+      // loading (RuiButton sets `disabled = disabled || loading`). The
+      // color/bg/text overrides for the "grey disabled" look live in the
+      // `loading: false` compounds below so they skip firing on loading
+      // buttons — where we want the variant color to stay visible behind
+      // the spinner. Cursor stays here since both states are non-clickable.
+      'disabled:cursor-not-allowed',
       'focus-visible:!ring-2',
     ].join(' '),
     label: 'inline-block text-nowrap',
@@ -21,10 +27,10 @@ export const buttonStyles = tv({
   variants: {
     variant: {
       default: {},
-      outlined: { root: 'disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent disabled:outline-rui-text-disabled' },
-      text: { root: 'px-3 disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent' },
+      outlined: {},
+      text: { root: 'px-3' },
       fab: { root: 'rounded-full py-2' },
-      list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent', label: 'w-full' },
+      list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left', label: 'w-full' },
     },
     size: {
       sm: { root: 'px-4 py-1.5 text-[.8125rem] leading-5' },
@@ -50,13 +56,23 @@ export const buttonStyles = tv({
       false: {},
     },
     loading: {
-      true: { root: 'relative space-x-0 [&>*:not([data-spinner])]:opacity-0 [&>*:not([data-spinner])]:invisible' },
+      true: { root: 'relative !cursor-progress space-x-0 [&>*:not([data-spinner])]:opacity-0 [&>*:not([data-spinner])]:invisible' },
+      false: {},
     },
     hideFocusIndicator: {
       true: { root: 'focus-visible:!ring-0' },
     },
   },
   compoundVariants: [
+    // === Disabled (not loading) appearance ===
+    // Applied only when `loading: false` so that loading buttons keep their
+    // variant color/outline visible behind the spinner; pure disabled buttons
+    // fade to the Material disabled palette.
+    { loading: false, class: { root: 'disabled:!bg-black/[.12] dark:disabled:!bg-white/[.12] disabled:!text-rui-text-disabled disabled:active:!text-rui-text-disabled' } },
+    { loading: false, variant: 'outlined', class: { root: 'disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent disabled:outline-rui-text-disabled' } },
+    { loading: false, variant: 'text', class: { root: 'disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent' } },
+    { loading: false, variant: 'list', class: { root: 'disabled:!bg-transparent dark:disabled:!bg-transparent disabled:active:!bg-transparent' } },
+
     // === Grey color variants ===
     { color: 'grey', active: true, class: { root: 'bg-rui-grey-50' } },
     { color: 'grey', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-black/[.04] active:bg-black/10 dark:bg-transparent dark:active:bg-white/10 dark:hover:bg-white/[.04] dark:text-rui-text' } },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -53,7 +53,7 @@ export const buttonStyles = tv({
   compoundVariants: [
     // === Grey color variants ===
     { color: 'grey', active: true, class: { root: 'bg-rui-grey-50' } },
-    { color: 'grey', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-black/[.04] active:bg-black/10 dark:active:bg-white/10 dark:hover:bg-white/[.04] dark:text-rui-text' } },
+    { color: 'grey', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-black/[.04] active:bg-black/10 dark:bg-transparent dark:active:bg-white/10 dark:hover:bg-white/[.04] dark:text-rui-text' } },
     { color: 'grey', variant: ['outlined', 'text', 'list'], active: true, class: { root: 'bg-black/10 dark:bg-white/30' } },
     { color: 'grey', variant: 'outlined', class: { root: 'outline-rui-text' } },
     { color: 'grey', variant: 'text', class: { root: 'text-rui-text-secondary' } },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -11,7 +11,7 @@ export const buttonStyles = tv({
       // utility — usually `relative` — and the consumer's `right-*`/`bottom-*`
       // end up as relative offsets, which misplaces FABs).
       'flex items-center justify-center gap-x-2',
-      'px-6 py-2.5 rounded transition-all',
+      'px-4 py-1.5 rounded transition-all',
       // `disabled` on the element covers two states: actually disabled and
       // loading (RuiButton sets `disabled = disabled || loading`). The
       // color/bg/text overrides for the "grey disabled" look live in the
@@ -28,13 +28,13 @@ export const buttonStyles = tv({
     variant: {
       default: {},
       outlined: {},
-      text: { root: 'px-3' },
+      text: { root: 'px-2' },
       fab: { root: 'rounded-full py-2' },
       list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left', label: 'w-full' },
     },
     size: {
-      sm: { root: 'px-4 py-1.5 text-[.8125rem] leading-5' },
-      lg: { root: 'px-8 py-3 text-[1rem] leading-5' },
+      sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5' },
+      lg: { root: 'px-6 py-2 text-[1rem] leading-5' },
     },
     color: {
       grey: { root: 'bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text ring-rui-grey-400 dark:bg-rui-grey-300 dark:text-rui-light-text dark:ring-rui-grey-600' },
@@ -117,8 +117,8 @@ export const buttonStyles = tv({
     { color: 'success', variant: 'outlined', class: { root: 'outline-rui-success/[0.5]' } },
 
     // === Size overrides per variant ===
-    { variant: 'text', size: 'sm', class: { root: 'px-2' } },
-    { variant: 'text', size: 'lg', class: { root: 'px-4' } },
+    { variant: 'text', size: 'sm', class: { root: 'px-1.5' } },
+    { variant: 'text', size: 'lg', class: { root: 'px-2.5' } },
     { variant: 'fab', size: 'sm', class: { root: 'py-1.5 px-2' } },
     { variant: 'fab', size: 'lg', class: { root: 'py-3' } },
     { variant: 'list', size: 'sm', class: { root: 'px-3 py-1' } },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -4,7 +4,13 @@ export const buttonStyles = tv({
   slots: {
     root: [
       'text-sm leading-5 font-medium outline outline-1 outline-transparent outline-offset-[-1px]',
-      'flex items-center justify-center gap-x-2 relative',
+      // `position: relative` is only needed as a positioning context for the
+      // absolute-positioned loading spinner; applied via the `loading` variant
+      // below. Putting it here would collide with consumers that need to pin
+      // the button with `fixed`/`absolute` (cascade order picks the later
+      // utility — usually `relative` — and the consumer's `right-*`/`bottom-*`
+      // end up as relative offsets, which misplaces FABs).
+      'flex items-center justify-center gap-x-2',
       'px-6 py-2.5 rounded transition-all',
       '!disabled:bg-black/[.12] dark:!disabled:bg-white/[.12] !disabled:text-rui-text-disabled !disabled:active:text-rui-text-disabled',
       '!focus-visible:ring-2',
@@ -44,7 +50,7 @@ export const buttonStyles = tv({
       false: {},
     },
     loading: {
-      true: { root: 'space-x-0 [&>*:not([data-spinner])]:opacity-0 [&>*:not([data-spinner])]:invisible' },
+      true: { root: 'relative space-x-0 [&>*:not([data-spinner])]:opacity-0 [&>*:not([data-spinner])]:invisible' },
     },
     hideFocusIndicator: {
       true: { root: '!focus-visible:ring-0' },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -22,7 +22,7 @@ export const buttonStyles = tv({
     },
     size: {
       sm: { root: 'px-4 py-1.5 text-[.8125rem] leading-5' },
-      lg: { root: 'px-8 py-3 text-base leading-5' },
+      lg: { root: 'px-8 py-3 text-[1rem] leading-5' },
     },
     color: {
       grey: { root: 'bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text ring-rui-grey-400 dark:bg-rui-grey-300 dark:text-rui-light-text dark:ring-rui-grey-600' },

--- a/packages/ui-library/src/components/cards/RuiCard.vue
+++ b/packages/ui-library/src/components/cards/RuiCard.vue
@@ -95,8 +95,8 @@ const ui = computed<ReturnType<typeof card>>(() => card({ variant: cardVariant, 
 
 <template>
   <div
-    :class="ui.root({ class: [`shadow-${elevation}`, cn(classNames?.root)] })"
-    v-bind="$attrs"
+    :class="ui.root({ class: [`shadow-${elevation}`, cn(classNames?.root ?? $attrs.class)] })"
+    v-bind="{ ...$attrs, class: undefined }"
   >
     <div
       v-if="slots.image"

--- a/packages/ui-library/src/components/color-picker/RuiColorBoard.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorBoard.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { clamp } from '@vueuse/shared';
 import tinycolor from 'tinycolor2';
+import { cn, tv } from '@/utils/tv';
 import { type Color, useElementDrag } from './utils';
 
 defineOptions({
@@ -81,6 +82,8 @@ watch(
 onMounted(() => {
   updatePosition();
 });
+
+const rootStyle = tv({ base: 'relative w-full h-40 overflow-hidden cursor-pointer' });
 </script>
 
 <template>
@@ -90,8 +93,8 @@ onMounted(() => {
     aria-label="Color saturation and brightness"
     :aria-valuetext="`Saturation ${Math.round(state.saturation * 100)}%, Brightness ${Math.round(state.brightness * 100)}%`"
     data-id="color-board"
-    class="relative w-full h-40 overflow-hidden cursor-pointer"
-    v-bind="$attrs"
+    :class="rootStyle({ class: cn($attrs.class) })"
+    v-bind="{ ...$attrs, class: undefined }"
     :style="{ backgroundColor: state.hexString }"
     @click="handleClick($event)"
     @mousedown="onMouseDown($event)"

--- a/packages/ui-library/src/components/color-picker/RuiColorHue.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorHue.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { clamp } from '@vueuse/shared';
+import { cn, tv } from '@/utils/tv';
 import { roundTwoDecimal, useElementDrag } from './utils';
 
 interface Limit {
@@ -76,6 +77,8 @@ watch(modelValue, () => {
 onMounted(() => {
   updatePosition();
 });
+
+const rootStyle = tv({ base: 'relative w-full h-3.5 rounded-full cursor-pointer bg-hue-spectrum' });
 </script>
 
 <template>
@@ -87,8 +90,8 @@ onMounted(() => {
     aria-valuemin="0"
     aria-valuemax="360"
     data-id="color-hue"
-    class="relative w-full h-3.5 rounded-full cursor-pointer bg-hue-spectrum"
-    v-bind="$attrs"
+    :class="rootStyle({ class: cn($attrs.class) })"
+    v-bind="{ ...$attrs, class: undefined }"
     @click="handleClick($event)"
     @mousedown="onMouseDown($event)"
     @touchstart="onTouchStart($event)"

--- a/packages/ui-library/src/components/color-picker/RuiColorPicker.vue
+++ b/packages/ui-library/src/components/color-picker/RuiColorPicker.vue
@@ -4,6 +4,7 @@ import RuiColorBoard from '@/components/color-picker/RuiColorBoard.vue';
 import RuiColorDisplay from '@/components/color-picker/RuiColorDisplay.vue';
 import RuiColorHue from '@/components/color-picker/RuiColorHue.vue';
 import RuiColorInput from '@/components/color-picker/RuiColorInput.vue';
+import { cn, tv } from '@/utils/tv';
 import { Color } from './utils';
 
 defineOptions({
@@ -43,6 +44,8 @@ watch(
   },
   { immediate: true },
 );
+
+const rootStyle = tv({ base: 'relative select-none bg-initial' });
 </script>
 
 <template>
@@ -50,8 +53,8 @@ watch(
     role="application"
     aria-label="Color picker"
     data-id="color-picker"
-    class="relative select-none bg-initial"
-    v-bind="$attrs"
+    :class="rootStyle({ class: cn($attrs.class) })"
+    v-bind="{ ...$attrs, class: undefined }"
   >
     <RuiColorBoard
       :color="state.color"

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -11,6 +11,7 @@ import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
 import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
+import { cn } from '@/utils/tv';
 
 type DateFormat = 'year-first' | 'month-first' | 'day-first';
 
@@ -288,8 +289,8 @@ function arrowClicked(event: MouseEvent): void {
 <template>
   <RuiMenu
     v-model="isOpen"
-    v-bind="getRootAttrs($attrs)"
-    :class="ui.wrapper()"
+    v-bind="getRootAttrs($attrs, [])"
+    :class="ui.wrapper({ class: cn($attrs.class) })"
     placement="bottom-start"
     :dense="dense"
     :hint="hint"

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -446,8 +446,8 @@ defineExpose({
 <template>
   <RuiMenu
     v-model="isOpen"
-    v-bind="{ ...getRootAttrs($attrs), ...menuOptions }"
-    :class="ui.wrapper()"
+    v-bind="{ ...getRootAttrs($attrs, []), ...menuOptions }"
+    :class="ui.wrapper({ class: cn($attrs.class) })"
     placement="bottom-start"
     :close-on-content-click="false"
     :full-width="true"

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -129,7 +129,7 @@ const slots = defineSlots<{
   }) => any;
   'activator.label'?: (props: { value: TItem[] }) => any;
   'selection.prepend'?: (props: { index: number; item: TItem }) => any;
-  'selection'?: (props: { index: number; item: TItem; chipAttrs?: Record<string, unknown> }) => any;
+  'selection'?: (props: { index: number; item: TItem; chipAttrs: Record<string, unknown> }) => any;
   'item.prepend'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
   'item'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
   'item.append'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
@@ -543,7 +543,7 @@ defineExpose({
                   <slot
                     :index="i"
                     name="selection"
-                    v-bind="{ item }"
+                    v-bind="{ item, chipAttrs: chipAttrs(item, i) }"
                   >
                     {{ getText(item) }}
                   </slot>

--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
@@ -186,8 +186,8 @@ function clear(): void {
 <template>
   <RuiMenu
     v-model="isOpen"
-    v-bind="{ ...getRootAttrs($attrs), ...menuOptions }"
-    :class="ui.wrapper()"
+    v-bind="{ ...getRootAttrs($attrs, []), ...menuOptions }"
+    :class="ui.wrapper({ class: cn($attrs.class) })"
     placement="bottom-start"
     :close-on-content-click="true"
     :full-width="true"

--- a/packages/ui-library/src/components/forms/text-area/text-area-styles.ts
+++ b/packages/ui-library/src/components/forms/text-area/text-area-styles.ts
@@ -25,7 +25,7 @@ export const textAreaStyles = tv({
     ].join(' '),
     textareaSizer: 'invisible absolute top-0 left-0 w-full h-0 -z-10 pointer-events-none',
     label: [
-      'left-0 text-base pointer-events-none',
+      'left-0 text-[1rem] pointer-events-none',
       'absolute top-0 h-full w-full select-none',
       '[padding-left:calc(var(--x-padding,0px)+var(--prepend-w,0px))]',
       '[padding-right:calc(var(--x-padding,0px)+var(--append-w,0px))]',
@@ -93,7 +93,7 @@ export const textAreaStyles = tv({
     active: {
       true: {
         label: [
-          'text-xs leading-tight',
+          'text-[0.75rem] leading-tight',
           '[padding-left:var(--x-padding,0px)]',
           '[padding-right:var(--x-padding,0px)]',
         ].join(' '),

--- a/packages/ui-library/src/components/forms/text-field/text-field-styles.ts
+++ b/packages/ui-library/src/components/forms/text-field/text-field-styles.ts
@@ -27,13 +27,17 @@ export const textFieldStyles = tv({
     ].join(' '),
     // No border-b or display here — each variant sets its own
     label: [
-      'left-0 text-base pointer-events-none',
+      // Use arbitrary `text-[1rem]` instead of `text-base` — the named class
+      // bundles `line-height: 1.5rem`, and the consumer's later-loaded
+      // `.text-base` rule would override our `leading-*` per variant. The
+      // arbitrary form emits font-size only, so `leading-*` stays authoritative.
+      'left-0 text-[1rem] pointer-events-none',
       'absolute top-0 h-full w-full select-none',
       // Dynamic padding via CSS variables
       '[padding-left:calc(var(--x-padding,0px)+var(--prepend-w,0px))]',
       '[padding-right:calc(var(--x-padding,0px)+var(--append-w,0px))]',
       // CSS-only autofill fallback (before JS catches up)
-      'peer-autofill:text-xs peer-autofill:leading-tight',
+      'peer-autofill:text-[0.75rem] peer-autofill:leading-tight',
     ].join(' '),
     labelText: 'truncate transition-all duration-75',
     inputWrapper: 'flex flex-1 overflow-hidden',
@@ -86,7 +90,7 @@ export const textFieldStyles = tv({
     active: {
       true: {
         label: [
-          'text-xs leading-tight',
+          'text-[0.75rem] leading-tight',
           '[padding-left:var(--x-padding,0px)]',
           '[padding-right:var(--x-padding,0px)]',
         ].join(' '),

--- a/packages/ui-library/src/components/forms/text-input-styles.ts
+++ b/packages/ui-library/src/components/forms/text-input-styles.ts
@@ -122,12 +122,14 @@ export const activatorStyles = tv({
     // Re-declare base slots for type inference
     fieldset: '',
     legend: '',
-    // Block-level `flex` (not inline-flex w-full) so a consumer-provided width
-    // class like `w-[20rem]` overrides the default fill-parent behavior. With
-    // `inline-flex w-full` the library's `w-full` conflicts with the consumer's
-    // width utility on the same element; cascade order decides the winner and
-    // the consumer class silently loses.
-    wrapper: 'flex flex-col',
+    // `w-full inline-flex flex-col` so the activator fills its parent
+    // regardless of context (block, flex-row, grid). A consumer-passed
+    // width utility like `w-[20rem]` would normally collide with `w-full`
+    // on the same element and lose to cascade order; RuiAutoComplete /
+    // RuiMenuSelect / RuiDateTimePicker route consumer classes through
+    // `ui.wrapper({ class })` so tailwind-variants' twMerge deduplicates
+    // and the consumer's width wins.
+    wrapper: 'w-full inline-flex flex-col',
     activator: [
       'group relative inline-flex items-center w-full',
       'outline-none focus:outline-none focus-within:outline-none cursor-pointer',

--- a/packages/ui-library/src/components/forms/text-input-styles.ts
+++ b/packages/ui-library/src/components/forms/text-input-styles.ts
@@ -46,7 +46,7 @@ export const textInputBase = tv({
       'border border-black/[0.23]',
       'dark:border-white/[0.23]',
     ].join(' '),
-    legend: 'invisible text-xs truncate [max-width:calc(100%-1rem)] leading-[0]',
+    legend: 'invisible text-[0.75rem] truncate [max-width:calc(100%-1rem)] leading-[0]',
   },
   variants: {
     focused: {
@@ -182,7 +182,7 @@ export const activatorStyles = tv({
     },
     float: {
       true: {
-        label: '-translate-y-2 top-0 text-xs px-1',
+        label: '-translate-y-2 top-0 text-[0.75rem] leading-4',
       },
     },
     opened: {

--- a/packages/ui-library/src/components/forms/text-input-styles.ts
+++ b/packages/ui-library/src/components/forms/text-input-styles.ts
@@ -122,7 +122,12 @@ export const activatorStyles = tv({
     // Re-declare base slots for type inference
     fieldset: '',
     legend: '',
-    wrapper: 'w-full inline-flex flex-col',
+    // Block-level `flex` (not inline-flex w-full) so a consumer-provided width
+    // class like `w-[20rem]` overrides the default fill-parent behavior. With
+    // `inline-flex w-full` the library's `w-full` conflicts with the consumer's
+    // width utility on the same element; cascade order decides the winner and
+    // the consumer class silently loses.
+    wrapper: 'flex flex-col',
     activator: [
       'group relative inline-flex items-center w-full',
       'outline-none focus:outline-none focus-within:outline-none cursor-pointer',

--- a/packages/ui-library/src/components/loaders/RuiSkeletonLoader.vue
+++ b/packages/ui-library/src/components/loaders/RuiSkeletonLoader.vue
@@ -3,7 +3,7 @@ import RuiSkeletonBase, {
   type Props as SkeletonBaseProps,
 } from '@/components/loaders/RuiSkeletonBase.vue';
 import { SkeletonType } from '@/components/loaders/skeleton-type';
-import { tv } from '@/utils/tv';
+import { cn, tv } from '@/utils/tv';
 
 export interface Props extends SkeletonBaseProps {
   type?: SkeletonType;
@@ -34,7 +34,8 @@ const skeletonType = tv({
   },
 });
 
-const ui = computed<string>(() => skeletonType({ type }));
+const attrs = useAttrs();
+const ui = computed<string>(() => skeletonType({ type, class: cn(attrs.class) }));
 const isMultiLine = computed<boolean>(() => multiLineTypes.includes(type));
 </script>
 
@@ -43,12 +44,12 @@ const isMultiLine = computed<boolean>(() => multiLineTypes.includes(type));
     v-if="!isMultiLine"
     :class="ui"
     :rounded="rounded"
-    v-bind="$attrs"
+    v-bind="{ ...attrs, class: undefined }"
   />
   <div
     v-else
     :class="ui"
-    v-bind="$attrs"
+    v-bind="{ ...attrs, class: undefined }"
   >
     <RuiSkeletonBase
       v-if="type === SkeletonType.ARTICLE"

--- a/packages/ui-library/src/components/overlays/badge/RuiBadge.vue
+++ b/packages/ui-library/src/components/overlays/badge/RuiBadge.vue
@@ -49,7 +49,7 @@ const badgeStyles = tv({
   slots: {
     wrapper: 'relative inline-block',
     badge: 'flex items-center justify-center text-xs font-medium absolute bg-transparent text-rui-light-text dark:text-rui-text',
-    content: 'flex items-center px-1',
+    content: 'flex items-center px-1.5',
   },
   variants: {
     color: {
@@ -159,7 +159,7 @@ const positionStyle = computed<Record<string, string>>(() => {
       >
         <span
           v-if="!dot"
-          :class="ui.content({ class: hasIconAndText ? 'px-2' : undefined })"
+          :class="ui.content({ class: hasIconAndText ? 'px-2.5' : undefined })"
         >
           <slot name="badge">
             {{ text }}

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
@@ -136,29 +136,33 @@ const ui = computed<ReturnType<typeof menuStyles>>(() => menuStyles({
   dense,
 }));
 
+// NOTE: both computed functions must return the *same* object shape from
+// every branch — otherwise vue-tsc infers the slot's `attrs` type as a
+// discriminated union where each key is either "all defined" or "all
+// undefined", which breaks consumer code that types its own `attrs`
+// handler with individually-optional keys.
 const baseMenuAttrs = computed<BaseMenuAttrs>(() => {
-  if (disabled)
-    return {};
-
   const clickVal = get(click);
   return {
-    onMouseover: () => {
-      if (openOnHover)
-        onOpen();
-    },
-    onMouseleave: () => {
-      if (openOnHover && !clickVal)
-        onClose();
-    },
-  } satisfies BaseMenuAttrs;
+    onMouseover: disabled
+      ? undefined
+      : () => {
+          if (openOnHover)
+            onOpen();
+        },
+    onMouseleave: disabled
+      ? undefined
+      : () => {
+          if (openOnHover && !clickVal)
+            onClose();
+        },
+  };
 });
 
-const menuAttrs = computed<MenuAttrs>(() => {
-  if (disabled)
-    return {};
-
-  return { ...get(baseMenuAttrs), onClick: checkClick };
-});
+const menuAttrs = computed<MenuAttrs>(() => ({
+  ...get(baseMenuAttrs),
+  onClick: disabled ? undefined : checkClick,
+}));
 
 function focusOnContent() {
   const content = get(menuContent);

--- a/packages/ui-library/src/components/overlays/notification/RuiNotification.vue
+++ b/packages/ui-library/src/components/overlays/notification/RuiNotification.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { useTimeoutFn } from '@vueuse/core';
 import { transformPropsUnit } from '@/utils/helpers';
+import { cn, tv } from '@/utils/tv';
 
 export interface NotificationProps {
   timeout: number;
@@ -24,6 +25,8 @@ defineSlots<{
 const style = computed<{ width: string | undefined }>(() => ({
   width: transformPropsUnit(width),
 }));
+
+const rootStyle = tv({ base: 'top-2 right-2 fixed drop-shadow-lg rounded-sm z-50' });
 
 const { start, stop } = useTimeoutFn(() => {
   set(modelValue, false);
@@ -63,14 +66,13 @@ watchImmediate(modelValue, (display) => {
         v-if="modelValue"
         role="alert"
         aria-live="polite"
-        class="top-2 right-2 fixed drop-shadow-lg rounded-sm z-50"
-        :class="{
+        :class="rootStyle({ class: cn([$attrs.class, {
           'bg-white dark:bg-[#363636]': !theme,
           'bg-white text-rui-light-text': theme === 'light',
           'bg-[#363636] text-rui-dark-text': theme === 'dark',
-        }"
+        }]) })"
         :style="style"
-        v-bind="$attrs"
+        v-bind="{ ...$attrs, class: undefined }"
         @click="dismiss()"
       >
         <slot />

--- a/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.vue
+++ b/packages/ui-library/src/components/overlays/tooltip/RuiTooltip.vue
@@ -2,6 +2,7 @@
 import type { VueClassValue } from '@/types/class-value';
 import { type FloatingOptions, useFloating } from '@/composables/floating';
 import { type PopperOptions, toFloatingOptions } from '@/composables/popper';
+import { cn, tv } from '@/utils/tv';
 import { tooltipStyles } from './tooltip-styles';
 
 export interface RuiTooltipClassNames {
@@ -26,6 +27,7 @@ export interface Props {
 
 defineOptions({
   name: 'RuiTooltip',
+  inheritAttrs: false,
 });
 
 const {
@@ -45,6 +47,8 @@ defineSlots<{
   activator?: (props: { open: boolean; close: () => void }) => any;
   default?: () => any;
 }>();
+
+const rootStyle = tv({ base: 'relative inline-flex' });
 
 const tooltipId = useId();
 
@@ -87,7 +91,8 @@ defineExpose({
 <template>
   <div
     ref="activator"
-    class="relative inline-flex"
+    v-bind="{ ...$attrs, class: undefined }"
+    :class="rootStyle({ class: cn($attrs.class) })"
     :data-tooltip-disabled="disabled"
     :aria-describedby="!disabled && open ? tooltipId : undefined"
     @mouseover="onOpen()"

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -198,11 +198,9 @@ const { stick } = useStickyTableHeader(
   { table, tableScroller },
 );
 
-const hasExpandedItemSlot = computed<boolean>(() => !!slots['expanded-item']);
-
 const { expandable, isExpanded, onToggleExpand } = useTableExpansion<T, IdType>(
   { rowAttr, singleExpand },
-  { expanded, hasExpandedItemSlot },
+  { expanded },
 );
 
 function emitUpdateOptions(opts: { sort?: TableSortData<T>; pagination?: TablePaginationData }): void {
@@ -556,7 +554,7 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
               </tr>
 
               <tr
-                v-if="expandable && isExpanded(row[rowAttr])"
+                v-if="expandable && !!$slots['expanded-item'] && isExpanded(row[rowAttr])"
                 :key="`row-expand-${index}`"
                 :class="ui.tr({ rowVariant: 'expandable' })"
                 data-id="row-expanded"

--- a/packages/ui-library/src/components/tables/RuiTableHead.vue
+++ b/packages/ui-library/src/components/tables/RuiTableHead.vue
@@ -115,7 +115,7 @@ const tableHeadStyles = tv({
     thead: 'divide-y divide-black/[0.12] dark:divide-white/[0.12]',
     checkbox: 'px-2 w-[3.625rem] max-w-[3.625rem] [&_label]:ml-0',
     th: 'p-4',
-    columnText: 'text-rui-text dark:text-white font-medium text-sm leading-6',
+    columnText: 'text-rui-text dark:text-white font-medium text-[0.875rem] leading-6',
     sortButton: 'inline-flex group/sort',
     sortIcon: 'transition opacity-0 rotate-180 group-hover/sort:opacity-60',
     loaderRow: 'border-none',

--- a/packages/ui-library/src/components/tabs/tab-items/RuiTabItems.vue
+++ b/packages/ui-library/src/components/tabs/tab-items/RuiTabItems.vue
@@ -6,7 +6,14 @@ defineOptions({
   inheritAttrs: false,
 });
 
-const modelValue = defineModel<T>();
+// Default matches RuiTabs' `defineModel<... >({ default: 0 })`. Without a
+// default, consumers that bind both components to the same ref (e.g.
+// `v-model="item.modelValue"` on both RuiTabs and RuiTabItems, where the
+// ref starts as `undefined`) leave RuiTabItems with `modelValue === undefined`.
+// The `active = modelValue === value` check then fails for every tab — the
+// panel renders but stays height:0, so e2e `toHaveText` and `toBeVisible`
+// assertions pass the element but see no content.
+const modelValue = defineModel<T>({ default: 0 as T });
 
 const slots = useSlots();
 

--- a/packages/ui-library/src/components/tabs/tab/RuiTab.vue
+++ b/packages/ui-library/src/components/tabs/tab/RuiTab.vue
@@ -69,7 +69,11 @@ const tab = tv({
   variants: {
     layout: {
       [TabLayout.horizontal]: '',
-      [TabLayout.vertical]: '!h-[3rem] w-full max-w-none',
+      // `min-h` instead of `h`: keep the 48px floor so simple text tabs
+      // match horizontal layout, but let tabs grow to fit richer content
+      // (logo + label, multi-line text) instead of clipping against the
+      // scroll container's `overflow-auto`.
+      [TabLayout.vertical]: '!min-h-[3rem] w-full max-w-none',
     },
     align: {
       start: 'justify-start text-left rtl:justify-end rtl:text-right',

--- a/packages/ui-library/src/components/tabs/tabs/RuiTabs.vue
+++ b/packages/ui-library/src/components/tabs/tabs/RuiTabs.vue
@@ -31,7 +31,11 @@ defineOptions({
   name: 'RuiTabs',
 });
 
-const modelValue = defineModel<number | string>();
+// Default 0 (first tab) matches the existing internal fallback on line 163.
+// Providing a default narrows the `update:modelValue` emit payload from
+// `value?: number | string` to `value: number | string`, so consumers can
+// type their handler signatures without undefined unions.
+const modelValue = defineModel<number | string>({ default: 0 });
 
 const {
   color,

--- a/packages/ui-library/src/composables/forms/auto-complete/keyboard-navigation.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/keyboard-navigation.ts
@@ -27,7 +27,7 @@ export interface UseAutoCompleteKeyboardNavigationDeps<TItem> {
 }
 
 export interface UseAutoCompleteKeyboardNavigationReturn {
-  focusedValueIndex: Readonly<Ref<number>>;
+  focusedValueIndex: Ref<number>;
   moveSelectedValueHighlight: (event: KeyboardEvent, next: boolean) => void;
   onEnter: (event: KeyboardEvent) => void;
   onTab: (event: KeyboardEvent) => void;
@@ -203,7 +203,8 @@ export function useAutoCompleteKeyboardNavigation<TItem>(
   });
 
   return {
-    focusedValueIndex: readonly(focusedValueIndex),
+    // eslint-disable-next-line @rotki/composable-return-readonly -- written by focus.ts onInputFocused
+    focusedValueIndex,
     moveSelectedValueHighlight,
     onEnter,
     onInputDeletePressed,

--- a/packages/ui-library/src/composables/tables/data-table/expansion.spec.ts
+++ b/packages/ui-library/src/composables/tables/data-table/expansion.spec.ts
@@ -32,29 +32,20 @@ describe('composables/tables/data-table/expansion', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: false },
-        { expanded: ref(undefined), hasExpandedItemSlot: ref(true) },
+        { expanded: ref(undefined) },
       ),
     );
     unmount = u;
     expect(get(result.expandable)).toBe(false);
   });
 
-  it('should return expandable as false when no expanded-item slot', () => {
+  it('should return expandable as true when expanded is a defined array', () => {
+    // Slot presence is no longer checked here — the template does
+    // `!!$slots['expanded-item']` inline so conditional slots stay reactive.
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: false },
-        { expanded: ref([]), hasExpandedItemSlot: ref(false) },
-      ),
-    );
-    unmount = u;
-    expect(get(result.expandable)).toBe(false);
-  });
-
-  it('should return expandable as true when both expanded and slot exist', () => {
-    const { result, unmount: u } = withSetup(() =>
-      useTableExpansion<TestItem, 'id'>(
-        { rowAttr: 'id', singleExpand: false },
-        { expanded: ref([]), hasExpandedItemSlot: ref(true) },
+        { expanded: ref([]) },
       ),
     );
     unmount = u;
@@ -66,7 +57,7 @@ describe('composables/tables/data-table/expansion', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: false },
-        { expanded, hasExpandedItemSlot: ref(true) },
+        { expanded },
       ),
     );
     unmount = u;
@@ -86,7 +77,7 @@ describe('composables/tables/data-table/expansion', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: true },
-        { expanded, hasExpandedItemSlot: ref(true) },
+        { expanded },
       ),
     );
     unmount = u;
@@ -107,7 +98,7 @@ describe('composables/tables/data-table/expansion', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: false },
-        { expanded: expanded as any, hasExpandedItemSlot: ref(true) },
+        { expanded: expanded as any },
       ),
     );
     unmount = u;
@@ -121,7 +112,7 @@ describe('composables/tables/data-table/expansion', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: true },
-        { expanded, hasExpandedItemSlot: ref(true) },
+        { expanded },
       ),
     );
     unmount = u;
@@ -137,7 +128,7 @@ describe('composables/tables/data-table/expansion', () => {
     const { result, unmount: u } = withSetup(() =>
       useTableExpansion<TestItem, 'id'>(
         { rowAttr: 'id', singleExpand: false },
-        { expanded, hasExpandedItemSlot: ref(true) },
+        { expanded },
       ),
     );
     unmount = u;

--- a/packages/ui-library/src/composables/tables/data-table/expansion.ts
+++ b/packages/ui-library/src/composables/tables/data-table/expansion.ts
@@ -9,7 +9,6 @@ export interface UseTableExpansionOptions<T extends object, IdType extends keyof
 
 export interface UseTableExpansionDeps<T extends object> {
   expanded: Ref<T[] | undefined>;
-  hasExpandedItemSlot: Ref<boolean>;
 }
 
 export interface UseTableExpansionReturn<T extends object, IdType extends keyof T> {
@@ -23,9 +22,15 @@ export function useTableExpansion<T extends object, IdType extends keyof T>(
   deps: UseTableExpansionDeps<T>,
 ): UseTableExpansionReturn<T, IdType> {
   const { rowAttr, singleExpand } = options;
-  const { expanded, hasExpandedItemSlot } = deps;
+  const { expanded } = deps;
 
-  const expandable = computed<boolean>(() => !!get(expanded) && get(hasExpandedItemSlot));
+  // `expandable` only tracks whether the consumer has wired a two-way
+  // `expanded` model. Whether an `#expanded-item` slot is present is
+  // checked fresh in the template (`!!$slots['expanded-item']`) so that
+  // consumers which gate the slot with `v-if` (e.g. only after data
+  // loads) don't get stuck on the first-render slot snapshot — Vue's
+  // `slots` object is not reactive to property access inside a computed.
+  const expandable = computed<boolean>(() => !!get(expanded));
 
   const expandedSet = computed<Set<T[IdType]>>(() => {
     const expandedVal = get(expanded);

--- a/packages/ui-library/src/utils/tv.ts
+++ b/packages/ui-library/src/utils/tv.ts
@@ -21,6 +21,17 @@ export const tv = /* @__PURE__ */ createTV({
       'bg-shade': [{ 'bg-shade': [isAny] }],
       'text-tint': [{ 'text-tint': [isAny] }],
       'text-shade': [{ 'text-shade': [isAny] }],
+      // Custom theme colors (text-rui-*) belong to the text-color group so
+      // they don't conflict with the custom typography utilities below, which
+      // tw-merge would otherwise both classify as font-size.
+      'text-color': [{ 'text-rui': [isAny] }],
+      'font-size': [
+        { 'text-body': [isAny] },
+        'text-caption',
+        'text-overline',
+        { 'text-h': [isAny] },
+        { 'text-subtitle': [isAny] },
+      ],
     },
   },
 });

--- a/packages/ui-library/src/utils/tv.ts
+++ b/packages/ui-library/src/utils/tv.ts
@@ -10,7 +10,7 @@
 
 import type { VueClassValue } from '@/types/class-value';
 import { createTV } from 'tailwind-variants';
-import { normalizeClass } from 'vue';
+import { type ClassValue, normalizeClass } from 'vue';
 
 const isAny: (v: string) => boolean = () => true;
 
@@ -37,11 +37,13 @@ export const tv = /* @__PURE__ */ createTV({
 });
 
 /**
- * Normalizes a VueClassValue (string | object | array) to a plain string
- * compatible with tailwind-variants' class parameter.
+ * Normalizes any Vue `:class` binding value (string, object, array, nullish
+ * or `false`) to a plain string compatible with tailwind-variants' `class`
+ * parameter. Accepts Vue's runtime `ClassValue` so call sites can pass
+ * `$attrs.class` directly without casting.
  */
-export function cn(value: VueClassValue | undefined): string | undefined {
-  if (value == null)
+export function cn(value: ClassValue | VueClassValue | undefined): string | undefined {
+  if (value == null || value === false)
     return undefined;
   if (typeof value === 'string')
     return value || undefined;

--- a/packages/ui-library/src/vite-plugin/index.ts
+++ b/packages/ui-library/src/vite-plugin/index.ts
@@ -32,7 +32,7 @@ function loadValidIcons(): Set<string> {
       // Read and parse the file to extract the RuiIcons array
       const content = readFileSync(distPath, 'utf-8');
       // eslint-disable-next-line regexp/strict
-      const match = content.match(/const RuiIcons = \[(.*?)];/s);
+      const match = content.match(/(?:const|var|let) RuiIcons = \[(.*?)];?/s);
       if (match?.[1]) {
         const iconsStr = match[1];
         const icons = iconsStr.match(/"([^"]+)"/g)?.map(s => s.slice(1, -1)) || [];


### PR DESCRIPTION
## Summary

Tightens up a family of regressions that appeared after the tv() / inline-Tailwind refactor and the MD3 spacing alignment. They share one root cause: **library classes and consumer classes landed on the same element without `tw-merge`**, so CSS cascade order (not the `className` string) decided which utility won — and the consumer usually lost. This PR fixes each instance where that bit us, plus a couple of orthogonal dark-mode / padding issues noticed along the way.

### Class-merge fixes (tv's `twMerge` now dedupes)
- `RuiButton` — consumer `justify-start` lost to base `justify-center`; `fixed bottom-4 right-4` FAB lost to base `relative`
- `RuiAutoComplete` / `RuiMenuSelect` / `RuiDateTimePicker` — consumer `w-[20rem]` lost to wrapper `w-full`; wrapper also stayed fill-parent by default
- `RuiTooltip` — consumer `block flex-1 max-w-full` lost to base `inline-flex`, collapsing rotki's TableFilter
- `RuiNotification` — consumer `top-[3.5rem]` lost to base `top-2`, floating the popup under the app header
- `RuiCard` — consumer `h-auto` lost to base `h-full w-full`
- `RuiSkeletonLoader` — consumer `w-48` lost to variant `w-full`
- `RuiAccordion` — consumer `flex-*` / `items-*` lost to base `flex flex-col items-start`
- `RuiColorPicker` / `RuiColorBoard` / `RuiColorHue` — consumer sizing lost to hardcoded `w-full h-*`

### Button state fixes
- Disabled bg/text/cursor finally render: `!disabled:*` modifier-important syntax never generated CSS; swapped to `disabled:!*`
- Outlined/text label color in dark mode: `dark:text-rui-text` from color variant was overriding the outlined `text-rui-<color>`; added `dark:text-rui-<color>` per compound
- Loading keeps variant colors: moved the disabled fade into `{ loading: false, ... }` compounds so loading buttons no longer greyscale the spinner background
- `cursor-progress` during loading, `cursor-not-allowed` when truly disabled

### Other
- `RuiTab` vertical layout: `!h-[3rem]` → `!min-h-[3rem]` so tabs with logo+label (rotki's Kraken exchange tab) stop clipping the logo
- Button padding: reverted `px-6 py-2.5` / `px-8 py-3` / `px-4 py-1.5` to v2.12.2's tighter `px-4 py-1.5` / `px-6 py-2` / `px-2.5 py-1` — MD3 alignment broke existing rotki layouts
- `RuiBadge` content padding: `px-1` → `px-1.5` (and `px-2` → `px-2.5` with icon+text)
- `cn()` signature widened to Vue's runtime `ClassValue` so callers can pass `$attrs.class` without casting

## Test plan
- [ ] Unit tests pass
- [ ] Typecheck passes
- [ ] Verified in rotki: EVM accounts filter inputs respect `w-[20rem]` / `w-[25rem]`
- [ ] Verified in rotki: ETH staking location select fills its card row
- [ ] Verified in rotki: Kraken vertical tab shows full logo + label
- [ ] Verified in rotki: managed-assets TableFilter no longer collapses
- [ ] Verified in rotki: notification popup lands below the 56px header
- [ ] Verified in rotki: scroll-to-top FAB sits bottom-right
- [ ] Verified in Storybook: outlined buttons in dark mode (loading / disabled / idle) all correct