### PR TITLE
chore(tables): replace hardcoded test data with deterministic fixtures

### DIFF
--- a/apps/example/e2e/data-table.spec.ts
+++ b/apps/example/e2e/data-table.spec.ts
@@ -360,7 +360,7 @@ test.describe('data tables - search', () => {
     const initialRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Type search query
-    await searchInput.fill('Chelsey');
+    await searchInput.fill('Alice');
 
     // Wait for filtering
     await page.waitForTimeout(100);
@@ -381,7 +381,7 @@ test.describe('data tables - search', () => {
     const initialRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Search to filter
-    await searchInput.fill('Chelsey');
+    await searchInput.fill('Alice');
     await page.waitForTimeout(100);
 
     const filteredRows = await table.locator('tbody tr:not([data-id="row-empty"])').count();
@@ -404,13 +404,13 @@ test.describe('data tables - search', () => {
     await expect(table).toBeVisible();
 
     // Search with lowercase
-    await searchInput.fill('chelsey');
+    await searchInput.fill('alice');
     await page.waitForTimeout(100);
 
     const lowerCaseResults = await table.locator('tbody tr:not([data-id="row-empty"])').count();
 
     // Clear and search with uppercase
-    await searchInput.fill('CHELSEY');
+    await searchInput.fill('ALICE');
     await page.waitForTimeout(100);
 
     const upperCaseResults = await table.locator('tbody tr:not([data-id="row-empty"])').count();
@@ -452,7 +452,7 @@ test.describe('data tables - search', () => {
     await expect(rangeDisplay).toContainText('6 - 10');
 
     // Now search
-    await searchInput.fill('Chelsey');
+    await searchInput.fill('Alice');
     await page.waitForTimeout(100);
 
     // Page should reset to 1 (range should start from 1)

--- a/apps/example/src/data/table-configs.ts
+++ b/apps/example/src/data/table-configs.ts
@@ -64,120 +64,22 @@ export const fixedColumns: DataTableColumn<BaseUser>[] = [{
   key: 'action',
 }];
 
-export const fixedRows: ExtendedUser[] = [{
-  'id': 5,
-  'name': 'Chelsey Dietrich',
-  'username': 'Kamren',
-  'email': 'Lucio_Hettinger@annie.ca',
-  'website': 'demarco.info',
-  'address.street': 'Skiles Walks',
-  'address.city': 'Roscoeview',
-}, {
-  'id': 501,
-  'name': 'Chelsey Dietrich',
-  'username': 'Kamren',
-  'email': 'Lucio_Hettinger@annie.ca',
-  'website': 'demarco.info',
-  'address.street': 'Skiles Walks',
-  'address.city': 'Roscoeview',
-}, {
-  'id': 5012,
-  'name': 'Chelsey Dietrich',
-  'username': 'Kamren',
-  'email': 'Lucio_Hettinger@annie.ca',
-  'website': 'demarco.info',
-  'address.street': 'Skiles Walks',
-  'address.city': 'Roscoeview',
-}, {
-  'id': 5013,
-  'name': 'Chelsey Dietrich',
-  'username': 'Kamren',
-  'email': 'Lucio_Hettinger@annie.ca',
-  'website': 'demarco.info',
-  'address.street': 'Skiles Walks',
-  'address.city': 'Roscoeview',
-}, {
-  'id': 10,
-  'name': 'Clementina DuBuque',
-  'username': 'Moriah.Stanton',
-  'email': 'Rey.Padberg@karina.biz',
-  'website': 'ambrose.net',
-  'address.street': 'Kattie Turnpike',
-  'address.city': 'Lebsackbury',
-}, {
-  'id': 3,
-  'name': 'Clementine Bauch',
-  'username': 'Kamren',
-  'email': 'Nathan@yesenia.net',
-  'website': 'ramiro.info',
-  'address.street': 'Douglas Extension',
-  'address.city': 'McKenziehaven',
-}, {
-  'id': 2,
-  'name': 'Ervin Howell',
-  'username': 'Antonette',
-  'email': 'Shanna@melissa.tv',
-  'website': 'anastasia.net',
-  'address.street': 'Victor Plains',
-  'address.city': 'Wisokyburgh',
-}, {
-  'id': 203,
-  'name': 'Ervin Howell',
-  'username': 'Antonette',
-  'email': 'Shanna@melissa.tv',
-  'website': 'anastasia.net',
-  'address.street': 'Victor Plains',
-  'address.city': 'Wisokyburgh',
-}, {
-  'id': 19,
-  'name': 'Glenna Reichert',
-  'username': 'Kamren',
-  'email': 'Chaim_McDermott@dana.io',
-  'website': 'conrad.com',
-  'address.street': 'Dayna Park',
-  'address.city': 'Bartholomebury',
-}, {
-  'id': 15,
-  'name': 'Chelsey Dietrich',
-  'username': 'Kamren',
-  'email': 'Lucio_Hettinger@annie.ca',
-  'website': 'demarco.info',
-  'address.street': 'Skiles Walks',
-  'address.city': 'Roscoeview',
-}, {
-  'id': 110,
-  'name': 'Clementina DuBuque',
-  'username': 'Moriah.Stanton',
-  'email': 'Rey.Padberg@karina.biz',
-  'website': 'ambrose.net',
-  'address.street': 'Kattie Turnpike',
-  'address.city': 'Lebsackbury',
-}, {
-  'id': 13,
-  'name': 'Clementine Bauch',
-  'username': 'Kamren',
-  'email': 'Nathan@yesenia.net',
-  'website': 'ramiro.info',
-  'address.street': 'Douglas Extension',
-  'address.city': 'McKenziehaven',
-}, {
-  'id': 12,
-  'name': 'Ervin Howell',
-  'username': 'Antonette',
-  'email': 'Shanna@melissa.tv',
-  'website': 'anastasia.net',
-  'address.street': 'Victor Plains',
-  'address.city': 'Wisokyburgh',
-}];
+const userNames: string[] = ['Alice Martin', 'Bob Chen', 'Carol Davis', 'Dave Wilson', 'Eve Torres'];
+const usernames: string[] = ['amartin', 'bchen', 'amartin', 'dwilson', 'amartin'];
+const streets: string[] = ['Maple Avenue', 'Oak Boulevard', 'Pine Street', 'Cedar Lane', 'Elm Drive'];
+const cities: string[] = ['Springfield', 'Riverside', 'Lakewood', 'Fairview', 'Georgetown'];
+const websites: string[] = ['alice.dev', 'bobchen.io', 'carol.codes', 'dave.net', 'eve.tech'];
 
-export const sampleData: ExtendedUser[] = [{
-  'id': 1,
-  'name': 'Chelsey Dietrich',
-  'username': 'Kamren',
-  'email': 'Lucio_Hettinger@annie.ca',
-  'phone': '(254)954-1289',
-  'website': 'demarco.info',
-  'address.street': 'Skiles Walks',
-  'address.city': 'Roscoeview',
-  'company.name': 'Keebler LLC',
-}];
+export const fixedRows: ExtendedUser[] = Array.from({ length: 13 }, (_, i): ExtendedUser => {
+  const name = userNames[i % userNames.length]!;
+  const username = usernames[i % usernames.length]!;
+  return {
+    'id': i + 1,
+    'name': name,
+    'username': username,
+    'email': `${name.split(' ')[0]!.toLowerCase()}.${i + 1}@example.com`,
+    'website': websites[i % websites.length]!,
+    'address.street': streets[i % streets.length]!,
+    'address.city': cities[i % cities.length]!,
+  };
+});

--- a/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
@@ -126,9 +126,9 @@ function render(args: DataTableProps) {
         v-model:pagination="pagination"
         v-model:sort="sort"
         :search="search"
-        v-model:expanded="args.expanded"
-        v-model:group="args.group"
-        v-model:collapsed="args.collapsed"
+        v-model:expanded="expanded"
+        v-model:group="group"
+        v-model:collapsed="collapsed"
         :row-attr="args.rowAttr"
         :rows="args.rows"
       >
@@ -161,72 +161,39 @@ function render(args: DataTableProps) {
   };
 }
 
-const data: User[] = [
-  {
-    date: '10.09.2023',
-    email: 'Lefteris@example.com',
-    id: 1,
-    name: 'Lefteris',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  {
-    date: '10.09.2023',
-    email: 'Kelsos@example.com',
-    id: 2,
-    name: 'Kelsos',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  {
-    date: '10.09.2023',
-    email: 'Yabir@example.com',
-    id: 3,
-    name: 'Yabir',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  {
-    date: '10.09.2023',
-    email: 'Luki@example.com',
-    id: 4,
-    name: 'Luki',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  {
-    date: '10.09.2023',
-    email: 'Celina@example.com',
-    id: 5,
-    name: 'Celina',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  {
-    date: '10.09.2023',
-    email: 'Joseph@example.com',
-    id: 6,
-    name: 'Joseph',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  {
-    date: '10.09.2023',
-    email: 'Dimitry@example.com',
-    id: 7,
-    name: 'Dimitry',
-    role: 'Member',
-    title: 'Director of Product',
-  },
-  ...[...new Array(43)].map((_, index) => ({
-    date: '10.09.2023',
-    email: 'lindsay.walton@example.com',
-    id: index + 8,
-    name: 'Lindsay Walton',
-    role: 'Member',
-    title: 'Front-end Developer',
-  })),
+const names: string[] = [
+  'Alice',
+  'Bob',
+  'Carol',
+  'Dave',
+  'Eve',
+  'Frank',
+  'Grace',
+  'Hank',
+  'Ivy',
+  'Jack',
 ];
+const titles: string[] = [
+  'Frontend Engineer',
+  'Backend Engineer',
+  'Designer',
+  'QA Engineer',
+  'DevOps Engineer',
+  'Product Manager',
+];
+const roles: string[] = ['Member', 'Member', 'Admin'];
+
+const data: User[] = Array.from({ length: 50 }, (_, i): User => {
+  const name = names[i % names.length]!;
+  return {
+    date: `${((i % 28) + 1).toString().padStart(2, '0')}.${((i % 12) + 1).toString().padStart(2, '0')}.2024`,
+    email: `${name.toLowerCase()}.${i + 1}@example.com`,
+    id: i + 1,
+    name,
+    role: roles[i % roles.length]!,
+    title: titles[i % titles.length]!,
+  };
+});
 
 const columns: TableColumn<User>[] = [
   {
@@ -318,7 +285,7 @@ export const Default = meta.story({
   },
   async play({ canvas, userEvent }) {
     await expect(canvas.getByRole('table')).toBeVisible();
-    await expect(canvas.getByText('Lefteris')).toBeVisible();
+    await expect(canvas.getByText('Alice')).toBeVisible();
     // Click sortable column header to toggle sort
     const fullNameHeader = canvas.getByRole('columnheader', { name: /Full name/ });
     await userEvent.click(fullNameHeader);
@@ -527,6 +494,94 @@ export const Grouped = meta.story({
     cols: columns,
     expanded: [],
     group: 'name',
+    modelValue: [],
+    outlined: true,
+    pagination: { limit: 5, page: 1, total: 50 },
+    rows: data,
+    sort: [
+      { column: 'name', direction: 'asc' },
+      { column: 'email', direction: 'asc' },
+    ],
+  },
+});
+
+export const WithSearch = meta.story({
+  args: {
+    cols: columns,
+    outlined: true,
+    pagination: { limit: 10, page: 1, total: 50 },
+    rows: data,
+    search: '',
+    sort: [{ column: 'name', direction: 'asc' }],
+  },
+});
+
+export const RoundedSmall = meta.story({
+  args: {
+    cols: columns,
+    outlined: true,
+    rows: data,
+    rounded: 'sm',
+  },
+});
+
+export const RoundedLarge = meta.story({
+  args: {
+    cols: columns,
+    outlined: true,
+    rows: data,
+    rounded: 'lg',
+  },
+});
+
+export const DisabledRows = meta.story({
+  args: {
+    cols: columns,
+    disabledRows: data.slice(0, 3),
+    modelValue: [],
+    outlined: true,
+    pagination: { limit: 10, page: 1, total: 50 },
+    rows: data,
+  },
+});
+
+export const MultiPageSelect = meta.story({
+  args: {
+    cols: columns,
+    modelValue: [],
+    multiPageSelect: true,
+    outlined: true,
+    pagination: { limit: 5, page: 1, total: 50 },
+    rows: data,
+  },
+});
+
+export const CustomItemClass = meta.story({
+  args: {
+    cols: columns,
+    itemClass: (item: User) => (item.name === 'Alice' ? 'bg-rui-success/10' : ''),
+    outlined: true,
+    rows: data,
+  },
+});
+
+export const HiddenHeaderAndFooter = meta.story({
+  args: {
+    cols: columns,
+    hideDefaultFooter: true,
+    hideDefaultHeader: true,
+    outlined: true,
+    rows: data,
+  },
+});
+
+export const GroupedWithExpandButtonEnd = meta.story({
+  args: {
+    collapsed: [],
+    cols: columns,
+    expanded: [],
+    group: 'name',
+    groupExpandButtonPosition: 'end',
     modelValue: [],
     outlined: true,
     pagination: { limit: 5, page: 1, total: 50 },


### PR DESCRIPTION
## Summary
Cherry-picks the fixture / story-data portions out of #492 so they can land independently of the broader DataTable decomposition.

- **\`apps/example/src/data/table-configs.ts\`** — replaces the hand-written \`fixedRows\` array (and the unused \`sampleData\` export) with a small generator driven by fixed name/city/street/website lists. Produces deterministic rows whose values are predictable from the index.
- **\`packages/ui-library/src/components/tables/RuiDataTable.stories.ts\`** — same treatment for the story \`data\` array, plus eight new stories that exercise existing props: \`WithSearch\`, \`RoundedSmall\`, \`RoundedLarge\`, \`DisabledRows\`, \`MultiPageSelect\`, \`CustomItemClass\`, \`HiddenHeaderAndFooter\`, \`GroupedWithExpandButtonEnd\`.
- **\`apps/example/e2e/data-table.spec.ts\`** — swaps \`'Chelsey'\`/\`'chelsey'\`/\`'CHELSEY'\` search queries for \`'Alice'\` to match the new fixtures.

## Bug fix
The story \`render\` function's template bound \`v-model:expanded\`, \`v-model:group\`, \`v-model:collapsed\` to \`args.*\` directly while the \`setup\` block exposed matching \`computed\` refs that wrapped them. Changes coming back from the table didn't flow through the computed wrappers, so Storybook didn't re-render. Fixed by binding to the computed refs. (Same bug-fix as #492.)

## Test plan
- [x] \`pnpm lint\`
- [x] \`pnpm typecheck\`
- [x] \`pnpm test:run\` — 1029 tests pass
- [x] \`pnpm build:prod\`
- [x] \`pnpm test:e2e\` — 266 e2e tests pass