### PR TITLE
feat(button): add xl size (40px)

### DIFF
--- a/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
@@ -105,6 +105,10 @@ describe('components/buttons/button/RuiButton.vue', () => {
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
     expect(wrapper.find('button').classes()).toContain('text-[1rem]');
+    await wrapper.setProps({ size: 'xl' });
+    expect(wrapper.find('button').classes()).toContain('text-[1rem]');
+    expectWrapperToHaveClass(wrapper, 'button', /py-2\.5/);
+    expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
   });
 
   it('should pass elevation props and set to correct classes based on the state', async () => {

--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -32,7 +32,7 @@ const meta = preview.meta({
     label: { control: 'text' },
     loading: { control: 'boolean', table: { category: 'State' } },
     rounded: { control: 'boolean', table: { category: 'Shape' } },
-    size: { control: 'select', options: ['medium', 'sm', 'lg'] },
+    size: { control: 'select', options: ['medium', 'sm', 'lg', 'xl'] },
     type: { control: 'select', options: ['button', 'submit'] },
     variant: {
       control: 'select',
@@ -106,6 +106,14 @@ export const PrimaryLarge = meta.story({
     color: 'primary',
     label: 'Large',
     size: 'lg',
+  },
+});
+
+export const PrimaryExtraLarge = meta.story({
+  args: {
+    color: 'primary',
+    label: 'Extra Large',
+    size: 'xl',
   },
 });
 

--- a/packages/ui-library/src/components/buttons/button/button-props.ts
+++ b/packages/ui-library/src/components/buttons/button/button-props.ts
@@ -11,11 +11,12 @@ export type ButtonVariant = (typeof ButtonVariant)[keyof typeof ButtonVariant];
 export const ButtonSize = {
   sm: 'sm',
   lg: 'lg',
+  xl: 'xl',
 } as const;
 
 export type ButtonSize = (typeof ButtonSize)[keyof typeof ButtonSize];
 
-const SPINNER_SIZES: Record<string, number> = { sm: 18, lg: 26 };
+const SPINNER_SIZES: Record<string, number> = { sm: 18, lg: 26, xl: 28 };
 const DEFAULT_SPINNER_SIZE = 22;
 
 export const FAB_DEFAULT_ELEVATION = 6;

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -35,6 +35,7 @@ export const buttonStyles = tv({
     size: {
       sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5' },
       lg: { root: 'px-6 py-2 text-[1rem] leading-5' },
+      xl: { root: 'px-6 py-2.5 text-[1rem] leading-6' },
     },
     color: {
       grey: { root: 'bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text ring-rui-grey-400 dark:bg-rui-grey-300 dark:text-rui-light-text dark:ring-rui-grey-600' },


### PR DESCRIPTION
## Summary
- Adds an `xl` size variant to `RuiButton` (40px tall: 20px text + 20px padding, `px-6 py-2.5 text-base leading-6`).
- Extends `ButtonSize` enum and the spinner size map (`xl → 28`).
- New `PrimaryExtraLarge` story and `size="xl"` assertion in the spec.

## Why
Consumers currently hack 40px-tall buttons with `class="!h-10"` (e.g. rotki/rotki toolbars). An explicit size keeps styling in the library.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:run` — 1024 tests pass
- [x] `pnpm test:e2e` — 266 e2e tests pass
- [x] `pnpm build`