### PR TITLE
feat(auto-complete): expose openMenu and closeMenu

### DIFF
--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -1077,4 +1077,26 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     const chipElement = firstChip.element as HTMLElement;
     expect(chipElement.getAttribute('data-index')).toBe('0');
   });
+
+  it('should expose openMenu and closeMenu to control the menu programmatically', async () => {
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      props: {
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(queryByRole('menu')).toBeFalsy();
+
+    wrapper.vm.openMenu();
+    await vi.runAllTimersAsync();
+    expect(queryByRole('menu')).toBeTruthy();
+
+    wrapper.vm.closeMenu();
+    await vi.runAllTimersAsync();
+    expect(queryByRole('menu')).toBeFalsy();
+  });
 });

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -425,6 +425,14 @@ function arrowClicked(event: MouseEvent): void {
   }
 }
 
+function openMenu(): void {
+  set(isOpen, true);
+}
+
+function closeMenu(): void {
+  set(isOpen, false);
+}
+
 // Optimize options watcher with shallow comparison first
 watch(() => options, (curr, old) => {
   if (curr === old || customValue)
@@ -438,7 +446,9 @@ watch(() => options, (curr, old) => {
 });
 
 defineExpose({
+  closeMenu,
   focus: focusSetInputFocus,
+  openMenu,
   setSelectionRange,
 });
 </script>


### PR DESCRIPTION
## Summary
- Adds `openMenu()` and `closeMenu()` to `RuiAutoComplete`'s `defineExpose`, so consumers can programmatically toggle the dropdown.
- Removes the need for the synthetic `input`-event workaround when `hide-search-input` is active (the native input is `display: none`, so calling `.focus()` is a no-op and there is no public way to re-open the menu).
- Adds a unit test covering the new exposed methods.

Closes #517

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test:run --testNamePattern="openMenu and closeMenu"`