### PR TITLE
feat(button): auto-size icons inside button slots

### DIFF
--- a/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
@@ -111,6 +111,22 @@ describe('components/buttons/button/RuiButton.vue', () => {
     expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
   });
 
+  it('should scope descendant icon sizing to the button size', async () => {
+    wrapper = createWrapper();
+    // default (md) — 1.125rem icons, baked into the base root
+    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:w-[1.125rem]');
+
+    // size variants use `!` so they beat the md baseline regardless of CSS source order
+    await wrapper.setProps({ size: 'sm' });
+    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:!w-4');
+
+    await wrapper.setProps({ size: 'lg' });
+    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:!w-5');
+
+    await wrapper.setProps({ size: 'xl' });
+    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:!w-[1.375rem]');
+  });
+
   it('should pass elevation props and set to correct classes based on the state', async () => {
     wrapper = createWrapper();
     expectWrapperToHaveClass(wrapper, 'button', /shadow-0/);

--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -1,6 +1,7 @@
 import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import { expect } from 'storybook/test';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { contextColors } from '@/consts/colors';
 import preview from '~/.storybook/preview';
 
@@ -115,6 +116,47 @@ export const PrimaryExtraLarge = meta.story({
     label: 'Extra Large',
     size: 'xl',
   },
+});
+
+export const AutoSizedIcon = meta.story({
+  args: {
+    color: 'primary',
+    label: 'Refresh',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (sm → 1rem, md → 1.125rem, lg → 1.25rem, xl → 1.375rem). Passing `size` on `<RuiIcon>` still wins via inline width/height attributes.',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiButton, RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="flex items-center gap-4">
+        <RuiButton v-bind="args" size="sm">
+          <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
+          Small
+        </RuiButton>
+        <RuiButton v-bind="args">
+          <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
+          Medium
+        </RuiButton>
+        <RuiButton v-bind="args" size="lg">
+          <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
+          Large
+        </RuiButton>
+        <RuiButton v-bind="args" size="xl">
+          <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
+          Extra Large
+        </RuiButton>
+      </div>
+    `,
+  }),
 });
 
 export const PrimaryLargeRounded = meta.story({

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -12,6 +12,10 @@ export const buttonStyles = tv({
       // end up as relative offsets, which misplaces FABs).
       'flex items-center justify-center gap-x-2',
       'px-4 py-1.5 rounded transition-all',
+      // Default (md) icon sizing for RuiIcons in button slots (prepend/append
+      // /default). Size variants below override this via `!` so the rule
+      // specificity wins regardless of CSS source order.
+      '[&_.rui-icon]:w-[1.125rem] [&_.rui-icon]:h-[1.125rem]',
       // `disabled` on the element covers two states: actually disabled and
       // loading (RuiButton sets `disabled = disabled || loading`). The
       // color/bg/text overrides for the "grey disabled" look live in the
@@ -33,9 +37,18 @@ export const buttonStyles = tv({
       list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left', label: 'w-full' },
     },
     size: {
-      sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5' },
-      lg: { root: 'px-6 py-2 text-[1rem] leading-5' },
-      xl: { root: 'px-6 py-2.5 text-[1rem] leading-6' },
+      // Each size variant sets a matching descendant rule so RuiIcons in
+      // button slots (prepend/append/default) inherit a size proportional to
+      // the button's height. The `.rui-icon` class sits on the icon's <svg>
+      // and its `w-6 h-6` default (set by RuiIcon when no size prop is
+      // passed) is overridden here because the descendant selector is more
+      // specific. `!` guarantees size variants beat the md default baked
+      // into the base root regardless of CSS source order. Consumers can
+      // still force a specific icon size by passing the `size` prop on
+      // RuiIcon — that path stamps inline width/height which beats classes.
+      sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5 [&_.rui-icon]:!w-4 [&_.rui-icon]:!h-4' },
+      lg: { root: 'px-6 py-2 text-[1rem] leading-5 [&_.rui-icon]:!w-5 [&_.rui-icon]:!h-5' },
+      xl: { root: 'px-6 py-2.5 text-[1rem] leading-6 [&_.rui-icon]:!w-[1.375rem] [&_.rui-icon]:!h-[1.375rem]' },
     },
     color: {
       grey: { root: 'bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text ring-rui-grey-400 dark:bg-rui-grey-300 dark:text-rui-light-text dark:ring-rui-grey-600' },

--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -91,6 +91,16 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.classes()).not.toContain('h-6');
   });
 
+  it('should always carry the rui-icon marker class for parent-driven sizing', () => {
+    wrapper = createWrapper({
+      props: {
+        name: 'lu-circle-arrow-down',
+      },
+    });
+
+    expect(wrapper.classes()).toContain('rui-icon');
+  });
+
   it('should render svg element', () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -63,6 +63,7 @@ const components = computed<SvgComponent[] | undefined>(() => {
 <template>
   <svg
     aria-hidden="true"
+    class="rui-icon"
     :class="ui"
     :height="hasExplicitSize ? size : undefined"
     :width="hasExplicitSize ? size : undefined"


### PR DESCRIPTION
## Summary
\`RuiButton\` now scales \`<RuiIcon>\` in its prepend/append/default slots to a size proportional to the button's height via descendant CSS rules. Consumers drop per-site \`size=\"...\"\` overrides on icons inside buttons.

| Size | Icon |
|------|------|
| sm   | 1rem     (16px) |
| md (default) | 1.125rem (18px) |
| lg   | 1.25rem  (20px) |
| xl   | 1.375rem (22px) |

## How
- \`RuiIcon\` gets a stable \`rui-icon\` marker class on its \`<svg>\`.
- \`button-styles.ts\` adds \`[&_.rui-icon]:w-X [&_.rui-icon]:h-X\` per size variant.
- The md default is baked into the base root; size variants use \`!\` so they beat the baseline regardless of CSS source order.
- Only triggers when the icon has no \`size\` prop — a passed size still stamps inline \`width\`/\`height\` (via #502) which beats any class-based rule.

## Follow-ups (consumer side)
After this PR + #502 + #501 + #500 land and rotki ships them, the app can drop \`size=\"20\"\` props on icons inside buttons in favor of the auto-sizing.

## Stories / tests
- \`AutoSizedIcon\` story renders all four sizes side-by-side with unstyled \`<RuiIcon>\`.
- New \`should scope descendant icon sizing to the button size\` spec checks the correct class lands per size.
- Also adds a spec on RuiIcon asserting the \`rui-icon\` marker class is always present.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:run\` — 1028 tests pass
- [x] \`pnpm build\`
- [x] \`pnpm test:e2e\` — 266 e2e tests pass