### PR TITLE
feat(button-group): let child size override group size

### DIFF
--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
@@ -1,5 +1,6 @@
 import { type ComponentMountingOptions, mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
+import { h } from 'vue';
 import RuiButtonGroup from '@/components/buttons/button-group/RuiButtonGroup.vue';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import {
@@ -75,6 +76,28 @@ describe('components/buttons/button-group/RuiButtonGroup.vue', () => {
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
     expect(wrapper.find('button').classes()).toContain('text-[1rem]');
+    await wrapper.setProps({ size: 'xl' });
+    expectWrapperToHaveClass(wrapper, 'button', /py-2\.5/);
+    expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
+  });
+
+  it('should let child size override group size', () => {
+    // Group is lg but the first child explicitly sets sm; sm should win for that child only.
+    const wrapperWithOverride = mount(RuiButtonGroup, {
+      props: { size: 'lg' },
+      slots: {
+        default: [
+          h(RuiButton, { size: 'sm' }, () => 'sm'),
+          h(RuiButton, () => 'default'),
+        ],
+      },
+    });
+    const buttons = wrapperWithOverride.findAll('button');
+    // First button keeps sm
+    expect(buttons[0]!.classes()).toContain('py-1');
+    // Second button inherits group size lg
+    expect(buttons[1]!.classes()).toContain('text-[1rem]');
+    wrapperWithOverride.unmount();
   });
 
   it('should toggleable button group', async () => {

--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.stories.ts
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.stories.ts
@@ -50,7 +50,7 @@ const meta = preview.meta({
     activeColor: { control: 'select', options: contextColors },
     color: { control: 'select', options: contextColors },
     gap: { control: 'select', options: ['md', 'sm', 'lg'] },
-    size: { control: 'select', options: ['md', 'sm', 'lg'] },
+    size: { control: 'select', options: ['md', 'sm', 'lg', 'xl'] },
     variant: {
       control: 'select',
       options: ['default', 'outlined', 'text'],
@@ -89,6 +89,24 @@ export const Primary = meta.story({
 export const SmallGap = meta.story({
   args: {
     gap: 'sm',
+  },
+});
+
+export const Small = meta.story({
+  args: {
+    size: 'sm',
+  },
+});
+
+export const Large = meta.story({
+  args: {
+    size: 'lg',
+  },
+});
+
+export const ExtraLarge = meta.story({
+  args: {
+    size: 'xl',
   },
 });
 

--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.vue
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts" generic="T = undefined" setup>
+import type { ButtonSize } from '@/components/buttons/button/button-props';
 import type { ContextColorsType } from '@/consts/colors';
 import { Fragment, isVNode } from 'vue';
 import { tv } from '@/utils/tv';
@@ -8,7 +9,7 @@ export interface Props {
   color?: ContextColorsType;
   activeColor?: ContextColorsType;
   variant?: 'default' | 'outlined' | 'text';
-  size?: 'sm' | 'lg';
+  size?: ButtonSize;
   gap?: 'sm' | 'md' | 'lg';
   required?: boolean;
   disabled?: boolean;
@@ -134,11 +135,17 @@ const children = computed<VNode[]>(() => {
     const active = isActive(value ?? i, selectedValue);
     const resolvedColor = active && activeColor ? activeColor : color;
 
+    // Only fall back to the group's size when the child did not set one itself.
+    // This lets consumers override size per-button while still benefiting from
+    // the group-level default.
+    const childSize = child.props?.size;
+
     child.props = {
       ...child.props,
       active,
       ...(disabled && { disabled: true }),
       ...(resolvedColor && { color: resolvedColor }),
+      ...(!childSize && size && { size }),
     };
 
     return child;
@@ -199,7 +206,6 @@ function onClick(id: T): void {
       v-for="(child, i) in children"
       :key="i"
       :class="ui.button()"
-      :size="size"
       :variant="variant"
       @update:model-value="onClick($event ?? i)"
     />


### PR DESCRIPTION
## Summary
- `RuiButtonGroup` was forwarding `size` onto every child unconditionally via the template. That silently overrode any `size` prop the consumer had set on individual buttons.
- Moves the size forwarding into the `children` computed merge so the group's `size` acts as a **default**: if a button already specifies `size`, that wins; otherwise it inherits the group's.
- Types the group's `size` prop as `ButtonSize` so it picks up the new `xl` value (#500).

## Stories / tests
- Adds `Small` / `Large` / `ExtraLarge` stories.
- Extends the spec with an `xl` size assertion and a **per-child override** test (group `lg` + child `sm` → first button stays sm, second inherits lg).

## Why
Before this, a consumer couldn't mix sizes inside a group or even rely on a child's `size` at all. Opting into override also lets shared wrappers (e.g. a custom `<MyRefreshButton />` with `size="lg"`) keep their chosen size when dropped into a group without one.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:run` — 1025 tests pass
- [x] `pnpm test:e2e` — 266 e2e tests pass
- [x] `pnpm build`