### PR TITLE
fix(auto-complete): resync displayed text when options arrive late

### DIFF
--- a/packages/ui-library/src/composables/forms/auto-complete/value.spec.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/value.spec.ts
@@ -1,21 +1,25 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
-import { defineComponent, ref, toValue } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick, ref, shallowRef, toValue } from 'vue';
 import { useAutoCompleteValue, type UseAutoCompleteValueDeps, type UseAutoCompleteValueOptions, type UseAutoCompleteValueReturn } from '@/composables/forms/auto-complete/value';
 
 interface Harness<TValue, TItem> {
   result: UseAutoCompleteValueReturn<TItem>;
   modelValue: Ref<TValue | undefined>;
+  options: ShallowRef<TItem[]>;
+  updateInternalSearch: ReturnType<typeof vi.fn>;
   unmount: () => void;
 }
 
 function setup<TValue, TItem>(
   initialModelValue: TValue | undefined,
-  options: TItem[],
+  initialOptions: TItem[],
   opts: UseAutoCompleteValueOptions<TItem>,
   depsOverride: Partial<UseAutoCompleteValueDeps<TItem>> = {},
 ): Harness<TValue, TItem> {
   const modelValue = ref(initialModelValue) as Ref<TValue | undefined>;
+  const options = shallowRef<TItem[]>(initialOptions);
+  const updateInternalSearch = vi.fn();
   let result!: UseAutoCompleteValueReturn<TItem>;
 
   const TestComponent = defineComponent({
@@ -32,7 +36,7 @@ function setup<TValue, TItem>(
         shouldApplyValueAsSearch: true,
         isOpen: false,
         multiple: false,
-        updateInternalSearch: () => {},
+        updateInternalSearch,
         ...depsOverride,
       };
       result = useAutoCompleteValue<TValue, TItem>(modelValue, options, opts, deps);
@@ -41,7 +45,7 @@ function setup<TValue, TItem>(
     template: '<div></div>',
   });
   const wrapper = mount(TestComponent);
-  return { result, modelValue, unmount: () => wrapper.unmount() };
+  return { result, modelValue, options, updateInternalSearch, unmount: () => wrapper.unmount() };
 }
 
 describe('composables/forms/auto-complete/value', () => {
@@ -77,6 +81,29 @@ describe('composables/forms/auto-complete/value', () => {
     const h = setup<string, string>('apple', ['apple', 'banana'], {});
     unmount = h.unmount;
     expect(h.result.value.value).toEqual(['apple']);
+  });
+
+  it('should sync displayed text when options arrive after modelValue is set', async () => {
+    // Reproduces the LoginForm race where loadSettings() sets username before
+    // loadProfiles() populates the options list. The watcher must re-sync the
+    // input text once options arrive and the value can be resolved — otherwise
+    // the input renders empty while modelValue is still pointing at a valid
+    // (now-existing) option.
+    const h = setup<string, string>('alice', [], {});
+    unmount = h.unmount;
+
+    // Initial watch fires with empty options — value cannot resolve, search
+    // gets cleared (called with no argument).
+    expect(h.updateInternalSearch).toHaveBeenCalledTimes(1);
+    expect(h.updateInternalSearch).toHaveBeenLastCalledWith();
+
+    // Options arrive later; value should re-resolve and the displayed text
+    // should be updated to the option's label.
+    set(h.options, ['alice', 'bob']);
+    await nextTick();
+
+    expect(h.result.value.value).toEqual(['alice']);
+    expect(h.updateInternalSearch).toHaveBeenLastCalledWith('alice');
   });
 
   it('should not throw when custom-value matches an empty-string option identifier', () => {

--- a/packages/ui-library/src/composables/forms/auto-complete/value.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/value.ts
@@ -130,8 +130,9 @@ export function useAutoCompleteValue<TValue, TItem>(
     },
   });
 
-  // Sync search text when menu is closed and value changes
-  watch([modelValue, () => toValue(deps.isOpen)], () => {
+  // Watching `value` (not `modelValue`) so the search text resyncs once
+  // `options` arrives later and the lookup can finally resolve.
+  watch([value, () => toValue(deps.isOpen)], () => {
     if (toValue(deps.isOpen) || !toValue(deps.shouldApplyValueAsSearch))
       return;
 


### PR DESCRIPTION
## Summary
`useAutoCompleteValue`'s watcher depended on `[modelValue, isOpen]`, so when a parent set `modelValue` before the option list was loaded (restore-then-fetch pattern — e.g. rotki's `LoginForm` where `loadSettings()` writes the saved username before `loadProfiles()` populates the profile list), the initial sync pass saw an empty options map, failed to resolve the value, and cleared the displayed text.

Once options arrived `value` recomputed correctly but the watcher never fired again, so the input stayed visually blank even though `modelValue` still pointed at a valid option. Autocompletes with `customValue` dodged the bug because `textValueToProperValue` fabricates a synthetic option from the raw value on the first pass; single-select without custom values hit it directly.

Watches `value` (not `modelValue`) so the same watcher runs a second time once the lookup succeeds and stamps the matching text back into the input.

## Test plan
- [x] Added regression test in `value.spec.ts`: start with empty options + preset `modelValue`, populate options on next tick, assert `updateInternalSearch` is called with the resolved text.
- [x] `pnpm vitest run --project=unit src/composables/forms/auto-complete/ src/components/forms/auto-complete/` — 41/41 pass
- [x] `pnpm run build:prod` — clean
- [x] `pnpm run test:e2e` — 266/266 pass