### PR TITLE
fix(button): align icon-only button heights with text-button sizes

### DIFF
--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -159,6 +159,91 @@ export const AutoSizedIcon = meta.story({
   }),
 });
 
+export const IconOnlySizes = meta.story({
+  args: {
+    color: 'primary',
+    variant: 'text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only buttons (`icon` prop) land at the same height as text buttons of the matching `size` (sm 28px, md 32px, lg 36px, xl 44px) with a ~60–70% icon-to-box ratio.',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiButton, RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="flex items-center gap-4">
+        <RuiButton v-bind="args" icon size="sm" aria-label="small">
+          <RuiIcon name="lu-settings" />
+        </RuiButton>
+        <RuiButton v-bind="args" icon aria-label="medium">
+          <RuiIcon name="lu-settings" />
+        </RuiButton>
+        <RuiButton v-bind="args" icon size="lg" aria-label="large">
+          <RuiIcon name="lu-settings" />
+        </RuiButton>
+        <RuiButton v-bind="args" icon size="xl" aria-label="extra large">
+          <RuiIcon name="lu-settings" />
+        </RuiButton>
+      </div>
+    `,
+  }),
+});
+
+export const IconOnlyVsText = meta.story({
+  args: {
+    color: 'primary',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only and text buttons at the same `size` render at matching heights, so they line up cleanly when mixed in a toolbar.',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiButton, RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-3">
+          <RuiButton v-bind="args" size="sm">Small</RuiButton>
+          <RuiButton v-bind="args" variant="text" icon size="sm" aria-label="small icon">
+            <RuiIcon name="lu-ellipsis-vertical" />
+          </RuiButton>
+        </div>
+        <div class="flex items-center gap-3">
+          <RuiButton v-bind="args">Medium</RuiButton>
+          <RuiButton v-bind="args" variant="text" icon aria-label="medium icon">
+            <RuiIcon name="lu-ellipsis-vertical" />
+          </RuiButton>
+        </div>
+        <div class="flex items-center gap-3">
+          <RuiButton v-bind="args" size="lg">Large</RuiButton>
+          <RuiButton v-bind="args" variant="text" icon size="lg" aria-label="large icon">
+            <RuiIcon name="lu-ellipsis-vertical" />
+          </RuiButton>
+        </div>
+        <div class="flex items-center gap-3">
+          <RuiButton v-bind="args" size="xl">Extra Large</RuiButton>
+          <RuiButton v-bind="args" variant="text" icon size="xl" aria-label="xl icon">
+            <RuiIcon name="lu-ellipsis-vertical" />
+          </RuiButton>
+        </div>
+      </div>
+    `,
+  }),
+});
+
 export const PrimaryLargeRounded = meta.story({
   args: {
     color: 'primary',

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -63,7 +63,10 @@ export const buttonStyles = tv({
       true: { root: 'rounded-full' },
     },
     icon: {
-      true: { root: 'rounded-full px-3 py-3' },
+      // Padding and icon sizing live in the `icon + size` compound variants
+      // below so every size resolves to a height matching its text-button
+      // counterpart; this base only contributes the round shape.
+      true: { root: 'rounded-full' },
     },
     active: {
       true: {},
@@ -136,8 +139,24 @@ export const buttonStyles = tv({
     { variant: 'fab', size: 'sm', class: { root: 'py-1.5 px-2' } },
     { variant: 'fab', size: 'lg', class: { root: 'py-3' } },
     { variant: 'list', size: 'sm', class: { root: 'px-3 py-1' } },
-    { icon: true, size: 'sm', class: { root: 'px-1 py-1' } },
-    { icon: true, size: 'lg', class: { root: 'px-4 py-4' } },
+    // Icon-only button sizing — every size lands at the same height as the
+    // text button of the matching size, with a ~60–70% icon ratio (Material-3
+    // style). The `size` rule sizes icons to 16/20/22px for text-button
+    // prepend/append slots; here icon-only buttons get a larger glyph so they
+    // don't look lost in the square. All values use standard Tailwind tokens
+    // (rem-based): p-1 = 0.25rem, p-1.5 = 0.375rem, p-2 = 0.5rem; w-5/6/7 =
+    // 1.25/1.5/1.75rem. Prior `px-3 py-3` on icon base + `px-4 py-4` on lg
+    // compound produced 42px (md) and 52px (lg) squares that dwarfed
+    // neighboring text buttons in toolbars.
+    //
+    // md (default): p-1.5 + w-5  icon = 0.75 + 1.25 = 2rem   (32px)
+    // sm:           p-1   + w-5  icon = 0.5  + 1.25 = 1.75rem (28px)
+    // lg:           p-1.5 + w-6  icon = 0.75 + 1.5  = 2.25rem (36px)
+    // xl:           p-2   + w-7  icon = 1    + 1.75 = 2.75rem (44px)
+    { icon: true, class: { root: 'p-1.5 [&_.rui-icon]:!w-5 [&_.rui-icon]:!h-5' } },
+    { icon: true, size: 'sm', class: { root: 'p-1 [&_.rui-icon]:!w-5 [&_.rui-icon]:!h-5' } },
+    { icon: true, size: 'lg', class: { root: 'p-1.5 [&_.rui-icon]:!w-6 [&_.rui-icon]:!h-6' } },
+    { icon: true, size: 'xl', class: { root: 'p-2 [&_.rui-icon]:!w-7 [&_.rui-icon]:!h-7' } },
     { variant: 'fab', icon: true, size: 'sm', class: { root: 'px-2 py-2' } },
   ],
   compoundSlots: [


### PR DESCRIPTION
## Summary
Icon-only buttons were rendering taller than text buttons at the matching size:

| size | text btn | icon btn (before) | icon btn (now) |
|---|---|---|---|
| sm  | 28px | 24px | **28px** |
| md  | 32px | 42px | **32px** |
| lg  | 36px | 52px | **36px** |
| xl  | 44px | 46px | **44px** |

The `icon` base rule applied `px-3 py-3` regardless of size and only the `sm` compound overrode it, so toolbars mixing text and icon buttons ended up visibly uneven.

Drops the padding from the `icon` base and adds an explicit compound per size. Icon-only buttons now use a slightly larger glyph than text-button slots at the same size (Material-3-ish ~60–70% ratio) so they don't look tiny in the square:

```
sm  p-1   + w-5  icon  = 1.75rem  (28px)
md  p-1.5 + w-5  icon  = 2rem     (32px)
lg  p-1.5 + w-6  icon  = 2.25rem  (36px)
xl  p-2   + w-7  icon  = 2.75rem  (44px)
```

Text-button icon slots are untouched — the `size` rule's 16/20/22px icon sizing still applies to prepend/append icons inside text buttons.

Adds `IconOnlySizes` and `IconOnlyVsText` stories so the alignment can be verified visually.

## Consumer impact
Any rotki-app site that was compensating for the old 42/52px heights with `!p-2` or `!h-X` overrides will now over-shrink. Those are tracked for cleanup in the rotki-app 2.17 PR.

## Test plan
- [x] `pnpm vitest run --project=unit src/components/buttons/button/RuiButton.spec.ts` (10/10 pass)
- [x] `pnpm vitest run --project=storybook src/components/buttons/button/RuiButton.stories.ts` (25/25 pass — 2 new stories)
- [ ] Visual check: `Buttons/Button > Icon Only Sizes` and `Icon Only Vs Text`