### PR TITLE
fix(ci): stop storybook coverage from hanging on close

### DIFF
--- a/packages/ui-library/.storybook/vitest.setup.ts
+++ b/packages/ui-library/.storybook/vitest.setup.ts
@@ -1,11 +1,8 @@
-import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview';
-import { setProjectAnnotations } from '@storybook/vue3-vite';
 import { afterEach } from 'vitest';
-import previewAnnotations from './preview';
 
-// @ts-expect-error definePreview() returns VuePreview which is not compatible with setProjectAnnotations types storybookjs/storybook issues 33057
-const annotations = setProjectAnnotations([a11yAddonAnnotations, previewAnnotations]);
-await annotations.beforeAll?.();
+// Since Storybook 10.3, @storybook/addon-vitest applies preview annotations
+// automatically; calling setProjectAnnotations here registers duplicate hooks
+// that were preventing the browser backend from shutting down cleanly on CI.
 
 // Clean up teleported elements (tooltips, menus, dialogs) that persist in document.body
 afterEach(() => {

--- a/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
@@ -285,7 +285,9 @@ export const Default = meta.story({
   },
   async play({ canvas, userEvent }) {
     await expect(canvas.getByRole('table')).toBeVisible();
-    await expect(canvas.getByText('Alice')).toBeVisible();
+    // The deterministic fixture cycles through 10 names over 50 rows, so
+    // "Alice" matches multiple cells — assert the first is visible.
+    await expect(canvas.getAllByText('Alice')[0]).toBeVisible();
     // Click sortable column header to toggle sort
     const fullNameHeader = canvas.getByRole('columnheader', { name: /Full name/ });
     await userEvent.click(fullNameHeader);

--- a/packages/ui-library/vitest.config.ts
+++ b/packages/ui-library/vitest.config.ts
@@ -70,6 +70,7 @@ const vitestConfig = defineConfig({
           fileParallelism: false,
           testTimeout: 15_000,
           hookTimeout: 15_000,
+          closeTimeout: 30_000,
           retry: 2,
           exclude: ['**/stories/references/**'],
           setupFiles: ['./.storybook/vitest.setup.ts'],


### PR DESCRIPTION
## Summary
- Removes the `setProjectAnnotations` call from `.storybook/vitest.setup.ts` — since Storybook 10.3, `@storybook/addon-vitest` applies preview annotations automatically and the duplicate registration was keeping a browser hook alive past vitest's 10s `closeTimeout`, making CI exit 1 even though every test passed.
- Bumps `closeTimeout` on the storybook project to 30s as a safety net for slower runners.
- Updates the `Default` DataTable story to assert on `getAllByText('Alice')[0]` since the deterministic fixtures cycle names across 50 rows.

Closes #507

## Test plan
- [x] `pnpm run coverage:storybook` locally — exits 0, no "close timed out" message
- [ ] CI `Run Storybook Tests with Coverage` job passes