### PR TITLE
feat(icon): make default size CSS-overridable

### DIFF
--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -65,15 +65,30 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.classes()).toContain('text-rui-error');
   });
 
-  it('should use default size of 24', () => {
+  it('should default to w-6/h-6 without inline size attributes', () => {
     wrapper = createWrapper({
       props: {
         name: 'lu-circle-arrow-down',
       },
     });
 
-    expect(wrapper.attributes('width')).toMatch('24');
-    expect(wrapper.attributes('height')).toMatch('24');
+    // No inline width/height lets parent CSS override the size.
+    expect(wrapper.attributes('width')).toBeUndefined();
+    expect(wrapper.attributes('height')).toBeUndefined();
+    expect(wrapper.classes()).toContain('w-6');
+    expect(wrapper.classes()).toContain('h-6');
+  });
+
+  it('should drop the default sizing class when size prop is set', () => {
+    wrapper = createWrapper({
+      props: {
+        name: 'lu-circle-arrow-down',
+        size: 32,
+      },
+    });
+
+    expect(wrapper.classes()).not.toContain('w-6');
+    expect(wrapper.classes()).not.toContain('h-6');
   });
 
   it('should render svg element', () => {

--- a/packages/ui-library/src/components/icons/RuiIcon.stories.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.stories.ts
@@ -63,4 +63,42 @@ export const PrimaryLarge = meta.story({
   },
 });
 
+export const CssSized = meta.story({
+  args: {
+    color: 'primary',
+    name: 'lu-arrow-down',
+    size: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When the `size` prop is omitted, the icon falls back to `w-6 h-6` classes. Parents can override via CSS (e.g. wrapping in `<div class="w-4 h-4">` or applying `[&_svg]:w-5` on an ancestor).',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="flex items-center gap-6">
+        <div class="flex flex-col items-center gap-1">
+          <RuiIcon v-bind="args" />
+          <span class="text-xs">default (24px)</span>
+        </div>
+        <div class="flex flex-col items-center gap-1">
+          <div class="w-4 h-4"><RuiIcon v-bind="args" class="w-full h-full" /></div>
+          <span class="text-xs">wrapper w-4 h-4</span>
+        </div>
+        <div class="flex flex-col items-center gap-1 [&_svg]:w-5 [&_svg]:h-5">
+          <RuiIcon v-bind="args" />
+          <span class="text-xs">ancestor [&_svg]:w-5</span>
+        </div>
+      </div>
+    `,
+  }),
+});
+
 export default meta;

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -14,7 +14,7 @@ defineOptions({
   name: 'RuiIcon',
 });
 
-const { name, size = 24, color } = defineProps<Props>();
+const { name, size, color } = defineProps<Props>();
 
 const { registeredIcons } = useIcons();
 
@@ -30,10 +30,18 @@ const iconStyles = tv({
       info: 'text-rui-info',
       success: 'text-rui-success',
     },
+    sized: {
+      // When no explicit size prop is set, fall back to Tailwind classes so a
+      // parent (e.g. RuiButton) can override the icon size via CSS without
+      // competing with inline width/height attributes.
+      false: 'w-6 h-6',
+      true: '',
+    },
   },
 });
 
-const ui = computed<string>(() => iconStyles({ color }));
+const hasExplicitSize = computed<boolean>(() => size !== undefined);
+const ui = computed<string>(() => iconStyles({ color, sized: get(hasExplicitSize) }));
 
 const isFill = computed<boolean>(() => name.endsWith('-fill'));
 
@@ -56,8 +64,8 @@ const components = computed<SvgComponent[] | undefined>(() => {
   <svg
     aria-hidden="true"
     :class="ui"
-    :height="size"
-    :width="size"
+    :height="hasExplicitSize ? size : undefined"
+    :width="hasExplicitSize ? size : undefined"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >


### PR DESCRIPTION
## Summary
When \`RuiIcon\` is used without an explicit \`size\` prop, it now falls back to Tailwind \`w-6 h-6\` classes (same 24px default) and drops the inline \`width\`/\`height\` attributes. This lets an ancestor override the size purely via CSS — e.g. \`<div class=\"w-4 h-4\"><RuiIcon ... /></div>\` or \`[&_svg]:w-5\` on a parent. Passing \`size\` explicitly keeps the old inline-attribute behavior unchanged.

## Why
Today consumers have to pass \`size=\"20\"\` on every \`<RuiIcon>\` inside a button to get the right ratio against the button height. This blocks a follow-up PR that will have \`RuiButton\` auto-size icons per button size variant via CSS. With inline \`width\`/\`height\` attributes, parent CSS loses the cascade fight; switching to classes when no size is set makes parent-driven sizing possible.

## Stories / tests
- New \`CssSized\` story: default, wrapper-overridden, and \`[&_svg]:w-5\` ancestor.
- Updated the default-size spec to assert classes + absence of inline attrs.
- New assertion that the sizing classes drop when \`size\` is provided.

## Backwards compat
- Calls passing \`size\` are unaffected.
- Calls without \`size\` still render at 24px — only the mechanism changed (Tailwind classes instead of inline attributes).
- Low risk: any consumer relying on the inline attribute specifically (e.g. querying \`svg[width=\"24\"]\` in tests) would need to update, but the rendered pixel size is unchanged.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:run\` — 1026 tests pass
- [x] \`pnpm test:e2e\` — 266 e2e tests pass
- [x] \`pnpm build\`