### PR TITLE
feat(avatar): add RuiAvatar and RuiAvatarGroup components

### DIFF
--- a/apps/example/e2e/avatar.spec.ts
+++ b/apps/example/e2e/avatar.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('avatars', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/avatars');
+  });
+
+  test('renders image avatar', async ({ page }) => {
+    await expect(page.locator('h2[data-id=avatars]')).toContainText('Avatars');
+
+    const avatar = page.getByTestId('avatar-image-lg');
+    await expect(avatar).toBeVisible();
+    await expect(avatar.locator('img')).toHaveAttribute('src', /.+/);
+  });
+
+  test('renders initials fallback at each size', async ({ page }) => {
+    for (const size of ['xs', 'sm', 'md', 'lg', 'xl', '2xl']) {
+      const avatar = page.getByTestId(`avatar-initials-${size}`);
+      await expect(avatar).toBeVisible();
+      await expect(avatar).toContainText('AL');
+    }
+  });
+
+  test('renders icon fallback', async ({ page }) => {
+    const avatar = page.getByTestId('avatar-icon-md');
+    await expect(avatar).toBeVisible();
+    await expect(avatar.locator('svg')).toBeVisible();
+  });
+
+  test('broken image falls back to initials', async ({ page }) => {
+    const avatar = page.getByTestId('avatar-broken');
+    await expect(avatar).toBeVisible();
+    await expect(avatar).toContainText('GH');
+    await expect(avatar.locator('img')).toHaveCount(0);
+  });
+
+  test('applies variant and color data attributes', async ({ page }) => {
+    await expect(page.getByTestId('avatar-variant-circular')).toHaveAttribute('data-variant', 'circular');
+    await expect(page.getByTestId('avatar-variant-rounded')).toHaveAttribute('data-variant', 'rounded');
+    await expect(page.getByTestId('avatar-variant-square')).toHaveAttribute('data-variant', 'square');
+    await expect(page.getByTestId('avatar-color-primary')).toHaveAttribute('data-color', 'primary');
+    await expect(page.getByTestId('avatar-color-success')).toHaveAttribute('data-color', 'success');
+  });
+
+  test('connection indicator dot renders via RuiBadge wrapper', async ({ page }) => {
+    const online = page.getByTestId('avatar-online');
+    await expect(online).toBeVisible();
+    // The RuiBadge dot is rendered as a sibling status element within the wrapper.
+    const wrapper = online.locator('xpath=..');
+    await expect(wrapper.locator('[role=status][data-dot=true]')).toBeVisible();
+  });
+
+  test('group renders visible avatars plus surplus', async ({ page }) => {
+    const group = page.getByTestId('avatar-group-max');
+    await expect(group).toBeVisible();
+    const surplus = group.getByTestId('avatar-group-surplus');
+    await expect(surplus).toBeVisible();
+    await expect(surplus).toContainText('+2');
+  });
+
+  test('group with total prop overrides surplus', async ({ page }) => {
+    const group = page.getByTestId('avatar-group-total');
+    const surplus = group.getByTestId('avatar-group-surplus');
+    await expect(surplus).toContainText('+39');
+  });
+
+  test('group injects size into children', async ({ page }) => {
+    const group = page.getByTestId('avatar-group-max');
+    const firstChild = group.locator('[data-id=avatar-root]').first();
+    await expect(firstChild).toHaveAttribute('data-size', 'lg');
+  });
+
+  test('avatar root is not focusable by default', async ({ page }) => {
+    const avatar = page.getByTestId('avatar-initials-md');
+    const tabindex = await avatar.getAttribute('tabindex');
+    expect(tabindex).toBeNull();
+  });
+});

--- a/apps/example/src/App.vue
+++ b/apps/example/src/App.vue
@@ -32,6 +32,7 @@ const navigation = ref([
       { to: '/dividers', title: 'Dividers' },
       { to: '/cards', title: 'Cards' },
       { to: '/tabs', title: 'Tabs' },
+      { to: '/avatars', title: 'Avatars' },
       { to: '/badges', title: 'Badges' },
       { to: '/accordions', title: 'Accordions' },
       { to: '/dialogs', title: 'Dialogs' },

--- a/apps/example/src/pages/avatars.vue
+++ b/apps/example/src/pages/avatars.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import AvatarView from '@/views/AvatarView.vue';
+</script>
+
+<template>
+  <AvatarView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -104,6 +104,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/avatars': RouteRecordInfo<
+      '/avatars',
+      '/avatars',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/badges': RouteRecordInfo<
       '/badges',
       '/badges',
@@ -474,6 +481,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/auto-completes/selection.vue': {
       routes:
         | '/auto-completes/selection'
+      views:
+        | never
+    }
+    'src/pages/avatars.vue': {
+      routes:
+        | '/avatars'
       views:
         | never
     }

--- a/apps/example/src/views/AvatarView.vue
+++ b/apps/example/src/views/AvatarView.vue
@@ -1,0 +1,234 @@
+<script lang="ts" setup>
+import {
+  RuiAvatar,
+  RuiAvatarGroup,
+  RuiBadge,
+} from '@rotki/ui-library/components';
+import ComponentView from '@/components/ComponentView.vue';
+
+const sizes = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const;
+const variants = ['circular', 'rounded', 'square'] as const;
+const colors = ['default', 'primary', 'secondary', 'error', 'warning', 'info', 'success'] as const;
+</script>
+
+<template>
+  <ComponentView data-id="avatars">
+    <template #title>
+      Avatars
+    </template>
+
+    <div class="space-y-10">
+      <section>
+        <h3 class="text-h6 mb-4">
+          Image
+        </h3>
+        <div class="flex items-end gap-6">
+          <RuiAvatar
+            v-for="s in sizes"
+            :key="s"
+            :size="s"
+            :data-id="`avatar-image-${s}`"
+            src="https://avatars.githubusercontent.com/u/3921489"
+            alt="Avatar image"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Initials fallback
+        </h3>
+        <div class="flex items-end gap-6">
+          <RuiAvatar
+            v-for="s in sizes"
+            :key="s"
+            :size="s"
+            :data-id="`avatar-initials-${s}`"
+            text="Ada Lovelace"
+            alt="Ada Lovelace"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Icon fallback
+        </h3>
+        <div class="flex items-end gap-6">
+          <RuiAvatar
+            v-for="s in sizes"
+            :key="s"
+            :size="s"
+            :data-id="`avatar-icon-${s}`"
+            icon="lu-user"
+            alt="User"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Broken image falls back to initials
+        </h3>
+        <RuiAvatar
+          data-id="avatar-broken"
+          src="https://example.invalid/missing.png"
+          text="Grace Hopper"
+          alt="Grace Hopper"
+          size="lg"
+        />
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Variants
+        </h3>
+        <div class="flex items-center gap-6">
+          <RuiAvatar
+            v-for="v in variants"
+            :key="v"
+            :variant="v"
+            :data-id="`avatar-variant-${v}`"
+            text="AL"
+            size="lg"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Colors
+        </h3>
+        <div class="flex flex-wrap items-center gap-4">
+          <RuiAvatar
+            v-for="c in colors"
+            :key="c"
+            :color="c"
+            :data-id="`avatar-color-${c}`"
+            text="AL"
+          />
+        </div>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          With connection indicator (wrapped in RuiBadge)
+        </h3>
+        <div class="flex items-center gap-8">
+          <RuiBadge
+            dot
+            color="success"
+            placement="bottom"
+            :offset-x="-2"
+            :offset-y="-2"
+          >
+            <RuiAvatar
+              text="AL"
+              size="lg"
+              data-id="avatar-online"
+            />
+          </RuiBadge>
+          <RuiBadge
+            dot
+            color="warning"
+            placement="bottom"
+            :offset-x="-2"
+            :offset-y="-2"
+          >
+            <RuiAvatar
+              text="JS"
+              size="lg"
+              color="primary"
+              data-id="avatar-away"
+            />
+          </RuiBadge>
+          <RuiBadge
+            dot
+            color="error"
+            placement="bottom"
+            :offset-x="-2"
+            :offset-y="-2"
+          >
+            <RuiAvatar
+              icon="lu-user"
+              size="lg"
+              color="secondary"
+              data-id="avatar-offline"
+            />
+          </RuiBadge>
+        </div>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Group
+        </h3>
+        <RuiAvatarGroup data-id="avatar-group-basic">
+          <RuiAvatar text="Ada Lovelace" />
+          <RuiAvatar
+            text="Grace Hopper"
+            color="primary"
+          />
+          <RuiAvatar
+            text="Linus Torvalds"
+            color="secondary"
+          />
+        </RuiAvatarGroup>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Group with max (+surplus)
+        </h3>
+        <RuiAvatarGroup
+          :max="3"
+          size="lg"
+          data-id="avatar-group-max"
+        >
+          <RuiAvatar text="Ada Lovelace" />
+          <RuiAvatar
+            text="Grace Hopper"
+            color="primary"
+          />
+          <RuiAvatar
+            text="Linus Torvalds"
+            color="secondary"
+          />
+          <RuiAvatar
+            text="Margaret Hamilton"
+            color="success"
+          />
+          <RuiAvatar
+            text="Donald Knuth"
+            color="warning"
+          />
+        </RuiAvatarGroup>
+      </section>
+
+      <section>
+        <h3 class="text-h6 mb-4">
+          Group with total override
+        </h3>
+        <RuiAvatarGroup
+          :max="3"
+          :total="42"
+          data-id="avatar-group-total"
+        >
+          <RuiAvatar text="Ada" />
+          <RuiAvatar
+            text="Grace"
+            color="primary"
+          />
+          <RuiAvatar
+            text="Linus"
+            color="secondary"
+          />
+          <RuiAvatar
+            text="Margaret"
+            color="success"
+          />
+        </RuiAvatarGroup>
+      </section>
+    </div>
+  </ComponentView>
+</template>

--- a/packages/ui-library/src/components/avatars/RuiAvatar.spec.ts
+++ b/packages/ui-library/src/components/avatars/RuiAvatar.spec.ts
@@ -1,0 +1,159 @@
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiAvatar from '@/components/avatars/RuiAvatar.vue';
+
+function createWrapper(
+  options?: ComponentMountingOptions<typeof RuiAvatar>,
+): VueWrapper<InstanceType<typeof RuiAvatar>> {
+  return mount(RuiAvatar, options);
+}
+
+describe('components/avatars/RuiAvatar.vue', () => {
+  let wrapper: VueWrapper<InstanceType<typeof RuiAvatar>>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders <img> when src is provided', () => {
+    wrapper = createWrapper({
+      props: { src: 'https://example.com/a.png', alt: 'Ada' },
+    });
+
+    const img = wrapper.find('img[data-id="avatar-image"]');
+    expect(img.exists()).toBeTruthy();
+    expect(img.attributes('src')).toBe('https://example.com/a.png');
+    expect(img.attributes('alt')).toBe('Ada');
+    expect(img.attributes('loading')).toBe('lazy');
+  });
+
+  it('emits load when image loads', async () => {
+    wrapper = createWrapper({ props: { src: 'https://example.com/a.png' } });
+    await wrapper.find('img').trigger('load');
+    expect(wrapper.emitted('load')).toBeTruthy();
+  });
+
+  it('falls back to initials on image error', async () => {
+    wrapper = createWrapper({
+      props: { src: 'https://example.com/a.png', text: 'Ada Lovelace' },
+    });
+    await wrapper.find('img').trigger('error');
+
+    expect(wrapper.emitted('error')).toBeTruthy();
+    expect(wrapper.find('img').exists()).toBeFalsy();
+    const initials = wrapper.find('[data-id="avatar-initials"]');
+    expect(initials.exists()).toBeTruthy();
+    expect(initials.text()).toBe('AL');
+  });
+
+  it('resets error state when src changes', async () => {
+    wrapper = createWrapper({
+      props: { src: 'https://example.com/a.png', text: 'Ada' },
+    });
+    await wrapper.find('img').trigger('error');
+    expect(wrapper.find('img').exists()).toBeFalsy();
+
+    await wrapper.setProps({ src: 'https://example.com/b.png' });
+    expect(wrapper.find('img').exists()).toBeTruthy();
+  });
+
+  it('derives initials from alt when text missing', () => {
+    wrapper = createWrapper({ props: { alt: 'Grace Hopper' } });
+    expect(wrapper.find('[data-id="avatar-initials"]').text()).toBe('GH');
+  });
+
+  it('handles single-word name initials', () => {
+    wrapper = createWrapper({ props: { text: 'kelsos' } });
+    expect(wrapper.find('[data-id="avatar-initials"]').text()).toBe('K');
+  });
+
+  it('trims initials to max 2 characters', () => {
+    wrapper = createWrapper({ props: { text: 'Ada Lovelace Turing' } });
+    expect(wrapper.find('[data-id="avatar-initials"]').text()).toBe('AL');
+  });
+
+  it('uses default slot over initials/icon', () => {
+    wrapper = createWrapper({
+      props: { text: 'AL', icon: 'lu-user' },
+      slots: { default: '<span data-test="custom">custom</span>' },
+    });
+    expect(wrapper.find('[data-test="custom"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="avatar-initials"]').exists()).toBeFalsy();
+  });
+
+  it('renders icon when no image or slot', () => {
+    wrapper = createWrapper({ props: { alt: '', icon: 'lu-user' } });
+    expect(wrapper.find('[data-id="avatar-icon"]').exists()).toBeTruthy();
+  });
+
+  it('icon wins over initials when both provided', () => {
+    wrapper = createWrapper({ props: { text: 'Ada', icon: 'lu-user' } });
+    expect(wrapper.find('[data-id="avatar-icon"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id="avatar-initials"]').exists()).toBeFalsy();
+  });
+
+  it('applies variant classes', async () => {
+    wrapper = createWrapper({ props: { variant: 'circular', text: 'A' } });
+    expect(wrapper.find('[data-id="avatar-root"]').classes()).toContain('rounded-full');
+
+    await wrapper.setProps({ variant: 'rounded' });
+    expect(wrapper.find('[data-id="avatar-root"]').classes()).toContain('rounded-md');
+
+    await wrapper.setProps({ variant: 'square' });
+    expect(wrapper.find('[data-id="avatar-root"]').classes()).toContain('rounded-none');
+  });
+
+  it('applies color classes', async () => {
+    wrapper = createWrapper({ props: { text: 'A', color: 'primary' } });
+    expect(wrapper.find('[data-id="avatar-root"]').classes()).toContain('bg-rui-primary');
+
+    await wrapper.setProps({ color: 'success' });
+    expect(wrapper.find('[data-id="avatar-root"]').classes()).toContain('bg-rui-success');
+  });
+
+  it('applies token size as inline dimensions', () => {
+    wrapper = createWrapper({ props: { text: 'A', size: 'lg' } });
+    const style = wrapper.find('[data-id="avatar-root"]').attributes('style') ?? '';
+    expect(style).toContain('width: 40px');
+    expect(style).toContain('height: 40px');
+  });
+
+  it('applies numeric size as inline dimensions', () => {
+    wrapper = createWrapper({ props: { text: 'A', size: 56 } });
+    const style = wrapper.find('[data-id="avatar-root"]').attributes('style') ?? '';
+    expect(style).toContain('width: 56px');
+    expect(style).toContain('height: 56px');
+  });
+
+  it('sets role=img with aria-label on fallback', () => {
+    wrapper = createWrapper({ props: { text: 'Ada', alt: 'Ada' } });
+    const root = wrapper.find('[data-id="avatar-root"]');
+    expect(root.attributes('role')).toBe('img');
+    expect(root.attributes('aria-label')).toBe('Ada');
+  });
+
+  it('treats empty alt as decorative', () => {
+    wrapper = createWrapper({ props: { icon: 'lu-user', alt: '' } });
+    const root = wrapper.find('[data-id="avatar-root"]');
+    expect(root.attributes('aria-label')).toBeUndefined();
+  });
+
+  it('omits role=img when showing an image', () => {
+    wrapper = createWrapper({ props: { src: 'https://example.com/a.png', alt: 'Ada' } });
+    expect(wrapper.find('[data-id="avatar-root"]').attributes('role')).toBeUndefined();
+  });
+
+  it('marks fallback aria-hidden', async () => {
+    wrapper = createWrapper({ props: { src: 'https://example.com/a.png', text: 'Ada' } });
+    await wrapper.find('img').trigger('error');
+    const fallback = wrapper.find('[data-id="avatar-fallback"]');
+    expect(fallback.attributes('aria-hidden')).toBe('true');
+  });
+
+  it('renders placeholder when nothing is resolvable', () => {
+    wrapper = createWrapper({ props: { alt: '' } });
+    expect(wrapper.find('[data-id="avatar-initials"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-id="avatar-icon"]').exists()).toBeFalsy();
+    expect(wrapper.find('[data-id="avatar-fallback"]').exists()).toBeTruthy();
+  });
+});

--- a/packages/ui-library/src/components/avatars/RuiAvatar.stories.ts
+++ b/packages/ui-library/src/components/avatars/RuiAvatar.stories.ts
@@ -1,0 +1,145 @@
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiAvatar from '@/components/avatars/RuiAvatar.vue';
+import RuiBadge from '@/components/overlays/badge/RuiBadge.vue';
+import { contextColors } from '@/consts/colors';
+import { RuiIcons } from '@/icons';
+import preview from '~/.storybook/preview';
+
+type AvatarStoryArgs = ComponentPropsAndSlots<typeof RuiAvatar>;
+
+function render(args: AvatarStoryArgs) {
+  return {
+    components: { RuiAvatar },
+    setup: () => ({ args }),
+    template: `
+      <div class="p-8">
+        <RuiAvatar v-bind="args" />
+      </div>`,
+  };
+}
+
+const meta = preview.meta({
+  args: {
+    alt: 'Ada Lovelace',
+    color: 'default',
+    icon: null,
+    loading: 'lazy',
+    size: 'md',
+    src: null,
+    text: null,
+    variant: 'circular',
+  },
+  argTypes: {
+    color: { control: 'select', options: ['default', ...contextColors] },
+    icon: { control: 'select', options: [null, ...RuiIcons] },
+    size: { control: 'select', options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] },
+    src: { control: 'text' },
+    text: { control: 'text' },
+    variant: { control: 'select', options: ['circular', 'rounded', 'square'] },
+  },
+  render,
+  tags: ['autodocs'],
+  title: 'Components/Avatars/Avatar',
+});
+
+export const Default = meta.story({
+  args: {},
+});
+
+export const WithImage = meta.story({
+  args: {
+    alt: 'Vue logo',
+    src: 'https://vuejs.org/images/logo.png',
+  },
+});
+
+export const Initials = meta.story({
+  args: {
+    alt: 'Ada Lovelace',
+    text: 'Ada Lovelace',
+  },
+});
+
+export const WithIcon = meta.story({
+  args: {
+    alt: 'User icon',
+    icon: 'lu-user',
+  },
+});
+
+export const BrokenImage = meta.story({
+  args: {
+    alt: 'Falls back to initials',
+    src: 'https://example.invalid/no-such-image.png',
+    text: 'Ada Lovelace',
+  },
+});
+
+export const Sizes = meta.story({
+  render(args: AvatarStoryArgs) {
+    return {
+      components: { RuiAvatar },
+      setup: () => ({ args, sizes: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const }),
+      template: `
+        <div class="flex items-center gap-4 p-8">
+          <RuiAvatar v-for="s in sizes" :key="s" :size="s" text="AL" />
+        </div>`,
+    };
+  },
+});
+
+export const Variants = meta.story({
+  render(args: AvatarStoryArgs) {
+    return {
+      components: { RuiAvatar },
+      setup: () => ({ args, variants: ['circular', 'rounded', 'square'] as const }),
+      template: `
+        <div class="flex items-center gap-4 p-8">
+          <RuiAvatar v-for="v in variants" :key="v" :variant="v" text="AL" size="lg" />
+        </div>`,
+    };
+  },
+});
+
+export const Colors = meta.story({
+  render(args: AvatarStoryArgs) {
+    return {
+      components: { RuiAvatar },
+      setup: () => ({ args, colors: ['default', ...contextColors] }),
+      template: `
+        <div class="flex flex-wrap items-center gap-4 p-8">
+          <RuiAvatar v-for="c in colors" :key="c" :color="c" text="AL" />
+        </div>`,
+    };
+  },
+});
+
+export const NumericSize = meta.story({
+  args: {
+    size: 56,
+    text: 'AL',
+  },
+});
+
+export const WithStatusBadge = meta.story({
+  render(args: AvatarStoryArgs) {
+    return {
+      components: { RuiAvatar, RuiBadge },
+      setup: () => ({ args }),
+      template: `
+        <div class="flex items-center gap-6 p-8">
+          <RuiBadge dot color="success" placement="bottom" :offset-x="-2" :offset-y="-2">
+            <RuiAvatar text="AL" size="lg" />
+          </RuiBadge>
+          <RuiBadge dot color="warning" placement="bottom" :offset-x="-2" :offset-y="-2">
+            <RuiAvatar text="JS" size="lg" color="primary" />
+          </RuiBadge>
+          <RuiBadge dot color="error" placement="bottom" :offset-x="-2" :offset-y="-2">
+            <RuiAvatar icon="lu-user" size="lg" color="secondary" />
+          </RuiBadge>
+        </div>`,
+    };
+  },
+});
+
+export default meta;

--- a/packages/ui-library/src/components/avatars/RuiAvatar.vue
+++ b/packages/ui-library/src/components/avatars/RuiAvatar.vue
@@ -1,0 +1,223 @@
+<script lang="ts" setup>
+import type { ContextColorsType } from '@/consts/colors';
+import type { RuiIcons } from '@/icons';
+import { get, set } from '@vueuse/shared';
+import {
+  type AvatarSize,
+  type AvatarVariant,
+  computeInitials,
+  resolveAvatarIconPx,
+  resolveAvatarSizePx,
+} from '@/components/avatars/avatar-props';
+import { useAvatarGroup } from '@/components/avatars/use-avatar-group';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
+import { tv } from '@/utils/tv';
+
+export interface Props {
+  src?: string | null;
+  alt?: string;
+  text?: string | null;
+  icon?: RuiIcons | null;
+  size?: AvatarSize | number;
+  variant?: AvatarVariant;
+  color?: 'default' | ContextColorsType;
+  loading?: 'lazy' | 'eager';
+}
+
+defineOptions({
+  name: 'RuiAvatar',
+});
+
+const {
+  src = null,
+  alt = '',
+  text = null,
+  icon = null,
+  size,
+  variant,
+  color = 'default',
+  loading = 'lazy',
+} = defineProps<Props>();
+
+const emit = defineEmits<{
+  load: [event: Event];
+  error: [event: Event];
+}>();
+
+const slots = defineSlots<{
+  default?: () => any;
+}>();
+
+const group = useAvatarGroup();
+
+const resolvedSize = computed<AvatarSize | number>(() => {
+  if (size !== undefined)
+    return size;
+  if (group)
+    return get(group).size;
+  return 'md';
+});
+
+const resolvedVariant = computed<AvatarVariant>(() => {
+  if (variant !== undefined)
+    return variant;
+  if (group)
+    return get(group).variant;
+  return 'circular';
+});
+
+const sizeToken = computed<AvatarSize | undefined>(() => {
+  const value = get(resolvedSize);
+  return typeof value === 'string' ? value : undefined;
+});
+
+const sizePx = computed<number>(() => resolveAvatarSizePx(get(resolvedSize)));
+const iconPx = computed<number>(() => resolveAvatarIconPx(get(resolvedSize)));
+
+const errored = ref<boolean>(false);
+
+watch(() => src, () => {
+  set(errored, false);
+});
+
+const initials = computed<string>(() => {
+  const explicit = computeInitials(text ?? undefined);
+  if (explicit)
+    return explicit;
+  return computeInitials(alt);
+});
+
+type DisplayMode = 'image' | 'slot' | 'initials' | 'icon' | 'empty';
+
+const displayMode = computed<DisplayMode>(() => {
+  if (src && !get(errored))
+    return 'image';
+  if (slots.default)
+    return 'slot';
+  if (icon)
+    return 'icon';
+  if (get(initials))
+    return 'initials';
+  return 'empty';
+});
+
+const decorative = computed<boolean>(() => alt === '' && !text);
+
+const ariaLabel = computed<string | undefined>(() => {
+  if (get(displayMode) === 'image')
+    return undefined;
+  if (get(decorative))
+    return undefined;
+  return text ?? alt ?? undefined;
+});
+
+const rootStyle = computed<Record<string, string>>(() => {
+  const px = `${get(sizePx)}px`;
+  return { width: px, height: px };
+});
+
+const avatarStyles = tv({
+  slots: {
+    root: 'relative inline-flex items-center justify-center shrink-0 overflow-hidden select-none font-medium align-middle',
+    image: 'w-full h-full object-cover',
+    fallback: 'w-full h-full flex items-center justify-center',
+    initials: 'uppercase leading-none',
+  },
+  variants: {
+    variant: {
+      circular: { root: 'rounded-full' },
+      rounded: { root: 'rounded-md' },
+      square: { root: 'rounded-none' },
+    },
+    color: {
+      default: { root: 'bg-rui-grey-200 text-rui-text dark:bg-rui-grey-800' },
+      primary: { root: 'bg-rui-primary text-white' },
+      secondary: { root: 'bg-rui-secondary text-white' },
+      error: { root: 'bg-rui-error text-white' },
+      warning: { root: 'bg-rui-warning text-white' },
+      info: { root: 'bg-rui-info text-white' },
+      success: { root: 'bg-rui-success text-white' },
+    },
+    size: {
+      'xs': { initials: 'text-[0.625rem]' },
+      'sm': { initials: 'text-[0.6875rem]' },
+      'md': { initials: 'text-sm' },
+      'lg': { initials: 'text-base' },
+      'xl': { initials: 'text-lg' },
+      '2xl': { initials: 'text-xl' },
+    },
+  },
+  compoundSlots: [
+    { slots: ['root'], color: ['warning', 'success', 'info'], class: 'dark:text-rui-light-text' },
+  ],
+  defaultVariants: {
+    variant: 'circular',
+    color: 'default',
+    size: 'md',
+  },
+});
+
+const ui = computed<ReturnType<typeof avatarStyles>>(() => avatarStyles({
+  variant: get(resolvedVariant),
+  color,
+  size: get(sizeToken),
+}));
+
+function onLoad(event: Event): void {
+  set(errored, false);
+  emit('load', event);
+}
+
+function onError(event: Event): void {
+  set(errored, true);
+  emit('error', event);
+}
+</script>
+
+<template>
+  <span
+    :class="ui.root()"
+    :style="rootStyle"
+    :role="displayMode === 'image' ? undefined : 'img'"
+    :aria-label="ariaLabel"
+    :data-id="$attrs['data-id'] ?? 'avatar-root'"
+    :data-size="typeof resolvedSize === 'string' ? resolvedSize : undefined"
+    :data-variant="resolvedVariant"
+    :data-color="color"
+  >
+    <img
+      v-if="displayMode === 'image' && src"
+      :class="ui.image()"
+      :src="src"
+      :alt="alt"
+      :loading="loading"
+      :width="sizePx"
+      :height="sizePx"
+      data-id="avatar-image"
+      @load="onLoad($event)"
+      @error="onError($event)"
+    />
+    <span
+      v-else
+      :class="ui.fallback()"
+      data-id="avatar-fallback"
+      aria-hidden="true"
+    >
+      <slot v-if="displayMode === 'slot'" />
+      <span
+        v-else-if="displayMode === 'initials'"
+        :class="ui.initials()"
+        data-id="avatar-initials"
+      >
+        {{ initials }}
+      </span>
+      <RuiIcon
+        v-else-if="displayMode === 'icon' && icon"
+        :name="icon"
+        :size="iconPx"
+        data-id="avatar-icon"
+      />
+      <span v-else>&nbsp;</span>
+    </span>
+  </span>
+</template>

--- a/packages/ui-library/src/components/avatars/RuiAvatarGroup.spec.ts
+++ b/packages/ui-library/src/components/avatars/RuiAvatarGroup.spec.ts
@@ -1,0 +1,131 @@
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiAvatar from '@/components/avatars/RuiAvatar.vue';
+import RuiAvatarGroup from '@/components/avatars/RuiAvatarGroup.vue';
+
+function createWrapper(
+  options?: ComponentMountingOptions<typeof RuiAvatarGroup>,
+): VueWrapper<InstanceType<typeof RuiAvatarGroup>> {
+  return mount(RuiAvatarGroup, {
+    ...options,
+    global: {
+      components: { RuiAvatar },
+    },
+  });
+}
+
+describe('components/avatars/RuiAvatarGroup.vue', () => {
+  let wrapper: VueWrapper<InstanceType<typeof RuiAvatarGroup>>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders all children when max is not set', () => {
+    wrapper = createWrapper({
+      slots: {
+        default: `
+          <RuiAvatar text="AB" />
+          <RuiAvatar text="CD" />
+          <RuiAvatar text="EF" />
+        `,
+      },
+    });
+
+    const items = wrapper.findAllComponents(RuiAvatar);
+    expect(items).toHaveLength(3);
+    expect(wrapper.find('[data-id="avatar-group-surplus"]').exists()).toBeFalsy();
+  });
+
+  it('slices children to max and renders +N surplus', () => {
+    wrapper = createWrapper({
+      props: { max: 2 },
+      slots: {
+        default: `
+          <RuiAvatar text="AB" />
+          <RuiAvatar text="CD" />
+          <RuiAvatar text="EF" />
+          <RuiAvatar text="GH" />
+        `,
+      },
+    });
+
+    const surplus = wrapper.find('[data-id="avatar-group-surplus"]');
+    expect(surplus.exists()).toBeTruthy();
+    expect(surplus.text()).toBe('+2');
+  });
+
+  it('uses total prop to override surplus count', () => {
+    wrapper = createWrapper({
+      props: { max: 2, total: 42 },
+      slots: {
+        default: `
+          <RuiAvatar text="AB" />
+          <RuiAvatar text="CD" />
+          <RuiAvatar text="EF" />
+        `,
+      },
+    });
+
+    expect(wrapper.find('[data-id="avatar-group-surplus"]').text()).toBe('+40');
+  });
+
+  it('uses surplus slot override', () => {
+    wrapper = createWrapper({
+      props: { max: 1 },
+      slots: {
+        default: `
+          <RuiAvatar text="AB" />
+          <RuiAvatar text="CD" />
+          <RuiAvatar text="EF" />
+        `,
+        surplus: '<span data-test="surplus">custom {{ params.count }}</span>',
+      },
+    });
+
+    const surplus = wrapper.find('[data-test="surplus"]');
+    expect(surplus.exists()).toBeTruthy();
+  });
+
+  it('injects size into children without explicit size', () => {
+    wrapper = createWrapper({
+      props: { size: 'lg' },
+      slots: {
+        default: '<RuiAvatar text="AB" />',
+      },
+    });
+
+    const child = wrapper.find('[data-id="avatar-root"]');
+    expect(child.attributes('data-size')).toBe('lg');
+  });
+
+  it('child explicit size wins over injected', () => {
+    wrapper = createWrapper({
+      props: { size: 'lg' },
+      slots: {
+        default: '<RuiAvatar text="AB" size="sm" />',
+      },
+    });
+
+    const child = wrapper.find('[data-id="avatar-root"]');
+    expect(child.attributes('data-size')).toBe('sm');
+  });
+
+  it('injects variant into children', () => {
+    wrapper = createWrapper({
+      props: { variant: 'square' },
+      slots: {
+        default: '<RuiAvatar text="AB" />',
+      },
+    });
+
+    expect(wrapper.find('[data-id="avatar-root"]').attributes('data-variant')).toBe('square');
+  });
+
+  it('exposes data-id on group root', () => {
+    wrapper = createWrapper({
+      slots: { default: '<RuiAvatar text="AB" />' },
+    });
+    expect(wrapper.find('[data-id="avatar-group"]').exists()).toBeTruthy();
+  });
+});

--- a/packages/ui-library/src/components/avatars/RuiAvatarGroup.stories.ts
+++ b/packages/ui-library/src/components/avatars/RuiAvatarGroup.stories.ts
@@ -1,0 +1,108 @@
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiAvatar from '@/components/avatars/RuiAvatar.vue';
+import RuiAvatarGroup from '@/components/avatars/RuiAvatarGroup.vue';
+import preview from '~/.storybook/preview';
+
+type AvatarGroupStoryArgs = ComponentPropsAndSlots<typeof RuiAvatarGroup>;
+
+function render(args: AvatarGroupStoryArgs) {
+  return {
+    components: { RuiAvatar, RuiAvatarGroup },
+    setup: () => ({ args }),
+    template: `
+      <div class="p-8">
+        <RuiAvatarGroup v-bind="args">
+          <RuiAvatar text="Ada Lovelace" />
+          <RuiAvatar text="Grace Hopper" color="primary" />
+          <RuiAvatar text="Linus Torvalds" color="secondary" />
+          <RuiAvatar text="Margaret Hamilton" color="success" />
+          <RuiAvatar text="Donald Knuth" color="warning" />
+        </RuiAvatarGroup>
+      </div>`,
+  };
+}
+
+const meta = preview.meta({
+  args: {
+    max: undefined,
+    size: 'md',
+    spacing: 'md',
+    total: undefined,
+    variant: 'circular',
+  },
+  argTypes: {
+    max: { control: 'number' },
+    size: { control: 'select', options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] },
+    spacing: { control: 'select', options: ['sm', 'md', 'lg'] },
+    total: { control: 'number' },
+    variant: { control: 'select', options: ['circular', 'rounded', 'square'] },
+  },
+  render,
+  tags: ['autodocs'],
+  title: 'Components/Avatars/AvatarGroup',
+});
+
+export const Basic = meta.story({
+  args: {},
+});
+
+export const WithMax = meta.story({
+  args: { max: 3 },
+});
+
+export const WithTotal = meta.story({
+  args: { max: 3, total: 42 },
+});
+
+export const LargerSize = meta.story({
+  args: { size: 'lg' },
+});
+
+export const SquareVariant = meta.story({
+  args: { variant: 'rounded' },
+});
+
+export const SpacingOptions = meta.story({
+  render(args: AvatarGroupStoryArgs) {
+    return {
+      components: { RuiAvatar, RuiAvatarGroup },
+      setup: () => ({ args, spacings: ['sm', 'md', 'lg'] as const }),
+      template: `
+        <div class="flex flex-col gap-6 p-8">
+          <div v-for="s in spacings" :key="s" class="flex items-center gap-4">
+            <span class="w-16 text-sm">{{ s }}</span>
+            <RuiAvatarGroup :spacing="s" :max="3">
+              <RuiAvatar text="AB" color="primary" />
+              <RuiAvatar text="CD" color="secondary" />
+              <RuiAvatar text="EF" color="success" />
+              <RuiAvatar text="GH" color="warning" />
+              <RuiAvatar text="IJ" color="error" />
+            </RuiAvatarGroup>
+          </div>
+        </div>`,
+    };
+  },
+});
+
+export const SurplusSlot = meta.story({
+  render(args: AvatarGroupStoryArgs) {
+    return {
+      components: { RuiAvatar, RuiAvatarGroup },
+      setup: () => ({ args }),
+      template: `
+        <div class="p-8">
+          <RuiAvatarGroup :max="2">
+            <RuiAvatar text="AB" color="primary" />
+            <RuiAvatar text="CD" color="secondary" />
+            <RuiAvatar text="EF" color="success" />
+            <RuiAvatar text="GH" color="warning" />
+            <template #surplus="{ count }">
+              <RuiAvatar :text="'...'" color="info" :alt="'and ' + count + ' more'" />
+            </template>
+          </RuiAvatarGroup>
+        </div>`,
+    };
+  },
+});
+
+export default meta;

--- a/packages/ui-library/src/components/avatars/RuiAvatarGroup.vue
+++ b/packages/ui-library/src/components/avatars/RuiAvatarGroup.vue
@@ -1,0 +1,152 @@
+<script lang="ts" setup>
+import { get } from '@vueuse/shared';
+import { Comment, defineComponent, Fragment, Text, type VNode } from 'vue';
+import {
+  AVATAR_GROUP_SPACING_PX,
+  avatarGroupInjectionKey,
+  AvatarGroupSpacing,
+  type AvatarSize,
+  type AvatarVariant,
+  resolveAvatarSizePx,
+} from '@/components/avatars/avatar-props';
+import RuiAvatar from '@/components/avatars/RuiAvatar.vue';
+import { tv } from '@/utils/tv';
+
+export interface Props {
+  size?: AvatarSize | number;
+  variant?: AvatarVariant;
+  max?: number;
+  total?: number;
+  spacing?: AvatarGroupSpacing | number;
+}
+
+defineOptions({
+  name: 'RuiAvatarGroup',
+});
+
+const {
+  size,
+  variant = 'circular',
+  max,
+  total,
+  spacing = AvatarGroupSpacing.md,
+} = defineProps<Props>();
+
+const slots = defineSlots<{
+  default?: () => VNode[];
+  surplus?: (props: { count: number }) => any;
+}>();
+
+const resolvedSize = computed<AvatarSize | number>(() => size ?? 'md');
+
+const VNodeRenderer = defineComponent<{ vnode: VNode }>({
+  props: ['vnode'],
+  setup(props) {
+    return (): VNode => props.vnode;
+  },
+});
+
+provide(avatarGroupInjectionKey, computed(() => ({ size: get(resolvedSize), variant })));
+
+const groupStyles = tv({
+  slots: {
+    root: 'inline-flex items-center isolate',
+    item: 'relative ring-2 ring-white dark:ring-rui-grey-900 rounded-full',
+  },
+});
+
+function flattenChildren(nodes: VNode[] | undefined): VNode[] {
+  if (!nodes)
+    return [];
+  const out: VNode[] = [];
+  for (const node of nodes) {
+    if (node.type === Comment)
+      continue;
+    if (node.type === Text && typeof node.children === 'string' && node.children.trim() === '')
+      continue;
+    if (node.type === Fragment && Array.isArray(node.children)) {
+      const inner = node.children.filter((c): c is VNode => typeof c === 'object' && c !== null && 'type' in c);
+      out.push(...flattenChildren(inner));
+      continue;
+    }
+    out.push(node);
+  }
+  return out;
+}
+
+const children = computed<VNode[]>(() => flattenChildren(slots.default?.()));
+
+const visible = computed<VNode[]>(() => {
+  if (max === undefined)
+    return get(children);
+  return get(children).slice(0, max);
+});
+
+const surplusCount = computed<number>(() => {
+  const totalCount = total ?? get(children).length;
+  const shown = get(visible).length;
+  return Math.max(0, totalCount - shown);
+});
+
+const spacingPx = computed<number>(() => {
+  if (typeof spacing === 'number')
+    return spacing;
+  return AVATAR_GROUP_SPACING_PX[spacing];
+});
+
+const ringOffsetPx = computed<number>(() =>
+  // ring-2 is 2px. Keep items overlapping by the configured spacing
+  // (negative margin). spacing is already negative for tokens.
+  get(spacingPx),
+);
+
+const itemStyle = computed<Record<string, string>>(() => ({
+  marginInlineStart: `${get(ringOffsetPx)}px`,
+}));
+
+const firstItemStyle = computed<Record<string, string>>(() => ({
+  marginInlineStart: '0',
+}));
+
+const avatarPx = computed<number>(() => resolveAvatarSizePx(get(resolvedSize)));
+
+const ui = computed<ReturnType<typeof groupStyles>>(() => groupStyles());
+</script>
+
+<template>
+  <div
+    :class="ui.root()"
+    data-id="avatar-group"
+    :data-size="typeof resolvedSize === 'string' ? resolvedSize : undefined"
+    :data-variant="variant"
+  >
+    <span
+      v-for="(child, index) in visible"
+      :key="child.key ?? index"
+      :class="ui.item()"
+      :style="index === 0 ? firstItemStyle : itemStyle"
+    >
+      <VNodeRenderer :vnode="child" />
+    </span>
+    <span
+      v-if="surplusCount > 0"
+      :class="ui.item()"
+      :style="visible.length === 0 ? firstItemStyle : itemStyle"
+      data-id="avatar-group-surplus"
+    >
+      <slot
+        name="surplus"
+        :count="surplusCount"
+      >
+        <RuiAvatar
+          :size="resolvedSize"
+          :variant="variant"
+          :alt="`+${surplusCount} more`"
+          :style="{ width: `${avatarPx}px`, height: `${avatarPx}px` }"
+        >
+          <span class="leading-none">+{{ surplusCount }}</span>
+        </RuiAvatar>
+      </slot>
+    </span>
+  </div>
+</template>

--- a/packages/ui-library/src/components/avatars/avatar-props.ts
+++ b/packages/ui-library/src/components/avatars/avatar-props.ts
@@ -1,0 +1,85 @@
+import type { ComputedRef, InjectionKey } from 'vue';
+
+export const AvatarSize = {
+  'xs': 'xs',
+  'sm': 'sm',
+  'md': 'md',
+  'lg': 'lg',
+  'xl': 'xl',
+  '2xl': '2xl',
+} as const;
+
+export type AvatarSize = (typeof AvatarSize)[keyof typeof AvatarSize];
+
+export const AvatarVariant = {
+  circular: 'circular',
+  rounded: 'rounded',
+  square: 'square',
+} as const;
+
+export type AvatarVariant = (typeof AvatarVariant)[keyof typeof AvatarVariant];
+
+export const AvatarGroupSpacing = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+} as const;
+
+export type AvatarGroupSpacing = (typeof AvatarGroupSpacing)[keyof typeof AvatarGroupSpacing];
+
+export const AVATAR_SIZE_PX: Record<AvatarSize, number> = {
+  'xs': 20,
+  'sm': 24,
+  'md': 32,
+  'lg': 40,
+  'xl': 48,
+  '2xl': 64,
+};
+
+export const AVATAR_ICON_PX: Record<AvatarSize, number> = {
+  'xs': 12,
+  'sm': 14,
+  'md': 18,
+  'lg': 22,
+  'xl': 28,
+  '2xl': 36,
+};
+
+export const AVATAR_GROUP_SPACING_PX: Record<AvatarGroupSpacing, number> = {
+  sm: -4,
+  md: -8,
+  lg: -12,
+};
+
+export function resolveAvatarSizePx(size: AvatarSize | number | undefined): number {
+  if (typeof size === 'number')
+    return size;
+  return AVATAR_SIZE_PX[size ?? 'md'];
+}
+
+export function resolveAvatarIconPx(size: AvatarSize | number | undefined): number {
+  if (typeof size === 'number')
+    return Math.round(size * 0.56);
+  return AVATAR_ICON_PX[size ?? 'md'];
+}
+
+export function computeInitials(source: string | undefined | null): string {
+  if (!source)
+    return '';
+  const parts = source
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+  if (parts.length === 0)
+    return '';
+  return parts.map(p => p.charAt(0).toUpperCase()).join('');
+}
+
+export interface AvatarGroupContext {
+  size: AvatarSize | number;
+  variant: AvatarVariant;
+}
+
+export const avatarGroupInjectionKey: InjectionKey<ComputedRef<AvatarGroupContext>>
+  = Symbol('avatarGroup');

--- a/packages/ui-library/src/components/avatars/use-avatar-group.ts
+++ b/packages/ui-library/src/components/avatars/use-avatar-group.ts
@@ -1,0 +1,6 @@
+import type { ComputedRef } from 'vue';
+import { type AvatarGroupContext, avatarGroupInjectionKey } from '@/components/avatars/avatar-props';
+
+export function useAvatarGroup(): ComputedRef<AvatarGroupContext> | undefined {
+  return inject(avatarGroupInjectionKey, undefined);
+}

--- a/packages/ui-library/src/components/index.ts
+++ b/packages/ui-library/src/components/index.ts
@@ -9,6 +9,8 @@ import type {
 import RuiAccordion, { type AccordionProps, type RuiAccordionClassNames } from '@/components/accordions/accordion/RuiAccordion.vue';
 import RuiAccordions, { type Props as AccordionsProps } from '@/components/accordions/accordions/RuiAccordions.vue';
 import RuiAlert, { type Props as AlertProps } from '@/components/alerts/RuiAlert.vue';
+import RuiAvatar, { type Props as AvatarProps } from '@/components/avatars/RuiAvatar.vue';
+import RuiAvatarGroup, { type Props as AvatarGroupProps } from '@/components/avatars/RuiAvatarGroup.vue';
 import RuiButtonGroup, { type Props as ButtonGroupProps } from '@/components/buttons/button-group/RuiButtonGroup.vue';
 import RuiButton, { type Props as ButtonProps } from '@/components/buttons/button/RuiButton.vue';
 import RuiCalendar, { type CalendarProps } from '@/components/calendar/RuiCalendar.vue';
@@ -56,6 +58,8 @@ export type {
   AccordionsProps,
   AlertProps,
   AutoCompleteProps,
+  AvatarGroupProps,
+  AvatarProps,
   BadgeProps,
   BottomSheetProps,
   ButtonGroupProps,
@@ -120,6 +124,8 @@ export {
   RuiAccordions,
   RuiAlert,
   RuiAutoComplete,
+  RuiAvatar,
+  RuiAvatarGroup,
   RuiBadge,
   RuiBottomSheet,
   RuiButton,


### PR DESCRIPTION
## Summary
- Add `RuiAvatar` with image-first rendering, initials/icon/slot fallback, six size tokens (xs–2xl) plus arbitrary numeric sizes, three variants (circular/rounded/square), and context-color theming.
- Add `RuiAvatarGroup` that overlaps children with a configurable spacing token, slices to `max` with a `+N` surplus (overridable via `total` or the `surplus` slot), and provides size/variant to children via injection.
- Wire up the example app page (`/avatars`), Storybook stories, and Playwright e2e coverage.

Closes #144

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm --filter @rotki/ui-library run test:run` (28 avatar unit tests pass)
- [x] `pnpm run build:prod`
- [x] `PLAYWRIGHT_CHROMIUM_PATH=/usr/bin/chromium pnpm test:e2e avatar.spec.ts` (10/10 pass)
- [ ] Visual review in Storybook (`pnpm run storybook`) — Default, WithImage, Initials, WithIcon, BrokenImage, Sizes, Variants, Colors, NumericSize, WithStatusBadge
- [ ] Visual review of `/avatars` example page across sizes, variants, colors, and group cases