### PR TITLE
fix(table-pagination): align jump-to-page input with the selects

### DIFF
--- a/packages/ui-library/src/components/tables/RuiTablePagination.vue
+++ b/packages/ui-library/src/components/tables/RuiTablePagination.vue
@@ -36,7 +36,7 @@ const paginationStyles = tv({
     wrapper: 'relative flex flex-wrap items-center justify-end gap-x-4 gap-y-0',
     limit: 'flex items-center space-x-2 text-caption',
     ranges: 'flex items-center space-x-2 text-caption pr-2',
-    pageInput: 'w-20',
+    pageInput: 'w-14 [&_input]:text-center',
     sectionLabel: 'text-rui-text-secondary whitespace-nowrap py-3',
     indicator: 'text-rui-text text-caption whitespace-nowrap',
     navigation: 'flex items-center',
@@ -119,14 +119,14 @@ function commitPageInput(): void {
         v-if="useInputJump"
         v-model="pageDraft"
         :disabled="loading"
-        :class="ui.pageInput()"
+        :class="[ui.pageInput()]"
+        class="[&_input]:!pr-0"
         type="number"
         min="1"
         :max="pages"
         inputmode="numeric"
         hide-details
         dense
-        variant="outlined"
         data-id="table-pagination-ranges-input"
         @blur="commitPageInput()"
         @keydown.enter="commitPageInput()"


### PR DESCRIPTION
## Summary
The jump-to-page input was set to \`variant=\"outlined\"\` and \`w-20\`, while the rows-per-page and page-ranges controls are underlined \`RuiMenuSelect\`s. That left a 40px outlined input sitting next to two 32px underlined selects — underlines at different heights, widths that didn't match.

Drops \`variant=\"outlined\"\` so the input uses the default (underlined) style. The dense+noLabel compound from the previous fix makes it render at 32px with the underline at the same y as the MenuSelects.

Also narrows the wrapper to \`w-14\` and centers the input text (\`[&_input]:text-center [&_input]:!pr-0\`) so the visible underline hugs the digit like the selects' underlines do.

## Before / After
- Before: 80px wide outlined input at 40px tall, underline below the select underlines.
- After: 56px underlined input at 32px tall, underline at the same baseline as the selects.

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:run\` — 1029 tests pass
- [x] \`pnpm build\`
- [x] \`pnpm test:e2e\` — 266 e2e tests pass