### PR TITLE
feat(icons): auto-register icons used by library components

### DIFF
--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -85,6 +85,7 @@
     "build:web-types": "tsx scripts/build-web-types.mjs",
     "generate-icons": "tsx scripts/generate-icons.ts",
     "resolve:alias": "tsc-alias --replacer ./scripts/tsc-alias-replacer.cjs -p tsconfig.build.json --dir dist",
+    "scan:library-icons": "tsx scripts/scan-library-icons.ts",
     "verify:dist": "tsx scripts/verify-dist.ts",
     "dev": "vite",
     "prepare": "node scripts/prepare.mjs",

--- a/packages/ui-library/scripts/dist-build.mjs
+++ b/packages/ui-library/scripts/dist-build.mjs
@@ -16,6 +16,8 @@ consola.info('resolving aliases');
 execSync('pnpm run resolve:alias', { stdio: 'inherit' });
 consola.info('build web-types.json');
 execSync('pnpm run build:web-types', { stdio: 'inherit' });
+consola.info('scanning library icons');
+execSync('pnpm run scan:library-icons', { stdio: 'inherit' });
 consola.info('verifying dist');
 execSync('pnpm run verify:dist', { stdio: 'inherit' });
 consola.success('build done');

--- a/packages/ui-library/scripts/scan-library-icons.ts
+++ b/packages/ui-library/scripts/scan-library-icons.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import consola from 'consola';
+import fg from 'fast-glob';
+import { extractIconsFromSource } from '../src/vite-plugin/scanner.js';
+
+const root = resolve(import.meta.dirname, '..');
+const dist = resolve(root, 'dist');
+
+if (!existsSync(dist)) {
+  consola.error(`dist/ not found at ${dist} — run the main build first`);
+  process.exit(1);
+}
+
+const iconsSource = readFileSync(resolve(root, 'src/icons/index.ts'), 'utf-8');
+// eslint-disable-next-line regexp/strict
+const validIconsMatch = iconsSource.match(/export const RuiIcons = \[(.*?)] as const/s)
+  // eslint-disable-next-line regexp/strict
+  ?? iconsSource.match(/export const RuiIcons = \[(.*?)]/s);
+if (!validIconsMatch?.[1]) {
+  consola.error('could not parse RuiIcons from src/icons/index.ts');
+  process.exit(1);
+}
+const validIcons = new Set<string>(
+  validIconsMatch[1].match(/"([^"]+)"/g)?.map(s => s.slice(1, -1)) ?? [],
+);
+
+const files = fg.sync(['src/components/**/*.vue', 'src/components/**/*.ts'], {
+  cwd: root,
+  absolute: true,
+  ignore: ['**/*.spec.ts', '**/*.stories.ts'],
+});
+
+const icons = new Set<string>();
+for (const file of files) {
+  const source = readFileSync(file, 'utf-8');
+  for (const name of extractIconsFromSource(source)) {
+    if (validIcons.has(name))
+      icons.add(name);
+  }
+}
+
+const sorted = [...icons].sort();
+const out = resolve(dist, 'library-icons.json');
+writeFileSync(out, `${JSON.stringify(sorted, null, 2)}\n`);
+
+consola.success(`wrote dist/library-icons.json (${sorted.length} icons used by library components)`);

--- a/packages/ui-library/src/vite-plugin/index.ts
+++ b/packages/ui-library/src/vite-plugin/index.ts
@@ -62,6 +62,25 @@ function loadValidIcons(): Set<string> {
 }
 
 /**
+ * Loads the baseline icons used by library components, emitted at library
+ * build time. Consumers always need these regardless of their own source.
+ */
+function loadLibraryBaselineIcons(): string[] {
+  const distPath = resolve(__dirname, '../library-icons.json');
+  if (existsSync(distPath)) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(distPath, 'utf-8'));
+      if (Array.isArray(parsed))
+        return parsed.filter((v): v is string => typeof v === 'string');
+    }
+    catch {
+      // fall through
+    }
+  }
+  return [];
+}
+
+/**
  * Vite plugin for automatic icon detection and registration
  */
 export function ruiIconsPlugin(options: RuiIconsPluginOptions = {}): Plugin {
@@ -73,6 +92,7 @@ export function ruiIconsPlugin(options: RuiIconsPluginOptions = {}): Plugin {
   } = options;
 
   let validIcons: Set<string>;
+  let libraryBaseline: string[];
   let scanResult: ScanResult;
   let server: ViteDevServer | null = null;
   let root: string;
@@ -96,7 +116,7 @@ export function ruiIconsPlugin(options: RuiIconsPluginOptions = {}): Plugin {
     const glob = fg.default || fg;
 
     scanResult = {
-      icons: new Set(include),
+      icons: new Set([...libraryBaseline, ...include]),
       invalidIcons: new Map(),
     };
 
@@ -200,7 +220,9 @@ export function ruiIconsPlugin(options: RuiIconsPluginOptions = {}): Plugin {
     configResolved(config) {
       root = config.root;
       validIcons = loadValidIcons();
+      libraryBaseline = loadLibraryBaselineIcons();
       log(`Loaded ${validIcons.size} valid icon names`);
+      log(`Loaded ${libraryBaseline.length} baseline icons used by library components`);
     },
 
     configureServer(_server) {

--- a/packages/ui-library/tsconfig.node.json
+++ b/packages/ui-library/tsconfig.node.json
@@ -15,6 +15,8 @@
     "src/consts/colors.ts",
     "src/consts/typography.ts",
     "src/theme/index.ts",
-    "src/types/icons.ts"
+    "src/types/icons.ts",
+    "src/vite-plugin/scanner.ts",
+    "src/vite-plugin/types.ts"
   ]
 }


### PR DESCRIPTION
## Summary
Library-internal icons (e.g. `lu-calendar-days` in `RuiDateTimePicker`, `lu-clock` in `RuiTimePicker`, the dozens used by `RuiCalendar`, `RuiCheckbox`, `RuiDataTable`, etc.) were never registered automatically — every consumer would have to add them via the plugin's `include` option, or hit a runtime "Icons \"...\" not found" warning the first time the component rendered.

Now:
- A new `scripts/scan-library-icons.ts` step (run from `dist-build.mjs` after web-types) scans `src/components/**/*.{vue,ts}` (excluding specs/stories) and writes the validated icon list to `dist/library-icons.json`.
- `ruiIconsPlugin` reads `dist/library-icons.json` at `configResolved` and seeds its `scanResult.icons` with this baseline.
- Net effect: every consumer gets all 30 library-baseline icons for free, on top of whatever the plugin auto-detects in their own source and whatever they pass via `include`.

Verified the example app's plugin now logs `Loaded 30 baseline icons used by library components` and the detected-icon count went from 31 → 56.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm -w run lint` clean
- [x] `pnpm --filter @rotki/ui-library run test:run` (1072 pass)
- [x] `pnpm run test:e2e` (280 pass)
- [x] `pnpm --filter @rotki/ui-library run build:prod` emits `dist/library-icons.json`
- [x] Example app picks up baseline (verified via plugin debug log)