### PR TITLE
feat(button)!: shift xl to 40px for input-row parity, add 2xl at 44px

### DIFF
--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
@@ -76,7 +76,12 @@ describe('components/buttons/button-group/RuiButtonGroup.vue', () => {
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
     expect(wrapper.find('button').classes()).toContain('text-[1rem]');
+    // xl now targets the 40px input-row height (py-2 + leading-6 = 40).
     await wrapper.setProps({ size: 'xl' });
+    expectWrapperToHaveClass(wrapper, 'button', /py-2(?!\.5)/);
+    expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
+    // 2xl keeps the previous xl geometry at 44px.
+    await wrapper.setProps({ size: '2xl' });
     expectWrapperToHaveClass(wrapper, 'button', /py-2\.5/);
     expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
   });

--- a/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.spec.ts
@@ -109,7 +109,13 @@ describe('components/buttons/button/RuiButton.vue', () => {
     expectWrapperToHaveClass(wrapper, 'button', /py-1/);
     await wrapper.setProps({ size: 'lg' });
     expect(wrapper.find('button').classes()).toContain('text-[1rem]');
+    // xl now targets 40px (input-row height): py-2 (16) + leading-6 (24) = 40.
     await wrapper.setProps({ size: 'xl' });
+    expect(wrapper.find('button').classes()).toContain('text-[1rem]');
+    expect(wrapper.find('button').classes()).toContain('py-2');
+    expect(wrapper.find('button').classes()).toContain('leading-6');
+    // 2xl keeps the previous xl geometry at 44px (py-2.5 + leading-6).
+    await wrapper.setProps({ size: '2xl' });
     expect(wrapper.find('button').classes()).toContain('text-[1rem]');
     expectWrapperToHaveClass(wrapper, 'button', /py-2\.5/);
     expectWrapperToHaveClass(wrapper, 'button', /leading-6/);
@@ -129,7 +135,13 @@ describe('components/buttons/button/RuiButton.vue', () => {
     await wrapper.setProps({ size: 'lg' });
     expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.25rem]');
 
+    // xl and 2xl share the same text-slot glyph (1.375rem) — they differ only
+    // in box height (40 vs 44). The glyph weight stays identical so a row of
+    // xl+2xl buttons doesn't shift in icon weight when heights differ.
     await wrapper.setProps({ size: 'xl' });
+    expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.375rem]');
+
+    await wrapper.setProps({ size: '2xl' });
     expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.375rem]');
   });
 
@@ -140,8 +152,14 @@ describe('components/buttons/button/RuiButton.vue', () => {
   // passing `size` on RuiIcon stamps an inline style on the svg, which
   // overrides the inherited value without needing !important.
   describe('icon size cascade inside button (issue #512)', () => {
-    const perSize = { xs: '![--rui-icon-size:0.75rem]', sm: '![--rui-icon-size:1rem]', lg: '![--rui-icon-size:1.25rem]', xl: '![--rui-icon-size:1.375rem]' } as const;
-    for (const size of ['xs', 'sm', 'lg', 'xl'] as const) {
+    const perSize = {
+      'xs': '![--rui-icon-size:0.75rem]',
+      'sm': '![--rui-icon-size:1rem]',
+      'lg': '![--rui-icon-size:1.25rem]',
+      'xl': '![--rui-icon-size:1.375rem]',
+      '2xl': '![--rui-icon-size:1.375rem]',
+    } as const;
+    for (const size of ['xs', 'sm', 'lg', 'xl', '2xl'] as const) {
       it(`should attach ${perSize[size]} when size is ${size}`, () => {
         wrapper = createWrapper({
           props: { size },
@@ -213,8 +231,15 @@ describe('components/buttons/button/RuiButton.vue', () => {
       await wrapper.setProps({ size: 'lg' });
       expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.5rem]');
 
+      // xl icon-only lands at 40px (p-2 + 1.5rem = 40) with a 60% icon ratio.
       await wrapper.setProps({ size: 'xl' });
+      expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.5rem]');
+      expect(wrapper.find('button').classes()).toContain('p-2');
+
+      // 2xl icon-only keeps the 44px box (p-2 + 1.75rem = 44), 64% ratio.
+      await wrapper.setProps({ size: '2xl' });
       expect(wrapper.find('button').classes()).toContain('![--rui-icon-size:1.75rem]');
+      expect(wrapper.find('button').classes()).toContain('p-2');
     });
   });
 

--- a/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
+++ b/packages/ui-library/src/components/buttons/button/RuiButton.stories.ts
@@ -1,6 +1,7 @@
 import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
 import { expect } from 'storybook/test';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import RuiTextField from '@/components/forms/text-field/RuiTextField.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { contextColors } from '@/consts/colors';
 import preview from '~/.storybook/preview';
@@ -33,7 +34,10 @@ const meta = preview.meta({
     label: { control: 'text' },
     loading: { control: 'boolean', table: { category: 'State' } },
     rounded: { control: 'boolean', table: { category: 'Shape' } },
-    size: { control: 'select', options: ['medium', 'xs', 'sm', 'lg', 'xl'] },
+    // `md` is the default and is represented by an unset `size` — clear the
+    // control to see it. The enum intentionally omits `md`; ButtonSize only
+    // lists the opt-in deltas.
+    size: { control: 'select', options: ['xs', 'sm', 'lg', 'xl', '2xl'] },
     type: { control: 'select', options: ['button', 'submit'] },
     variant: {
       control: 'select',
@@ -118,6 +122,14 @@ export const PrimaryExtraLarge = meta.story({
   },
 });
 
+export const Primary2xl = meta.story({
+  args: {
+    color: 'primary',
+    label: '2× Extra Large',
+    size: '2xl',
+  },
+});
+
 export const AutoSizedIcon = meta.story({
   args: {
     color: 'primary',
@@ -127,7 +139,7 @@ export const AutoSizedIcon = meta.story({
     docs: {
       description: {
         story:
-          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (xs → 0.75rem, sm → 1rem, md → 1.125rem, lg → 1.25rem, xl → 1.375rem). Sizing flows through the `--rui-icon-size` custom property: the button seeds it per size variant, and the icon reads it via `width: var(--rui-icon-size, 1.5rem)`. A consumer passing `size` on `<RuiIcon>` still wins because that path stamps an inline style on the svg itself (see `ConsumerIconSizeOverride`).',
+          'When `<RuiIcon>` is used inside a button without an explicit `size` prop, it inherits a size proportional to the button height (xs → 0.75rem, sm → 1rem, md → 1.125rem, lg → 1.25rem, xl & 2xl → 1.375rem). Sizing flows through the `--rui-icon-size` custom property: the button seeds it per size variant, and the icon reads it via `width: var(--rui-icon-size, 1.5rem)`. A consumer passing `size` on `<RuiIcon>` still wins because that path stamps an inline style on the svg itself (see `ConsumerIconSizeOverride`). `xl` and `2xl` share the same glyph weight — `xl` targets the 40px input-row height; `2xl` keeps the previous 44px for jumbo CTAs.',
       },
     },
   },
@@ -156,7 +168,11 @@ export const AutoSizedIcon = meta.story({
         </RuiButton>
         <RuiButton v-bind="args" size="xl">
           <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
-          Extra Large
+          Extra Large (40)
+        </RuiButton>
+        <RuiButton v-bind="args" size="2xl">
+          <template #prepend><RuiIcon name="lu-refresh-ccw" /></template>
+          2× Extra Large (44)
         </RuiButton>
       </div>
     `,
@@ -172,7 +188,7 @@ export const IconOnlySizes = meta.story({
     docs: {
       description: {
         story:
-          'Icon-only buttons (`icon` prop) land at the same height as text buttons of the matching `size` (xs 20px, sm 28px, md 32px, lg 36px, xl 44px) with a ~60–70% icon-to-box ratio. `xs` is aimed at inline contexts like copy buttons or badge actions where a 28px `sm` would still feel heavy.',
+          'Icon-only buttons (`icon` prop) land at the same height as text buttons of the matching `size` (xs 20px, sm 28px, md 32px, lg 36px, xl 40px, 2xl 44px) with a ~60–70% icon-to-box ratio. `xs` is aimed at inline contexts like copy buttons or badge actions; `xl` lines up with RuiTextField / RuiMenuSelect at the 40px input height; `2xl` is for jumbo CTAs that used to land on the old 44px `xl`.',
       },
     },
   },
@@ -196,6 +212,9 @@ export const IconOnlySizes = meta.story({
           <RuiIcon name="lu-settings" />
         </RuiButton>
         <RuiButton v-bind="args" icon size="xl" aria-label="extra large">
+          <RuiIcon name="lu-settings" />
+        </RuiButton>
+        <RuiButton v-bind="args" icon size="2xl" aria-label="two extra large">
           <RuiIcon name="lu-settings" />
         </RuiButton>
       </div>
@@ -247,11 +266,55 @@ export const IconOnlyVsText = meta.story({
           </RuiButton>
         </div>
         <div class="flex items-center gap-3">
-          <RuiButton v-bind="args" size="xl">Extra Large</RuiButton>
+          <RuiButton v-bind="args" size="xl">Extra Large (40)</RuiButton>
           <RuiButton v-bind="args" variant="text" icon size="xl" aria-label="xl icon">
             <RuiIcon name="lu-ellipsis-vertical" />
           </RuiButton>
         </div>
+        <div class="flex items-center gap-3">
+          <RuiButton v-bind="args" size="2xl">2× Extra Large (44)</RuiButton>
+          <RuiButton v-bind="args" variant="text" icon size="2xl" aria-label="2xl icon">
+            <RuiIcon name="lu-ellipsis-vertical" />
+          </RuiButton>
+        </div>
+      </div>
+    `,
+  }),
+});
+
+export const XlMatchesInputHeight = meta.story({
+  args: {
+    color: 'primary',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`size="xl"` is tuned to the 40px input-row height so buttons line up with `<RuiTextField>` / `<RuiMenuSelect>` in a toolbar without ad-hoc `class="!h-10"` workarounds. Combine it with `size="md"` or `"lg"` elsewhere in the app; reach for `2xl` only when you need a 44px jumbo CTA.',
+      },
+    },
+  },
+  render: args => ({
+    components: { RuiButton, RuiIcon, RuiTextField },
+    setup() {
+      return { args };
+    },
+    template: `
+      <div class="flex items-center gap-3">
+        <RuiTextField
+          placeholder="Search"
+          variant="outlined"
+          color="primary"
+          dense
+          hide-details
+        />
+        <RuiButton v-bind="args" size="xl" icon aria-label="filter">
+          <RuiIcon name="lu-funnel" />
+        </RuiButton>
+        <RuiButton v-bind="args" size="xl">
+          <template #prepend><RuiIcon name="lu-file-down" /></template>
+          Export
+        </RuiButton>
       </div>
     `,
   }),

--- a/packages/ui-library/src/components/buttons/button/button-props.ts
+++ b/packages/ui-library/src/components/buttons/button/button-props.ts
@@ -9,15 +9,16 @@ export const ButtonVariant = {
 export type ButtonVariant = (typeof ButtonVariant)[keyof typeof ButtonVariant];
 
 export const ButtonSize = {
-  xs: 'xs',
-  sm: 'sm',
-  lg: 'lg',
-  xl: 'xl',
+  'xs': 'xs',
+  'sm': 'sm',
+  'lg': 'lg',
+  'xl': 'xl',
+  '2xl': '2xl',
 } as const;
 
 export type ButtonSize = (typeof ButtonSize)[keyof typeof ButtonSize];
 
-const SPINNER_SIZES: Record<string, number> = { xs: 12, sm: 18, lg: 26, xl: 28 };
+const SPINNER_SIZES: Record<string, number> = { 'xs': 12, 'sm': 18, 'lg': 26, 'xl': 26, '2xl': 28 };
 const DEFAULT_SPINNER_SIZE = 22;
 
 export const FAB_DEFAULT_ELEVATION = 6;

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -47,10 +47,15 @@ export const buttonStyles = tv({
       // base root regardless of CSS source order. A consumer passing `size`
       // on RuiIcon still wins: that path stamps an inline style on the svg
       // element itself, which beats the inherited value from the button.
-      xs: { root: 'px-2 py-[0.125rem] text-[.75rem] leading-4 ![--rui-icon-size:0.75rem]' },
-      sm: { root: 'px-2.5 py-1 text-[.8125rem] leading-5 ![--rui-icon-size:1rem]' },
-      lg: { root: 'px-6 py-2 text-[1rem] leading-5 ![--rui-icon-size:1.25rem]' },
-      xl: { root: 'px-6 py-2.5 text-[1rem] leading-6 ![--rui-icon-size:1.375rem]' },
+      'xs': { root: 'px-2 py-[0.125rem] text-[.75rem] leading-4 ![--rui-icon-size:0.75rem]' },
+      'sm': { root: 'px-2.5 py-1 text-[.8125rem] leading-5 ![--rui-icon-size:1rem]' },
+      'lg': { root: 'px-6 py-2 text-[1rem] leading-5 ![--rui-icon-size:1.25rem]' },
+      // `xl` targets the 40px input height — the common toolbar case where a
+      // RuiButton needs to line up with RuiTextField / RuiMenuSelect. For a
+      // 44px jumbo-CTA button (auth screens, empty-state primaries), reach for
+      // `2xl` instead.
+      'xl': { root: 'px-6 py-2 text-[1rem] leading-6 ![--rui-icon-size:1.375rem]' },
+      '2xl': { root: 'px-6 py-2.5 text-[1rem] leading-6 ![--rui-icon-size:1.375rem]' },
     },
     color: {
       grey: { root: 'bg-rui-grey-200 hover:bg-rui-grey-100 active:bg-rui-grey-50 text-rui-text ring-rui-grey-400 dark:bg-rui-grey-300 dark:text-rui-light-text dark:ring-rui-grey-600' },
@@ -139,6 +144,8 @@ export const buttonStyles = tv({
     { variant: 'text', size: 'xs', class: { root: 'px-1' } },
     { variant: 'text', size: 'sm', class: { root: 'px-1.5' } },
     { variant: 'text', size: 'lg', class: { root: 'px-2.5' } },
+    { variant: 'text', size: 'xl', class: { root: 'px-2.5' } },
+    { variant: 'text', size: '2xl', class: { root: 'px-2.5' } },
     { variant: 'fab', size: 'xs', class: { root: 'py-1 px-1' } },
     { variant: 'fab', size: 'sm', class: { root: 'py-1.5 px-2' } },
     { variant: 'fab', size: 'lg', class: { root: 'py-3' } },
@@ -153,16 +160,18 @@ export const buttonStyles = tv({
     // xs uses an arbitrary 0.1875rem (3px) padding — no Tailwind token hits
     // it cleanly — to keep the 70% icon ratio with a 14px glyph.
     //
-    // xs:           p-[0.1875rem] + 0.875rem icon = 0.375 + 0.875 = 1.25rem (20px) — 70% ratio
-    // sm:           p-1           + 1.25rem icon  = 0.5   + 1.25  = 1.75rem (28px)
-    // md (default): p-1.5         + 1.25rem icon  = 0.75  + 1.25  = 2rem    (32px)
-    // lg:           p-1.5         + 1.5rem icon   = 0.75  + 1.5   = 2.25rem (36px)
-    // xl:           p-2           + 1.75rem icon  = 1     + 1.75  = 2.75rem (44px)
+    // xs:           p-[0.1875rem] + 0.875rem icon = 0.375 + 0.875 = 1.25rem (20px) — 70%
+    // sm:           p-1           + 1.25rem icon  = 0.5   + 1.25  = 1.75rem (28px) — 71%
+    // md (default): p-1.5         + 1.25rem icon  = 0.75  + 1.25  = 2rem    (32px) — 63%
+    // lg:           p-1.5         + 1.5rem  icon  = 0.75  + 1.5   = 2.25rem (36px) — 67%
+    // xl:           p-2           + 1.5rem  icon  = 1     + 1.5   = 2.5rem  (40px) — 60%
+    // 2xl:          p-2           + 1.75rem icon  = 1     + 1.75  = 2.75rem (44px) — 64%
     { icon: true, class: { root: 'p-1.5 ![--rui-icon-size:1.25rem]' } },
     { icon: true, size: 'xs', class: { root: 'p-[0.1875rem] ![--rui-icon-size:0.875rem]' } },
     { icon: true, size: 'sm', class: { root: 'p-1 ![--rui-icon-size:1.25rem]' } },
     { icon: true, size: 'lg', class: { root: 'p-1.5 ![--rui-icon-size:1.5rem]' } },
-    { icon: true, size: 'xl', class: { root: 'p-2 ![--rui-icon-size:1.75rem]' } },
+    { icon: true, size: 'xl', class: { root: 'p-2 ![--rui-icon-size:1.5rem]' } },
+    { icon: true, size: '2xl', class: { root: 'p-2 ![--rui-icon-size:1.75rem]' } },
     { variant: 'fab', icon: true, size: 'sm', class: { root: 'px-2 py-2' } },
   ],
   compoundSlots: [


### PR DESCRIPTION
## Summary
- Move `xl` from 44px → **40px** so it matches the 40px height of `RuiTextField` / `RuiMenuSelect`. Consumers can now use `size=\"xl\"` in toolbars instead of `class=\"!h-10\"` hacks.
- Add a new `2xl` at 44px for jumbo-CTA cases (auth, onboarding, empty-state primaries) that used to rely on the old xl.
- `xl` and `2xl` share the same 1.375rem text-slot glyph — only box heights differ.

## Why
Scan of the `rotki` app surfaced 47 files with inconsistent button heights in toolbars. The common root cause: there was no button preset at 40px, so contributors reached for `!h-10` / `h-9` / `!p-2` escape hatches. A [recent cleanup plan](https://github.com/rotki/ui-library/issues/512#issuecomment-…) even mapped \`!h-10 → size=\"xl\"\`, assuming xl was 40px — it wasn't, which is why `xl` call sites in rotki-app are currently off-size.

## Blast radius
- **0** internal ui-library call sites of `xl`.
- **2** call sites in `rotki/rotki` (both authored expecting 40px — they auto-correct after this lands).
- **0** call sites in `rotki/rotki.com`.

A minor version bump covers the BREAKING CHANGE on the `xl` token.

## New size ladder
| size | box | icon-only glyph | text-slot glyph |
|------|-----|-----------------|-----------------|
| xs   | 20  | 14              | 12              |
| sm   | 28  | 20              | 16              |
| md   | 32  | 20              | 18              |
| lg   | 36  | 24              | 20              |
| **xl** | **40** (was 44) | **24** (was 28) | **22** (unchanged, 1.375rem) |
| **2xl** | **44** (new) | 28 | 22 |

## Test plan
- [x] `pnpm test` — 1042/1042 pass (updated RuiButton + RuiButtonGroup specs for xl/2xl).
- [x] `pnpm lint` — 0 errors.
- [x] `pnpm typecheck` — clean on package + example app.
- [x] `pnpm build:prod` — dist regenerated cleanly.
- [ ] Visual review in Storybook:
  - `Button / AutoSizedIcon` — text buttons across all six sizes.
  - `Button / IconOnlySizes` — icon-only buttons across all six sizes.
  - `Button / IconOnlyVsText` — text vs icon-only at the same size, rows stack cleanly.
  - `Button / XlMatchesInputHeight` (new) — xl button paired with a 40px RuiTextField, heights line up.
  - `Button / Primary2xl` (new).