### PR TITLE
fix(text-field): drop floating-label reserve when used without a label

### DIFF
--- a/packages/ui-library/src/components/forms/text-field/RuiTextField.spec.ts
+++ b/packages/ui-library/src/components/forms/text-field/RuiTextField.spec.ts
@@ -75,10 +75,11 @@ describe('components/forms/text-field/RuiTextField.vue', () => {
   it('should pass variant props', async () => {
     wrapper = createWrapper({
       props: {
+        label: 'Field',
         modelValue: '',
       },
     });
-    // Default variant has pt-3 on wrapper
+    // Default variant reserves pt-3 on the wrapper for the floating label.
     expectWrapperToHaveClass(wrapper, '[data-id=wrapper]', /pt-3/);
 
     await wrapper.setProps({ variant: 'filled' });
@@ -88,6 +89,35 @@ describe('components/forms/text-field/RuiTextField.vue', () => {
     await wrapper.setProps({ variant: 'outlined' });
     expectWrapperNotToHaveClass(wrapper, '[data-id=wrapper]', /pt-3/);
     expect(wrapper.find('fieldset').exists()).toBeTruthy();
+  });
+
+  it('should drop the floating-label reserve when used without a label', async () => {
+    // Default variant reserves pt-3 on the wrapper for the floating label.
+    // When there is no label the compound variant adds `!pt-0`, which
+    // overrides pt-3 via !important. This makes a dense unlabeled field line
+    // up with a dense RuiMenuSelect activator (both 32px).
+    wrapper = createWrapper({
+      props: {
+        modelValue: '',
+      },
+    });
+    expectWrapperToHaveClass(wrapper, '[data-id=wrapper]', /!pt-0/);
+
+    // Non-dense noLabel uses py-2 on the input (40px total, matches
+    // MenuSelect's non-dense min-h-10).
+    expectWrapperToHaveClass(wrapper, 'input', /py-2/);
+
+    // Dense noLabel tightens the input further to py-1 (32px total,
+    // matches MenuSelect's dense `!min-h-8`).
+    await wrapper.setProps({ dense: true });
+    expectWrapperToHaveClass(wrapper, 'input', /py-1(?!\.)/);
+    expectWrapperToHaveClass(wrapper, '[data-id=wrapper]', /!pt-0/);
+
+    // Once a label is provided the !pt-0 override is dropped so the
+    // floating-label reserve behaves as before.
+    await wrapper.setProps({ label: 'Labelled', dense: false });
+    expectWrapperNotToHaveClass(wrapper, '[data-id=wrapper]', /!pt-0/);
+    expectWrapperToHaveClass(wrapper, '[data-id=wrapper]', /pt-3/);
   });
 
   it('should pass dense props', async () => {

--- a/packages/ui-library/src/components/forms/text-field/RuiTextField.stories.ts
+++ b/packages/ui-library/src/components/forms/text-field/RuiTextField.stories.ts
@@ -199,6 +199,35 @@ export const OutlinedWithNoLabel = meta.story({
   },
 });
 
+export const DefaultWithNoLabel = meta.story({
+  args: {
+    placeholder: 'Placeholder',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When the default (underlined) variant is used without a label, the wrapper drops the `pt-3` floating-label reserve. This keeps the underline at a consistent height with other controls in the same row — for example the dense variant lines up with RuiMenuSelect dense at 32px.',
+      },
+    },
+  },
+});
+
+export const DenseWithNoLabel = meta.story({
+  args: {
+    dense: true,
+    placeholder: 'Placeholder',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dense + no label = 32px, matching `<RuiMenuSelect dense>`. Useful for inline controls such as table pagination where a text field sits next to a select.',
+      },
+    },
+  },
+});
+
 export const OutlinedWithVeryLongLabel = meta.story({
   args: {
     label:

--- a/packages/ui-library/src/components/forms/text-field/text-field-styles.ts
+++ b/packages/ui-library/src/components/forms/text-field/text-field-styles.ts
@@ -125,6 +125,14 @@ export const textFieldStyles = tv({
     // --- Default variant ---
     { variant: 'default', focused: true, class: { label: 'after:scale-x-100' } },
     { variant: 'default', dense: true, class: { input: 'py-1', label: 'leading-[3.5]' } },
+    // Without a label, the wrapper's `pt-3` floating-label reserve serves no
+    // purpose and leaves the field ~4–12px taller than an equivalent
+    // RuiMenuSelect dense activator. Strip it and tighten the input padding
+    // so the underline sits at a matching baseline (40px non-dense, 32px
+    // dense) — these match min-h-10 and !min-h-8 of the menu-select
+    // activator.
+    { variant: 'default', noLabel: true, class: { wrapper: '!pt-0', input: 'py-2' } },
+    { variant: 'default', noLabel: true, dense: true, class: { input: 'py-1' } },
 
     // --- Filled variant ---
     { variant: 'filled', focused: true, class: { label: 'bg-black/[0.09] dark:bg-white/[0.13]' } },


### PR DESCRIPTION
## Summary
The default (underlined) variant always reserves \`pt-3\` on the wrapper for the floating label. When no label is passed, that reserve still applies, leaving a **dense** unlabeled \`RuiTextField\` at 36px while a **dense** \`RuiMenuSelect\` activator renders at 32px. Rows that mix both (e.g. \`RuiTablePagination\`) end up with visibly mismatched underlines.

Adds two compound variants under \`variant: 'default'\`:

| noLabel | dense | Resulting height |
|---------|-------|------------------|
| ✅      | ❌    | **40px** — wrapper \`!pt-0\`, input \`py-2\` (matches MenuSelect \`min-h-10\`) |
| ✅      | ✅    | **32px** — wrapper \`!pt-0\`, input \`py-1\` (matches MenuSelect \`!min-h-8\`) |

The \`filled\` variant already has analogous \`noLabel\` compounds — this PR brings the default variant to parity.

## Why
Without this, consumers layer manual overrides (\`[&>div]:!pt-0 [&_label]:!h-8 …\`) on every inline \`RuiTextField\` that sits next to a \`RuiMenuSelect\`. After this, \`<RuiTextField dense />\` is enough — no overrides.

## Risk
Low:
- Behavior with a label is **unchanged** — the new compound only activates when \`label\` is empty. Covered by the updated \`pass variant props\` spec.
- The existing \`should pass dense props\` spec (also called without a label) already expected \`py-1\` for dense, which is preserved.

## Stories / tests
- New \`DefaultWithNoLabel\` and \`DenseWithNoLabel\` stories.
- New \`should drop the floating-label reserve when used without a label\` spec asserts wrapper \`!pt-0\` + input padding for both dense and non-dense, plus reversion when a label is supplied.
- Updated the variant-switching spec so it uses a labelled field where the \`pt-3\` reserve is expected.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:run\` — 1027 tests pass
- [x] \`pnpm build\`
- [x] \`pnpm test:e2e\` — 266 e2e tests pass