### PR TITLE
fix(button): make RuiIcon size prop work inside RuiButton + add xs size

### DIFF
--- a/apps/example/e2e/icon.spec.ts
+++ b/apps/example/e2e/icon.spec.ts
@@ -18,8 +18,12 @@ test.describe('icons', () => {
   test('should render icons with correct dimensions', async ({ page }) => {
     const contentArea = page.locator('h2[data-id=icons] + div[data-id=content]');
     const icon = contentArea.locator('svg[aria-hidden="true"]').first();
-    await expect(icon).toHaveAttribute('width', '24');
-    await expect(icon).toHaveAttribute('height', '24');
+    // Icon sizing flows through `--rui-icon-size` (fallback 1.5rem = 24px).
+    // Assert the computed box instead of the deprecated `width`/`height`
+    // presentation attrs — this tests what actually renders and survives
+    // any future shift in the mechanism (see rotki/ui-library#512).
+    await expect(icon).toHaveCSS('width', '24px');
+    await expect(icon).toHaveCSS('height', '24px');
   });
 
   test('should render multiple icons', async ({ page }) => {

--- a/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
@@ -1,6 +1,7 @@
 import { type ComponentMountingOptions, mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { expectWrapperNotToHaveClass, expectWrapperToHaveClass } from '~/tests/helpers/dom-helpers';
 
 function createWrapper(
@@ -111,20 +112,145 @@ describe('components/buttons/button/RuiButton.vue', () => {
     expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
   });
 
-  it('should scope descendant icon sizing to the button size', async () => {
+  it('should set --rui-icon-size per button size so descendant icons scale', async () => {
     wrapper = createWrapper();
-    // default (md) — 1.125rem icons, baked into the base root
-    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:w-[1.125rem]');
+    // default (md) — the base root seeds the property without `!` so consumer
+    // overrides via inline style on the svg still win.
+    expect(wrapper.find('button').classes()).toContain('[--rui-icon-size:1.125rem]');
 
-    // size variants use `!` so they beat the md baseline regardless of CSS source order
+    // Size variants redefine the property with `!` so they beat the base
+    // rule on the same element regardless of CSS source order.
     await wrapper.setProps({ size: 'sm' });
-    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:!w-4');
+    expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1rem]');
 
     await wrapper.setProps({ size: 'lg' });
-    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:!w-5');
+    expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.25rem]');
 
     await wrapper.setProps({ size: 'xl' });
-    expect(wrapper.find('button').classes()).toContain('[&_.rui-icon]:!w-[1.375rem]');
+    expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.375rem]');
+  });
+
+  // Regression tests for https://github.com/rotki/ui-library/issues/512
+  // Icon sizing inside a button now flows through a single CSS custom
+  // property, `--rui-icon-size`. The button seeds it per size variant; the
+  // icon reads it via `width: var(--rui-icon-size, 1.5rem)`. A consumer
+  // passing `size` on RuiIcon stamps an inline style on the svg, which
+  // overrides the inherited value without needing !important.
+  describe('icon size cascade inside button (issue #512)', () => {
+    const perSize = { sm: '![--rui-icon-size:1rem]', lg: '![--rui-icon-size:1.25rem]', xl: '![--rui-icon-size:1.375rem]' } as const;
+    for (const size of ['sm', 'lg', 'xl'] as const) {
+      it(`should attach ${perSize[size]} when size is ${size}`, () => {
+        wrapper = createWrapper({
+          props: { size },
+          slots: {
+            prepend: () => h(RuiIcon, { name: 'lu-circle-arrow-down', size: 14 }),
+          },
+        });
+        expect(wrapper.find('button').classes()).toContain(perSize[size]);
+      });
+    }
+
+    it('should let a consumer-supplied RuiIcon size override the button variant', () => {
+      wrapper = createWrapper({
+        props: { size: 'sm' },
+        slots: {
+          prepend: () => h(RuiIcon, { name: 'lu-circle-arrow-down', size: 14 }),
+        },
+      });
+      const svg = wrapper.find('svg.rui-icon');
+      // Consumer-driven size lands as inline style — beats the button's
+      // inherited `![--rui-icon-size:1rem]` on the svg itself.
+      expect(svg.attributes('style')).toContain('--rui-icon-size: 14px');
+      // Presentation attrs are gone — the whole point of #512 was to stop
+      // relying on them because they lost the cascade.
+      expect(svg.attributes('width')).toBeUndefined();
+      expect(svg.attributes('height')).toBeUndefined();
+      // Button still carries its own property so a bare RuiIcon (no size)
+      // next to this one would inherit the button-driven size.
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1rem]');
+    });
+
+    it('should override the md baseline via `!` on size variants', async () => {
+      wrapper = createWrapper({
+        slots: {
+          prepend: () => h(RuiIcon, { name: 'lu-circle-arrow-down' }),
+        },
+      });
+      // md default: no `!` prefix on the baseline rule — consumers can
+      // shadow it with their own `--rui-icon-size` without fighting
+      // !important.
+      expect(wrapper.find('button').classes()).toContain('[--rui-icon-size:1.125rem]');
+      expect(wrapper.find('button').classes()).not.toContain('![--rui-icon-size:1.125rem]');
+
+      await wrapper.setProps({ size: 'sm' });
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1rem]');
+      // baseline rule is still on the element — size variants win through
+      // `!important` + equal specificity, not removal.
+      expect(wrapper.find('button').classes()).toContain('[--rui-icon-size:1.125rem]');
+    });
+
+    it('should apply icon-only compound variant sizing across button sizes', async () => {
+      wrapper = createWrapper({
+        props: { icon: true },
+        slots: {
+          default: () => h(RuiIcon, { name: 'lu-circle-arrow-down' }),
+        },
+      });
+      // md icon-only: 1.25rem glyph via compound variant
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.25rem]');
+
+      await wrapper.setProps({ size: 'sm' });
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.25rem]');
+
+      await wrapper.setProps({ size: 'lg' });
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.5rem]');
+
+      await wrapper.setProps({ size: 'xl' });
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.75rem]');
+    });
+  });
+
+  // Pairs with issue #512 second half: list-variant icon alignment audit.
+  describe('list variant icon slot (issue #512)', () => {
+    it('should preserve flex alignment for prepend icons in list variant', () => {
+      wrapper = createWrapper({
+        props: { variant: 'list' },
+        slots: {
+          prepend: () => h(RuiIcon, { name: 'lu-circle-arrow-down' }),
+          default: () => 'Menu item',
+        },
+      });
+      const btn = wrapper.find('button');
+      expect(btn.classes()).toContain('flex');
+      expect(btn.classes()).toContain('items-center');
+      expect(btn.classes()).toContain('justify-start');
+    });
+
+    it('should give list-variant labels w-full so text fills the row', () => {
+      wrapper = createWrapper({
+        props: { variant: 'list' },
+        slots: {
+          prepend: () => h(RuiIcon, { name: 'lu-circle-arrow-down' }),
+          default: () => 'Menu item',
+        },
+      });
+      expect(wrapper.find('[data-id="btn-label"]').classes()).toContain('w-full');
+    });
+
+    it('should scale list-variant icons in lockstep with button size', async () => {
+      wrapper = createWrapper({
+        props: { variant: 'list' },
+        slots: {
+          prepend: () => h(RuiIcon, { name: 'lu-circle-arrow-down' }),
+          default: () => 'Menu item',
+        },
+      });
+      // md
+      expect(wrapper.find('button').classes()).toContain('[--rui-icon-size:1.125rem]');
+
+      await wrapper.setProps({ size: 'sm' });
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1rem]');
+    });
   });
 
   it('should pass elevation props and set to correct classes based on the state', async () => {

--- a/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
@@ -102,6 +102,9 @@ describe('components/buttons/button/RuiButton.vue', () => {
 
   it('should pass size props', async () => {
     wrapper = createWrapper();
+    await wrapper.setProps({ size: 'xs' });
+    expect(wrapper.find('button').classes()).toContain('text-[.75rem]');
+    expect(wrapper.find('button').classes()).toContain('leading-4');
     await wrapper.setProps({ size: 'sm' });
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
@@ -137,8 +140,8 @@ describe('components/buttons/button/RuiButton.vue', () => {
   // passing `size` on RuiIcon stamps an inline style on the svg, which
   // overrides the inherited value without needing !important.
   describe('icon size cascade inside button (issue #512)', () => {
-    const perSize = { sm: '![--rui-icon-size:1rem]', lg: '![--rui-icon-size:1.25rem]', xl: '![--rui-icon-size:1.375rem]' } as const;
-    for (const size of ['sm', 'lg', 'xl'] as const) {
+    const perSize = { xs: '![--rui-icon-size:0.75rem]', sm: '![--rui-icon-size:1rem]', lg: '![--rui-icon-size:1.25rem]', xl: '![--rui-icon-size:1.375rem]' } as const;
+    for (const size of ['xs', 'sm', 'lg', 'xl'] as const) {
       it(`should attach ${perSize[size]} when size is ${size}`, () => {
         wrapper = createWrapper({
           props: { size },
@@ -198,6 +201,11 @@ describe('components/buttons/button/RuiButton.vue', () => {
       });
       // md icon-only: 1.25rem glyph via compound variant
       expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.25rem]');
+
+      await wrapper.setProps({ size: 'xs' });
+      // xs icon-only: 0.875rem glyph (14px) at 70% of a 1.25rem (20px) box.
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:0.875rem]');
+      expect(wrapper.find('button').classes()).toContain('p-[0.1875rem]');
 
       await wrapper.setProps({ size: 'sm' });
       expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.25rem]');

--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -127,7 +127,7 @@ export const AutoSizedIcon = meta.story({
     docs: {
       description: {
         story:
-          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (sm → 1rem, md → 1.125rem, lg → 1.25rem, xl → 1.375rem). Passing `size` on `<RuiIcon>` still wins via inline width/height attributes.',
+          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (sm → 1rem, md → 1.125rem, lg → 1.25rem, xl → 1.375rem). Sizing flows through the `--rui-icon-size` custom property: the button seeds it per size variant, and the icon reads it via `width: var(--rui-icon-size, 1.5rem)`. A consumer passing `size` on `<RuiIcon>` still wins because that path stamps an inline style on the svg itself (see `ConsumerIconSizeOverride`).',
       },
     },
   },
@@ -239,6 +239,99 @@ export const IconOnlyVsText = meta.story({
             <RuiIcon name="lu-ellipsis-vertical" />
           </RuiButton>
         </div>
+      </div>
+    `,
+  }),
+});
+
+export const ConsumerIconSizeOverride = meta.story({
+  args: {
+    color: 'primary',
+    variant: 'text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A `size` prop on `<RuiIcon>` overrides the button-driven glyph size. The icon stamps `style="--rui-icon-size: <n>px"` on its own svg, which beats the value inherited from the button (inline style wins over any inherited custom property, including ones flagged `!important` on an ancestor). This is the case from rotki/ui-library#512 — before the fix, the icon-library\'s `!w-X` descendant rule always won and the `size` prop was a no-op inside any button.',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiButton, RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-4">
+          <RuiButton v-bind="args" icon size="sm" aria-label="default sm icon-only">
+            <RuiIcon name="lu-copy" />
+          </RuiButton>
+          <RuiButton v-bind="args" icon size="sm" aria-label="overridden sm icon-only">
+            <RuiIcon name="lu-copy" :size="14" />
+          </RuiButton>
+          <span class="text-rui-text-secondary text-sm">sm icon-only button — default 20px glyph vs. consumer-forced 14px</span>
+        </div>
+        <div class="flex items-center gap-4">
+          <RuiButton v-bind="args" size="lg">
+            <template #prepend><RuiIcon name="lu-plus" /></template>
+            Default
+          </RuiButton>
+          <RuiButton v-bind="args" size="lg">
+            <template #prepend><RuiIcon name="lu-plus" :size="12" /></template>
+            Tiny icon
+          </RuiButton>
+          <RuiButton v-bind="args" size="lg">
+            <template #prepend><RuiIcon name="lu-plus" :size="24" /></template>
+            Oversized icon
+          </RuiButton>
+        </div>
+      </div>
+    `,
+  }),
+});
+
+export const ListVariantWithIcons = meta.story({
+  args: {
+    color: 'primary',
+    variant: 'list',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'List-variant buttons (used inside menus) keep the same icon-size contract as every other variant: the glyph scales in lockstep with the button `size`, and a consumer-supplied `size` on `<RuiIcon>` still wins. Use this story as the visual baseline for text-baseline alignment against the icon — rows should center cleanly without clipping or drift.',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiButton, RuiIcon },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="w-64 border border-rui-grey-200 dark:border-rui-grey-800 rounded-md overflow-hidden divide-y divide-rui-grey-200 dark:divide-rui-grey-800">
+        <RuiButton v-bind="args" size="sm">
+          <template #prepend><RuiIcon name="lu-settings" /></template>
+          Small row
+        </RuiButton>
+        <RuiButton v-bind="args">
+          <template #prepend><RuiIcon name="lu-settings" /></template>
+          Medium row
+        </RuiButton>
+        <RuiButton v-bind="args" size="lg">
+          <template #prepend><RuiIcon name="lu-settings" /></template>
+          Large row
+        </RuiButton>
+        <RuiButton v-bind="args" size="xl">
+          <template #prepend><RuiIcon name="lu-settings" /></template>
+          Extra large row
+        </RuiButton>
+        <RuiButton v-bind="args">
+          <template #prepend><RuiIcon name="lu-settings" :size="12" /></template>
+          Medium row with forced 12px icon
+        </RuiButton>
       </div>
     `,
   }),

--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -33,7 +33,7 @@ const meta = preview.meta({
     label: { control: 'text' },
     loading: { control: 'boolean', table: { category: 'State' } },
     rounded: { control: 'boolean', table: { category: 'Shape' } },
-    size: { control: 'select', options: ['medium', 'sm', 'lg', 'xl'] },
+    size: { control: 'select', options: ['medium', 'xs', 'sm', 'lg', 'xl'] },
     type: { control: 'select', options: ['button', 'submit'] },
     variant: {
       control: 'select',
@@ -127,7 +127,7 @@ export const AutoSizedIcon = meta.story({
     docs: {
       description: {
         story:
-          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (sm → 1rem, md → 1.125rem, lg → 1.25rem, xl → 1.375rem). Sizing flows through the `--rui-icon-size` custom property: the button seeds it per size variant, and the icon reads it via `width: var(--rui-icon-size, 1.5rem)`. A consumer passing `size` on `<RuiIcon>` still wins because that path stamps an inline style on the svg itself (see `ConsumerIconSizeOverride`).',
+          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (xs → 0.75rem, sm → 1rem, md → 1.125rem, lg → 1.25rem, xl → 1.375rem). Sizing flows through the `--rui-icon-size` custom property: the button seeds it per size variant, and the icon reads it via `width: var(--rui-icon-size, 1.5rem)`. A consumer passing `size` on `<RuiIcon>` still wins because that path stamps an inline style on the svg itself (see `ConsumerIconSizeOverride`).',
       },
     },
   },
@@ -138,6 +138,10 @@ export const AutoSizedIcon = meta.story({
     },
     template: `
       <div class="flex items-center gap-4">
+        <RuiButton v-bind="args" size="xs">
+          <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
+          Extra Small
+        </RuiButton>
         <RuiButton v-bind="args" size="sm">
           <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
           Small
@@ -168,7 +172,7 @@ export const IconOnlySizes = meta.story({
     docs: {
       description: {
         story:
-          'Icon-only buttons (`icon` prop) land at the same height as text buttons of the matching `size` (sm 28px, md 32px, lg 36px, xl 44px) with a ~60–70% icon-to-box ratio.',
+          'Icon-only buttons (`icon` prop) land at the same height as text buttons of the matching `size` (xs 20px, sm 28px, md 32px, lg 36px, xl 44px) with a ~60–70% icon-to-box ratio. `xs` is aimed at inline contexts like copy buttons or badge actions where a 28px `sm` would still feel heavy.',
       },
     },
   },
@@ -179,6 +183,9 @@ export const IconOnlySizes = meta.story({
     },
     template: `
       <div class="flex items-center gap-4">
+        <RuiButton v-bind="args" icon size="xs" aria-label="extra small">
+          <RuiIcon name="lu-settings" />
+        </RuiButton>
         <RuiButton v-bind="args" icon size="sm" aria-label="small">
           <RuiIcon name="lu-settings" />
         </RuiButton>
@@ -215,6 +222,12 @@ export const IconOnlyVsText = meta.story({
     },
     template: `
       <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-3">
+          <RuiButton v-bind="args" size="xs">Extra Small</RuiButton>
+          <RuiButton v-bind="args" variant="text" icon size="xs" aria-label="xs icon">
+            <RuiIcon name="lu-ellipsis-vertical" />
+          </RuiButton>
+        </div>
         <div class="flex items-center gap-3">
           <RuiButton v-bind="args" size="sm">Small</RuiButton>
           <RuiButton v-bind="args" variant="text" icon size="sm" aria-label="small icon">
@@ -253,7 +266,7 @@ export const ConsumerIconSizeOverride = meta.story({
     docs: {
       description: {
         story:
-          'A `size` prop on `<RuiIcon>` overrides the button-driven glyph size. The icon stamps `style="--rui-icon-size: <n>px"` on its own svg, which beats the value inherited from the button (inline style wins over any inherited custom property, including ones flagged `!important` on an ancestor). This is the case from rotki/ui-library#512 — before the fix, the icon-library\'s `!w-X` descendant rule always won and the `size` prop was a no-op inside any button.',
+          'A `size` prop on `<RuiIcon>` overrides the button-driven glyph size. The icon stamps `style="--rui-icon-size: <n>px"` on its own svg, which beats the value inherited from the button (inline style wins over any inherited custom property, including ones flagged `!important` on an ancestor). This is the case from rotki/ui-library#512 — before the fix, the library\'s `!w-X` descendant rule always won and the `size` prop was a no-op inside any button. For inline "tiny button" cases (copy buttons, badge actions), reach for `size="xs"` first; use the icon-level override only when you specifically need a non-default ratio inside a given button size.',
       },
     },
   },
@@ -264,6 +277,12 @@ export const ConsumerIconSizeOverride = meta.story({
     },
     template: `
       <div class="flex flex-col gap-4">
+        <div class="flex items-center gap-4">
+          <RuiButton v-bind="args" icon size="xs" aria-label="xs icon-only copy">
+            <RuiIcon name="lu-copy" />
+          </RuiButton>
+          <span class="text-rui-text-secondary text-sm">xs icon-only (20px box, 14px glyph) — preferred for inline copy / badge actions instead of overriding the glyph inside a larger button.</span>
+        </div>
         <div class="flex items-center gap-4">
           <RuiButton v-bind="args" icon size="sm" aria-label="default sm icon-only">
             <RuiIcon name="lu-copy" />
@@ -312,6 +331,10 @@ export const ListVariantWithIcons = meta.story({
     },
     template: `
       <div class="w-64 border border-rui-grey-200 dark:border-rui-grey-800 rounded-md overflow-hidden divide-y divide-rui-grey-200 dark:divide-rui-grey-800">
+        <RuiButton v-bind="args" size="xs">
+          <template #prepend><RuiIcon name="lu-settings" /></template>
+          Extra small row
+        </RuiButton>
         <RuiButton v-bind="args" size="sm">
           <template #prepend><RuiIcon name="lu-settings" /></template>
           Small row

--- a/packages/ui-library/src/components/buttons/button/button-props.ts
+++ b/packages/ui-library/src/components/buttons/button/button-props.ts
@@ -9,6 +9,7 @@ export const ButtonVariant = {
 export type ButtonVariant = (typeof ButtonVariant)[keyof typeof ButtonVariant];
 
 export const ButtonSize = {
+  xs: 'xs',
   sm: 'sm',
   lg: 'lg',
   xl: 'xl',
@@ -16,7 +17,7 @@ export const ButtonSize = {
 
 export type ButtonSize = (typeof ButtonSize)[keyof typeof ButtonSize];
 
-const SPINNER_SIZES: Record<string, number> = { sm: 18, lg: 26, xl: 28 };
+const SPINNER_SIZES: Record<string, number> = { xs: 12, sm: 18, lg: 26, xl: 28 };
 const DEFAULT_SPINNER_SIZE = 22;
 
 export const FAB_DEFAULT_ELEVATION = 6;

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -47,6 +47,7 @@ export const buttonStyles = tv({
       // base root regardless of CSS source order. A consumer passing `size`
       // on RuiIcon still wins: that path stamps an inline style on the svg
       // element itself, which beats the inherited value from the button.
+      xs: { root: 'px-2 py-[0.125rem] text-[.75rem] leading-4 ![--rui-icon-size:0.75rem]' },
       sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5 ![--rui-icon-size:1rem]' },
       lg: { root: 'px-6 py-2 text-[1rem] leading-5 ![--rui-icon-size:1.25rem]' },
       xl: { root: 'px-6 py-2.5 text-[1rem] leading-6 ![--rui-icon-size:1.375rem]' },
@@ -135,26 +136,30 @@ export const buttonStyles = tv({
     { color: 'success', variant: 'outlined', class: { root: 'outline-rui-success/[0.5]' } },
 
     // === Size overrides per variant ===
+    { variant: 'text', size: 'xs', class: { root: 'px-1' } },
     { variant: 'text', size: 'sm', class: { root: 'px-1.5' } },
     { variant: 'text', size: 'lg', class: { root: 'px-2.5' } },
+    { variant: 'fab', size: 'xs', class: { root: 'py-1 px-1' } },
     { variant: 'fab', size: 'sm', class: { root: 'py-1.5 px-2' } },
     { variant: 'fab', size: 'lg', class: { root: 'py-3' } },
+    { variant: 'list', size: 'xs', class: { root: 'px-3 py-0.5' } },
     { variant: 'list', size: 'sm', class: { root: 'px-3 py-1' } },
     // Icon-only button sizing — every size lands at the same height as the
     // text button of the matching size, with a ~60–70% icon ratio (Material-3
-    // style). The `size` rule sizes icons to 16/20/22px for text-button
+    // style). The `size` rule sizes icons to 12/16/20/22px for text-button
     // prepend/append slots; here icon-only buttons get a larger glyph so they
-    // don't look lost in the square. All values use standard Tailwind tokens
-    // (rem-based): p-1 = 0.25rem, p-1.5 = 0.375rem, p-2 = 0.5rem; w-5/6/7 =
-    // 1.25/1.5/1.75rem. Prior `px-3 py-3` on icon base + `px-4 py-4` on lg
-    // compound produced 42px (md) and 52px (lg) squares that dwarfed
-    // neighboring text buttons in toolbars.
+    // don't look lost in the square. Values are rem-based throughout: p-1 =
+    // 0.25rem, p-1.5 = 0.375rem, p-2 = 0.5rem; glyph sizes use rem literals.
+    // xs uses an arbitrary 0.1875rem (3px) padding — no Tailwind token hits
+    // it cleanly — to keep the 70% icon ratio with a 14px glyph.
     //
-    // md (default): p-1.5 + w-5  icon = 0.75 + 1.25 = 2rem   (32px)
-    // sm:           p-1   + w-5  icon = 0.5  + 1.25 = 1.75rem (28px)
-    // lg:           p-1.5 + w-6  icon = 0.75 + 1.5  = 2.25rem (36px)
-    // xl:           p-2   + w-7  icon = 1    + 1.75 = 2.75rem (44px)
+    // xs:           p-[0.1875rem] + 0.875rem icon = 0.375 + 0.875 = 1.25rem (20px) — 70% ratio
+    // sm:           p-1           + 1.25rem icon  = 0.5   + 1.25  = 1.75rem (28px)
+    // md (default): p-1.5         + 1.25rem icon  = 0.75  + 1.25  = 2rem    (32px)
+    // lg:           p-1.5         + 1.5rem icon   = 0.75  + 1.5   = 2.25rem (36px)
+    // xl:           p-2           + 1.75rem icon  = 1     + 1.75  = 2.75rem (44px)
     { icon: true, class: { root: 'p-1.5 ![--rui-icon-size:1.25rem]' } },
+    { icon: true, size: 'xs', class: { root: 'p-[0.1875rem] ![--rui-icon-size:0.875rem]' } },
     { icon: true, size: 'sm', class: { root: 'p-1 ![--rui-icon-size:1.25rem]' } },
     { icon: true, size: 'lg', class: { root: 'p-1.5 ![--rui-icon-size:1.5rem]' } },
     { icon: true, size: 'xl', class: { root: 'p-2 ![--rui-icon-size:1.75rem]' } },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -12,10 +12,13 @@ export const buttonStyles = tv({
       // end up as relative offsets, which misplaces FABs).
       'flex items-center justify-center gap-x-2',
       'px-4 py-1.5 rounded transition-all',
-      // Default (md) icon sizing for RuiIcons in button slots (prepend/append
-      // /default). Size variants below override this via `!` so the rule
-      // specificity wins regardless of CSS source order.
-      '[&_.rui-icon]:w-[1.125rem] [&_.rui-icon]:h-[1.125rem]',
+      // Default (md) icon sizing is driven by a CSS custom property so that
+      // RuiIcon's `size` prop (stamped as inline `style="--rui-icon-size"` on
+      // the svg) can override it cleanly. Size variants below redefine the
+      // property with `!` so they beat this baseline on the same element;
+      // inline style on the svg then beats the inherited value when a
+      // consumer supplies their own size. See rotki/ui-library#512.
+      '[--rui-icon-size:1.125rem]',
       // `disabled` on the element covers two states: actually disabled and
       // loading (RuiButton sets `disabled = disabled || loading`). The
       // color/bg/text overrides for the "grey disabled" look live in the
@@ -37,18 +40,16 @@ export const buttonStyles = tv({
       list: { root: 'p-3 px-3 rounded-none w-full justify-start text-left', label: 'w-full' },
     },
     size: {
-      // Each size variant sets a matching descendant rule so RuiIcons in
-      // button slots (prepend/append/default) inherit a size proportional to
-      // the button's height. The `.rui-icon` class sits on the icon's <svg>
-      // and its `w-6 h-6` default (set by RuiIcon when no size prop is
-      // passed) is overridden here because the descendant selector is more
-      // specific. `!` guarantees size variants beat the md default baked
-      // into the base root regardless of CSS source order. Consumers can
-      // still force a specific icon size by passing the `size` prop on
-      // RuiIcon — that path stamps inline width/height which beats classes.
-      sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5 [&_.rui-icon]:!w-4 [&_.rui-icon]:!h-4' },
-      lg: { root: 'px-6 py-2 text-[1rem] leading-5 [&_.rui-icon]:!w-5 [&_.rui-icon]:!h-5' },
-      xl: { root: 'px-6 py-2.5 text-[1rem] leading-6 [&_.rui-icon]:!w-[1.375rem] [&_.rui-icon]:!h-[1.375rem]' },
+      // Each size variant redefines `--rui-icon-size` on the button so the
+      // value inherits into RuiIcons in button slots (prepend/append/default)
+      // and drives their `width: var(--rui-icon-size, 1.5rem)` class. `!` on
+      // the arbitrary property makes the variant beat the md baseline in the
+      // base root regardless of CSS source order. A consumer passing `size`
+      // on RuiIcon still wins: that path stamps an inline style on the svg
+      // element itself, which beats the inherited value from the button.
+      sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5 ![--rui-icon-size:1rem]' },
+      lg: { root: 'px-6 py-2 text-[1rem] leading-5 ![--rui-icon-size:1.25rem]' },
+      xl: { root: 'px-6 py-2.5 text-[1rem] leading-6 ![--rui-icon-size:1.375rem]' },
     },
     color: {
       grey: { root: 'bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text ring-rui-grey-400 dark:bg-rui-grey-300 dark:text-rui-light-text dark:ring-rui-grey-600' },
@@ -153,10 +154,10 @@ export const buttonStyles = tv({
     // sm:           p-1   + w-5  icon = 0.5  + 1.25 = 1.75rem (28px)
     // lg:           p-1.5 + w-6  icon = 0.75 + 1.5  = 2.25rem (36px)
     // xl:           p-2   + w-7  icon = 1    + 1.75 = 2.75rem (44px)
-    { icon: true, class: { root: 'p-1.5 [&_.rui-icon]:!w-5 [&_.rui-icon]:!h-5' } },
-    { icon: true, size: 'sm', class: { root: 'p-1 [&_.rui-icon]:!w-5 [&_.rui-icon]:!h-5' } },
-    { icon: true, size: 'lg', class: { root: 'p-1.5 [&_.rui-icon]:!w-6 [&_.rui-icon]:!h-6' } },
-    { icon: true, size: 'xl', class: { root: 'p-2 [&_.rui-icon]:!w-7 [&_.rui-icon]:!h-7' } },
+    { icon: true, class: { root: 'p-1.5 ![--rui-icon-size:1.25rem]' } },
+    { icon: true, size: 'sm', class: { root: 'p-1 ![--rui-icon-size:1.25rem]' } },
+    { icon: true, size: 'lg', class: { root: 'p-1.5 ![--rui-icon-size:1.5rem]' } },
+    { icon: true, size: 'xl', class: { root: 'p-2 ![--rui-icon-size:1.75rem]' } },
     { variant: 'fab', icon: true, size: 'sm', class: { root: 'px-2 py-2' } },
   ],
   compoundSlots: [

--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -55,6 +55,26 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.attributes('style')).toContain('--rui-icon-size: 1.25rem');
   });
 
+  it('should coerce a bare-number size string to px', async () => {
+    // `:size="16"` in a template binds as a string; before the fix this
+    // produced `--rui-icon-size: 16` (no unit), an invalid CSS length that
+    // computed to 0 width. Assert the numeric-string path stays px-coerced.
+    wrapper = createWrapper({
+      props: {
+        name: 'lu-circle-arrow-down',
+        size: '16',
+      },
+    });
+    expect(wrapper.attributes('style')).toContain('--rui-icon-size: 16px');
+
+    await wrapper.setProps({ size: '18.5' });
+    expect(wrapper.attributes('style')).toContain('--rui-icon-size: 18.5px');
+
+    // Values that already carry a unit pass through unchanged.
+    await wrapper.setProps({ size: '20px' });
+    expect(wrapper.attributes('style')).toContain('--rui-icon-size: 20px');
+  });
+
   it('should apply color classes', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -32,7 +32,7 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.attributes('aria-hidden')).toBe('true');
   });
 
-  it('should change size via size prop', async () => {
+  it('should drive size via --rui-icon-size inline style when size prop is set', async () => {
     wrapper = createWrapper({
       props: {
         name: 'lu-circle-arrow-down',
@@ -40,12 +40,19 @@ describe('components/icons/RuiIcon.vue', () => {
       },
     });
 
-    expect(wrapper.attributes('width')).toMatch('32');
-    expect(wrapper.attributes('height')).toMatch('32');
+    // Numeric sizes are normalized to px so the custom property has a valid
+    // CSS length for the svg's `width: var(--rui-icon-size, 1.5rem)` class.
+    expect(wrapper.attributes('style')).toContain('--rui-icon-size: 32px');
+    // Presentation attrs are intentionally gone — they had specificity 0 and
+    // lost the cascade inside RuiButton (see rotki/ui-library#512).
+    expect(wrapper.attributes('width')).toBeUndefined();
+    expect(wrapper.attributes('height')).toBeUndefined();
 
     await wrapper.setProps({ size: 48 });
-    expect(wrapper.attributes('width')).toMatch('48');
-    expect(wrapper.attributes('height')).toMatch('48');
+    expect(wrapper.attributes('style')).toContain('--rui-icon-size: 48px');
+
+    await wrapper.setProps({ size: '1.25rem' });
+    expect(wrapper.attributes('style')).toContain('--rui-icon-size: 1.25rem');
   });
 
   it('should apply color classes', async () => {
@@ -65,21 +72,22 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.classes()).toContain('text-rui-error');
   });
 
-  it('should default to w-6/h-6 without inline size attributes', () => {
+  it('should size via --rui-icon-size with a 1.5rem fallback and no inline style', () => {
     wrapper = createWrapper({
       props: {
         name: 'lu-circle-arrow-down',
       },
     });
 
-    // No inline width/height lets parent CSS override the size.
-    expect(wrapper.attributes('width')).toBeUndefined();
-    expect(wrapper.attributes('height')).toBeUndefined();
-    expect(wrapper.classes()).toContain('w-6');
-    expect(wrapper.classes()).toContain('h-6');
+    // No size prop → no inline `--rui-icon-size` → the var() fallback of
+    // 1.5rem drives width/height. A parent (e.g. RuiButton) can still inject
+    // `--rui-icon-size` to shrink the icon in lockstep with its own size.
+    expect(wrapper.attributes('style')).toBeUndefined();
+    expect(wrapper.classes()).toContain('w-[var(--rui-icon-size,1.5rem)]');
+    expect(wrapper.classes()).toContain('h-[var(--rui-icon-size,1.5rem)]');
   });
 
-  it('should drop the default sizing class when size prop is set', () => {
+  it('should keep the var-driven sizing classes when size prop is set', () => {
     wrapper = createWrapper({
       props: {
         name: 'lu-circle-arrow-down',
@@ -87,8 +95,9 @@ describe('components/icons/RuiIcon.vue', () => {
       },
     });
 
-    expect(wrapper.classes()).not.toContain('w-6');
-    expect(wrapper.classes()).not.toContain('h-6');
+    // The classes stay; the size prop just changes the custom property.
+    expect(wrapper.classes()).toContain('w-[var(--rui-icon-size,1.5rem)]');
+    expect(wrapper.classes()).toContain('h-[var(--rui-icon-size,1.5rem)]');
   });
 
   it('should always carry the rui-icon marker class for parent-driven sizing', () => {

--- a/packages/ui-library/src/components/icons/RuiIcon.stories.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.stories.ts
@@ -73,7 +73,7 @@ export const CssSized = meta.story({
     docs: {
       description: {
         story:
-          'When the `size` prop is omitted, the icon falls back to `w-6 h-6` classes. Parents can override via CSS (e.g. wrapping in `<div class="w-4 h-4">` or applying `[&_svg]:w-5` on an ancestor).',
+          'When the `size` prop is omitted, the icon resolves its width/height through `var(--rui-icon-size, 1.5rem)`. A parent (like `RuiButton`) can shrink every icon it contains by setting `--rui-icon-size`; supplying `size` on the icon instead stamps an inline style on the svg, which wins for that icon specifically.',
       },
     },
   },

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -21,6 +21,7 @@ const { registeredIcons } = useIcons();
 type SvgComponent = [tag: string, attrs: Record<string, string>];
 
 const iconStyles = tv({
+  base: 'w-[var(--rui-icon-size,1.5rem)] h-[var(--rui-icon-size,1.5rem)]',
   variants: {
     color: {
       primary: 'text-rui-primary',
@@ -30,18 +31,22 @@ const iconStyles = tv({
       info: 'text-rui-info',
       success: 'text-rui-success',
     },
-    sized: {
-      // When no explicit size prop is set, fall back to Tailwind classes so a
-      // parent (e.g. RuiButton) can override the icon size via CSS without
-      // competing with inline width/height attributes.
-      false: 'w-6 h-6',
-      true: '',
-    },
   },
 });
 
 const hasExplicitSize = computed<boolean>(() => size !== undefined);
-const ui = computed<string>(() => iconStyles({ color, sized: get(hasExplicitSize) }));
+const ui = computed<string>(() => iconStyles({ color }));
+
+// Render the `size` prop as an inline CSS custom property on the svg. Because
+// inline style wins against any inherited value for the same property on this
+// element, the consumer-supplied size beats the button's `--rui-icon-size`
+// assignment without needing !important. Numbers default to pixel units.
+const sizeStyle = computed<Record<string, string> | undefined>(() => {
+  if (!get(hasExplicitSize))
+    return undefined;
+  const value = typeof size === 'number' ? `${size}px` : String(size);
+  return { '--rui-icon-size': value };
+});
 
 const isFill = computed<boolean>(() => name.endsWith('-fill'));
 
@@ -65,8 +70,7 @@ const components = computed<SvgComponent[] | undefined>(() => {
     aria-hidden="true"
     class="rui-icon"
     :class="ui"
-    :height="hasExplicitSize ? size : undefined"
-    :width="hasExplicitSize ? size : undefined"
+    :style="sizeStyle"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -40,11 +40,16 @@ const ui = computed<string>(() => iconStyles({ color }));
 // Render the `size` prop as an inline CSS custom property on the svg. Because
 // inline style wins against any inherited value for the same property on this
 // element, the consumer-supplied size beats the button's `--rui-icon-size`
-// assignment without needing !important. Numbers default to pixel units.
+// assignment without needing !important. A bare number (or numeric string —
+// `:size="16"` resolves to a string in the template binding) is coerced to px;
+// values that already include a unit (`1rem`, `18px`, `calc(...)`) pass
+// through unchanged. The previous SVG-attr path accepted bare numbers because
+// `width`/`height` presentation attrs treat them as px; CSS does not.
 const sizeStyle = computed<Record<string, string> | undefined>(() => {
   if (!get(hasExplicitSize))
     return undefined;
-  const value = typeof size === 'number' ? `${size}px` : String(size);
+  const raw = String(size);
+  const value = /^\d+(?:\.\d+)?$/.test(raw) ? `${raw}px` : raw;
   return { '--rui-icon-size': value };
 });
 


### PR DESCRIPTION
## Summary
- Route icon sizing inside `RuiButton` through a `--rui-icon-size` CSS custom property so a consumer-supplied `size` on `RuiIcon` actually overrides the button-driven glyph size (option (b) from #512).
- Add a new `xs` button size — 20px box, 14px glyph, 70% ratio — targeted at inline copy buttons, badge actions, and other tight affordances where `sm` at 28px still feels heavy (option (c) from #512).
- Visual audit coverage for the list variant (second half of #512) via a new story that stacks sm/md/lg/xl rows with a prepend icon.

Closes #512.

## Why the cascade changed
Before: button used `[&_.rui-icon]:!w-X` descendant rules with (0,2,0) specificity + `!important`, so an `<RuiIcon size="14" />` stamped at specificity-0 SVG attributes always lost — no consumer override was possible without inline `style !important` hacks.

After: button seeds `[--rui-icon-size:<val>]` on its own root (with `!` on size variants so they beat the md base on the same element); `RuiIcon` reads it via `w-[var(--rui-icon-size,1.5rem)]`; when the consumer passes `size`, `RuiIcon` stamps `style="--rui-icon-size: <n>px"` on the svg itself, which wins on that element regardless of any `!important` assignment on an ancestor.

## `xs` size
| size | box | glyph | ratio |
|------|-----|-------|-------|
| xs   | 20px | 14px (icon-only) / 12px (text slot) | 70% |
| sm   | 28  | 20 / 16 | 71% |
| md   | 32  | 20 / 18 | 62% |
| lg   | 36  | 24 / 20 | 67% |
| xl   | 44  | 28 / 22 | 64% |

Text/fab/list compound variants updated so `xs` lines up with the rest of the family.

## Stories
- `AutoSizedIcon`, `IconOnlySizes`, `IconOnlyVsText` — extended to include `xs`, description refreshed to describe the new mechanism.
- `ConsumerIconSizeOverride` (new) — side-by-side of default vs. forced glyph size; nudges consumers toward `xs` for the common tiny-button case.
- `ListVariantWithIcons` (new) — stacked sm/md/lg/xl rows with a prepend icon + a row with a forced 12px glyph, for the list-variant alignment audit.
- `RuiIcon.stories.ts::CssSized` description rewritten to explain the custom-property contract.

## Test plan
- [x] `pnpm test` — 1040/1040 pass (+13 new specs)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — clean on package + example app
- [x] `pnpm build:tailwind` — verified the new arbitrary classes compile (`--rui-icon-size:0.75rem`, `0.875rem`, `1rem`, `1.125rem`, `1.25rem`, `1.375rem`, `1.5rem`, `1.75rem`)
- [ ] Visual pass through the updated stories in Storybook (reviewer)
- [ ] Confirm text baselines center cleanly in `ListVariantWithIcons` across sizes