### PR TITLE
feat(checkbox-group): add RuiCheckboxGroup component

### DIFF
--- a/apps/example/e2e/forms/checkbox.spec.ts
+++ b/apps/example/e2e/forms/checkbox.spec.ts
@@ -22,4 +22,42 @@ test.describe('forms/Checkbox', () => {
 
     await expect(disabledCheckbox).toBeDisabled();
   });
+
+  test('should have role="group" on checkbox group containers', async ({ page }) => {
+    const groups = page.locator('[data-id=checkbox-group-wrapper] [role=group]');
+    expect(await groups.count()).toBeGreaterThanOrEqual(3);
+  });
+
+  test('toggles values into the checkbox group v-model', async ({ page }) => {
+    const firstGroup = page.locator('[data-id=checkbox-group-0]');
+    const hint = firstGroup.locator('.details').first();
+
+    // Initial: apples + oranges checked
+    await expect(hint).toContainText('Selected: apples, oranges');
+
+    // Click third option (grapes) — adds to selection
+    await firstGroup.locator('label').nth(2).click();
+    await expect(hint).toContainText('grapes');
+
+    // Click first (apples) — removes from selection
+    await firstGroup.locator('label').nth(0).click();
+    await expect(hint).not.toContainText('apples');
+  });
+
+  test('should propagate disabled from group to children', async ({ page }) => {
+    const disabledGroup = page.locator('[data-id=checkbox-group-2]');
+    const inputs = disabledGroup.locator('input[type="checkbox"]');
+    const count = await inputs.count();
+    for (let i = 0; i < count; i++)
+      await expect(inputs.nth(i)).toBeDisabled();
+  });
+
+  test('supports non-string values in checkbox group', async ({ page }) => {
+    const numericGroup = page.locator('[data-id=checkbox-group-numeric]');
+    const hint = numericGroup.locator('.details').first();
+    await expect(hint).toContainText('Selected: 1, 3');
+
+    await numericGroup.locator('label').nth(1).click(); // toggle "Two"
+    await expect(hint).toContainText('2');
+  });
 });

--- a/apps/example/src/views/CheckboxView.vue
+++ b/apps/example/src/views/CheckboxView.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { type ContextColorsType, RuiCheckbox } from '@rotki/ui-library';
+import { type ContextColorsType, RuiCheckbox, RuiCheckboxGroup } from '@rotki/ui-library';
 import ComponentGroup from '@/components/ComponentGroup.vue';
 import ComponentView from '@/components/ComponentView.vue';
 
@@ -49,6 +49,56 @@ function generateCheckboxes(): CheckboxData[] {
 onBeforeMount(() => {
   set(checkboxes, generateCheckboxes());
 });
+
+const checkboxGroups = ref<{
+  value: string[];
+  disabled?: boolean;
+  size?: 'sm' | 'lg';
+  inline?: boolean;
+  options: { value: string; color: ContextColorsType }[];
+}[]>([
+  {
+    value: ['apples', 'oranges'],
+    inline: true,
+    options: [
+      { value: 'apples', color: 'primary' },
+      { value: 'oranges', color: 'secondary' },
+      { value: 'grapes', color: 'success' },
+      { value: 'bananas', color: 'warning' },
+    ],
+  },
+  {
+    value: [],
+    size: 'sm',
+    inline: true,
+    options: [
+      { value: 'a', color: 'primary' },
+      { value: 'b', color: 'secondary' },
+      { value: 'c', color: 'success' },
+    ],
+  },
+  {
+    value: ['x'],
+    disabled: true,
+    size: 'lg',
+    inline: true,
+    options: [
+      { value: 'x', color: 'primary' },
+      { value: 'y', color: 'secondary' },
+      { value: 'z', color: 'error' },
+    ],
+  },
+]);
+
+const numericCheckboxGroup = ref<{ value: number[]; options: { value: number; label: string }[] }>({
+  value: [1, 3],
+  options: [
+    { value: 1, label: 'One' },
+    { value: 2, label: 'Two' },
+    { value: 3, label: 'Three' },
+    { value: 4, label: 'Four' },
+  ],
+});
 </script>
 
 <template>
@@ -72,6 +122,50 @@ onBeforeMount(() => {
       </template>
     </ComponentGroup>
 
-    <div />
+    <h2
+      class="text-h4 mb-6"
+      data-id="checkbox-group-title"
+    >
+      Checkbox Groups
+    </h2>
+    <div
+      class="grid gap-8"
+      data-id="checkbox-group-wrapper"
+    >
+      <RuiCheckboxGroup
+        v-for="(group, i) in checkboxGroups"
+        :key="i"
+        v-model="group.value"
+        :disabled="group.disabled"
+        :size="group.size"
+        :inline="group.inline"
+        :hint="`Selected: ${group.value.join(', ') || 'none'}`"
+        :data-id="`checkbox-group-${i}`"
+      >
+        <RuiCheckbox
+          v-for="(option, j) in group.options"
+          :key="j"
+          :value="option.value"
+          :color="option.color"
+        >
+          <span class="capitalize">{{ option.value }}</span>
+        </RuiCheckbox>
+      </RuiCheckboxGroup>
+      <RuiCheckboxGroup
+        v-model="numericCheckboxGroup.value"
+        :hint="`Selected: ${numericCheckboxGroup.value.join(', ') || 'none'}`"
+        label="Numeric values"
+        data-id="checkbox-group-numeric"
+        inline
+      >
+        <RuiCheckbox
+          v-for="(option, j) in numericCheckboxGroup.options"
+          :key="j"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </RuiCheckbox>
+      </RuiCheckboxGroup>
+    </div>
   </ComponentView>
 </template>

--- a/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.spec.ts
+++ b/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.spec.ts
@@ -1,16 +1,14 @@
-import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
 import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
 import { expectWrapperNotToHaveClass, expectWrapperToHaveClass } from '~/tests/helpers/dom-helpers';
 
-function createWrapper(
-  options?: ComponentMountingOptions<typeof RuiCheckbox>,
-): VueWrapper<InstanceType<typeof RuiCheckbox>> {
+function createWrapper(options?: ComponentMountingOptions<typeof RuiCheckbox>) {
   return mount(RuiCheckbox, { ...options, global: { stubs: ['rui-icon'] } });
 }
 
 describe('components/forms/checkbox/RuiCheckbox.vue', () => {
-  let wrapper: VueWrapper<InstanceType<typeof RuiCheckbox>>;
+  let wrapper: ReturnType<typeof createWrapper>;
 
   afterEach(() => {
     wrapper.unmount();

--- a/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.vue
+++ b/packages/ui-library/src/components/forms/checkbox/RuiCheckbox.vue
@@ -1,13 +1,15 @@
-<script lang="ts" setup>
+<script lang="ts" setup generic="TValue">
 import type { ContextColorsType } from '@/consts/colors';
 import { objectPick } from '@vueuse/shared';
 import { checkControlStyles, getCheckControlIconSize } from '@/components/forms/check-control-styles';
+import { RuiCheckboxGroupContextKey } from '@/components/forms/checkbox/checkbox-group/context';
 import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 
-export interface Props {
+export interface Props<TValue> {
+  value?: TValue;
   disabled?: boolean;
   color?: ContextColorsType;
   size?: 'sm' | 'lg';
@@ -29,16 +31,17 @@ const modelValue = defineModel<boolean>({ default: false });
 const indeterminate = defineModel<boolean>('indeterminate', { default: false });
 
 const {
-  disabled = false,
-  color = undefined,
-  size = undefined,
+  value = undefined,
+  disabled: disabledProp = false,
+  color: colorProp = undefined,
+  size: sizeProp = undefined,
   label = '',
   hint = '',
   errorMessages = [],
   successMessages = [],
   hideDetails = false,
   required = false,
-} = defineProps<Props>();
+} = defineProps<Props<TValue>>();
 
 defineSlots<{
   default?: () => any;
@@ -46,29 +49,44 @@ defineSlots<{
 
 const el = useTemplateRef<HTMLInputElement>('el');
 
+const group = inject(RuiCheckboxGroupContextKey, undefined);
+
+const disabled = computed<boolean>(() => disabledProp || (group ? toValue(group.disabled) : false));
+const color = computed<ContextColorsType | undefined>(() => colorProp ?? (group ? toValue(group.color) : undefined));
+const size = computed<'sm' | 'lg' | undefined>(() => sizeProp ?? (group ? toValue(group.size) : undefined));
+// Suppress per-child details inside a group so the group's own hint/error wins.
+const effectiveHideDetails = computed<boolean>(() => hideDetails || (group !== undefined && value !== undefined));
+
 const { hasError, validation } = useFormTextDetail(
   () => errorMessages,
   () => successMessages,
 );
 
-const ui = computed<ReturnType<typeof checkControlStyles>>(() => checkControlStyles({
-  size,
-  disabled,
-  checked: get(modelValue) || get(indeterminate),
-  validation: get(validation),
-  color,
-}));
-
 const internalModelValue = computed<boolean>({
-  get: () => get(modelValue),
+  get: () => {
+    if (group && value !== undefined)
+      return group.isChecked(value);
+    return get(modelValue);
+  },
   set: (checked: boolean) => {
     if (checked)
       set(indeterminate, false);
-    set(modelValue, checked);
+    if (group && value !== undefined)
+      group.toggle(value, checked);
+    else
+      set(modelValue, checked);
   },
 });
 
-const iconSize = computed<number>(() => getCheckControlIconSize(size));
+const ui = computed<ReturnType<typeof checkControlStyles>>(() => checkControlStyles({
+  size: get(size),
+  disabled: get(disabled),
+  checked: get(internalModelValue) || get(indeterminate),
+  validation: get(validation),
+  color: get(color),
+}));
+
+const iconSize = computed<number>(() => getCheckControlIconSize(get(size)));
 
 watch(indeterminate, (val) => {
   const input = get(el);
@@ -92,7 +110,7 @@ watch(internalModelValue, (val) => {
       :class="ui.wrapper()"
       v-bind="objectPick($attrs, ['onClick'])"
       :data-disabled="disabled || undefined"
-      :data-checked="modelValue || indeterminate || undefined"
+      :data-checked="internalModelValue || indeterminate || undefined"
       :data-error="hasError ? '' : undefined"
     >
       <input
@@ -111,7 +129,7 @@ watch(internalModelValue, (val) => {
           :size="iconSize"
         />
         <RuiIcon
-          v-else-if="modelValue"
+          v-else-if="internalModelValue"
           name="lu-checkbox-fill"
           :size="iconSize"
         />
@@ -135,7 +153,7 @@ watch(internalModelValue, (val) => {
       </span>
     </label>
     <RuiFormTextDetail
-      v-if="!hideDetails"
+      v-if="!effectiveHideDetails"
       :error-messages="errorMessages"
       :success-messages="successMessages"
       :hint="hint"

--- a/packages/ui-library/src/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.spec.ts
+++ b/packages/ui-library/src/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.spec.ts
@@ -1,0 +1,140 @@
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiCheckboxGroup from '@/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue';
+import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
+
+function createWrapper(
+  options?: ComponentMountingOptions<typeof RuiCheckboxGroup>,
+) {
+  const opts: ComponentMountingOptions<typeof RuiCheckboxGroup> = {
+    ...options,
+    global: {
+      stubs: ['rui-icon'],
+    },
+  };
+
+  return mount(RuiCheckboxGroup, opts);
+}
+
+describe('components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue', () => {
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should have role="group" on wrapper', () => {
+    wrapper = createWrapper();
+    expect(wrapper.attributes('role')).toBe('group');
+  });
+
+  it('should pass inline props', async () => {
+    wrapper = createWrapper();
+    const groupWrapper = wrapper.findAll('div[role=group] > div')[0];
+    expect(groupWrapper?.classes()).not.toContain('flex');
+
+    await wrapper.setProps({ inline: true });
+    const updatedWrapper = wrapper.findAll('div[role=group] > div')[0];
+    expect(updatedWrapper?.classes()).toContain('flex');
+    expect(updatedWrapper?.classes()).toContain('space-x-6');
+  });
+
+  it('should pass hint props', async () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('.details > div').exists()).toBeFalsy();
+
+    const hint = 'CheckboxGroup Hints';
+    await wrapper.setProps({ hint });
+    const hintEl = wrapper.find('.details > div');
+    expect(hintEl.classes()).toEqual(expect.arrayContaining([expect.stringContaining('text-rui-text-secondary')]));
+    expect(hintEl.text()).toBe(hint);
+  });
+
+  it('should pass errorMessages', async () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('.details > div').exists()).toBeFalsy();
+
+    const errorMessage = 'CheckboxGroup Error Message';
+    await wrapper.setProps({ errorMessages: [errorMessage] });
+    const errorEl = wrapper.find('.details > div');
+    expect(errorEl.classes()).toEqual(expect.arrayContaining([expect.stringContaining('text-rui-error')]));
+    expect(errorEl.text()).toBe(errorMessage);
+  });
+
+  it('should pass hideDetails', () => {
+    wrapper = createWrapper({
+      props: {
+        hideDetails: true,
+        hint: 'This hint should not be rendered',
+      },
+    });
+    expect(wrapper.find('.details > div').exists()).toBeFalsy();
+  });
+
+  it('should show required asterisk when required prop is true', async () => {
+    const label = 'CheckboxGroup Label';
+    wrapper = createWrapper({
+      props: {
+        label,
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('﹡');
+
+    await wrapper.setProps({ required: true });
+    expect(wrapper.text()).toContain('﹡');
+    expect(wrapper.find('.text-rui-error').exists()).toBeTruthy();
+
+    await wrapper.setProps({ required: false });
+    expect(wrapper.text()).not.toContain('﹡');
+  });
+
+  it('should toggle values into the model array', async () => {
+    const Parent = defineComponent({
+      components: { RuiCheckbox, RuiCheckboxGroup },
+      data: () => ({ value: [] as string[] }),
+      template: `
+        <RuiCheckboxGroup v-model="value">
+          <RuiCheckbox value="a" label="A" />
+          <RuiCheckbox value="b" label="B" />
+        </RuiCheckboxGroup>
+      `,
+    });
+    const parent = mount(Parent, { global: { stubs: ['rui-icon'] } });
+
+    const inputs = parent.findAll('input[type=checkbox]');
+    expect(inputs).toHaveLength(2);
+
+    await inputs[0]!.setValue(true);
+    expect(parent.vm.value).toEqual(['a']);
+
+    await inputs[1]!.setValue(true);
+    expect(parent.vm.value).toEqual(['a', 'b']);
+
+    await inputs[0]!.setValue(false);
+    expect(parent.vm.value).toEqual(['b']);
+
+    parent.unmount();
+  });
+
+  it('should propagate disabled to children', () => {
+    const Parent = defineComponent({
+      components: { RuiCheckbox, RuiCheckboxGroup },
+      data: () => ({ value: [] as string[] }),
+      template: `
+        <RuiCheckboxGroup v-model="value" disabled>
+          <RuiCheckbox value="a" label="A" />
+          <RuiCheckbox value="b" label="B" />
+        </RuiCheckboxGroup>
+      `,
+    });
+    const parent = mount(Parent, { global: { stubs: ['rui-icon'] } });
+
+    const inputs = parent.findAll('input[type=checkbox]');
+    inputs.forEach((input) => {
+      expect(input.attributes('disabled')).toBeDefined();
+    });
+
+    parent.unmount();
+  });
+});

--- a/packages/ui-library/src/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.stories.ts
+++ b/packages/ui-library/src/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.stories.ts
@@ -1,0 +1,113 @@
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import { expect } from 'storybook/test';
+import RuiCheckboxGroup from '@/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue';
+import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
+import { contextColors } from '@/consts/colors';
+import preview from '~/.storybook/preview';
+
+function render(args: ComponentPropsAndSlots<typeof RuiCheckboxGroup<string>>) {
+  return {
+    components: {
+      RuiCheckbox: RuiCheckbox<string>,
+      RuiCheckboxGroup: RuiCheckboxGroup<string>,
+    },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          args.modelValue = val;
+        },
+      });
+
+      return { args, modelValue };
+    },
+    template: `<RuiCheckboxGroup v-bind="args" v-model="modelValue">
+    <RuiCheckbox value="apples">apples</RuiCheckbox>
+    <RuiCheckbox value="oranges">oranges</RuiCheckbox>
+    <RuiCheckbox value="grapes">grapes</RuiCheckbox>
+  </RuiCheckboxGroup>`,
+  };
+}
+
+const meta = preview.meta({
+  argTypes: {
+    color: { control: 'select', options: contextColors },
+    disabled: { control: 'boolean', table: { category: 'State' } },
+    errorMessages: { control: 'object' },
+    hideDetails: { control: 'boolean' },
+    hint: { control: 'text' },
+    inline: { control: 'boolean' },
+    label: { control: 'text' },
+    modelValue: { control: 'object' },
+    required: { control: 'boolean', table: { category: 'State' } },
+    size: { control: 'select', options: ['sm', 'lg'] },
+    successMessages: { control: 'object' },
+  },
+  args: {
+    modelValue: [],
+  },
+  component: RuiCheckboxGroup<string>,
+  render,
+  tags: ['autodocs'],
+  title: 'Components/Forms/Checkbox/CheckboxGroup',
+});
+
+export const Default = meta.story({
+  args: {},
+  async play({ canvas, userEvent }) {
+    const apples = canvas.getByRole('checkbox', { name: 'apples' });
+    const oranges = canvas.getByRole('checkbox', { name: 'oranges' });
+    await expect(apples).not.toBeChecked();
+    await expect(oranges).not.toBeChecked();
+    await userEvent.click(apples);
+    await expect(apples).toBeChecked();
+    await userEvent.click(oranges);
+    await expect(oranges).toBeChecked();
+    // Both can be checked simultaneously (vs radios)
+    await expect(apples).toBeChecked();
+  },
+});
+
+export const Inline = meta.story({
+  args: {
+    inline: true,
+  },
+});
+
+export const WithErrorMessage = meta.story({
+  args: {
+    errorMessages: ['Select at least one option'],
+  },
+});
+
+export const WithHint = meta.story({
+  args: {
+    hint: 'Pick any combination of fruits',
+  },
+});
+
+export const HideDetails = meta.story({
+  args: {
+    hideDetails: true,
+    hint: 'Hint (should be invisible)',
+  },
+});
+
+export const Required = meta.story({
+  args: {
+    label: 'Required Group',
+    required: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+    label: 'Disabled Group',
+    modelValue: ['apples'],
+  },
+});
+
+export default meta;

--- a/packages/ui-library/src/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue
+++ b/packages/ui-library/src/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue
@@ -1,0 +1,92 @@
+<script lang="ts" setup generic="TValue">
+import type { ContextColorsType } from '@/consts/colors';
+import { RuiCheckboxGroupContextKey } from '@/components/forms/checkbox/checkbox-group/context';
+import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
+
+export interface Props {
+  inline?: boolean;
+  label?: string;
+  hint?: string;
+  errorMessages?: string | string[];
+  successMessages?: string | string[];
+  hideDetails?: boolean;
+  disabled?: boolean;
+  color?: ContextColorsType;
+  size?: 'sm' | 'lg';
+  required?: boolean;
+}
+
+defineOptions({
+  name: 'RuiCheckboxGroup',
+  inheritAttrs: false,
+});
+
+const modelValue = defineModel<TValue[]>({ default: () => [] });
+
+const {
+  inline = false,
+  label = '',
+  hint = '',
+  errorMessages = [],
+  successMessages = [],
+  hideDetails = false,
+  disabled = false,
+  color,
+  size,
+  required = false,
+} = defineProps<Props>();
+
+defineSlots<{
+  default?: () => any;
+}>();
+
+function arrayIncludes(arr: readonly TValue[], value: unknown): boolean {
+  return Array.prototype.includes.call(arr, value);
+}
+
+provide(RuiCheckboxGroupContextKey, {
+  isChecked: (value: unknown): boolean => arrayIncludes(get(modelValue), value),
+  toggle: (value: unknown, checked: boolean): void => {
+    const current = get(modelValue);
+    const present = arrayIncludes(current, value);
+    if (checked === present)
+      return;
+    if (checked)
+      set(modelValue, [...current, value as TValue]);
+    else
+      set(modelValue, current.filter(v => v !== value));
+  },
+  disabled: () => disabled,
+  color: () => color,
+  size: () => size,
+});
+</script>
+
+<template>
+  <div
+    role="group"
+    v-bind="$attrs"
+  >
+    <div
+      v-if="label"
+      class="text-rui-text-secondary text-body-1"
+    >
+      {{ label }}
+      <span
+        v-if="required"
+        class="text-rui-error"
+      >
+        ﹡
+      </span>
+    </div>
+    <div :class="{ 'flex space-x-6': inline }">
+      <slot />
+    </div>
+    <RuiFormTextDetail
+      v-if="!hideDetails"
+      :error-messages="errorMessages"
+      :success-messages="successMessages"
+      :hint="hint"
+    />
+  </div>
+</template>

--- a/packages/ui-library/src/components/forms/checkbox/checkbox-group/context.ts
+++ b/packages/ui-library/src/components/forms/checkbox/checkbox-group/context.ts
@@ -1,0 +1,13 @@
+import type { InjectionKey, MaybeRefOrGetter } from 'vue';
+import type { ContextColorsType } from '@/consts/colors';
+
+export interface RuiCheckboxGroupContext {
+  isChecked: (value: unknown) => boolean;
+  toggle: (value: unknown, checked: boolean) => void;
+  disabled: MaybeRefOrGetter<boolean>;
+  color: MaybeRefOrGetter<ContextColorsType | undefined>;
+  size: MaybeRefOrGetter<'sm' | 'lg' | undefined>;
+}
+
+export const RuiCheckboxGroupContextKey: InjectionKey<RuiCheckboxGroupContext>
+  = Symbol('RuiCheckboxGroupContext');

--- a/packages/ui-library/src/components/index.ts
+++ b/packages/ui-library/src/components/index.ts
@@ -21,6 +21,7 @@ import RuiColorPicker from '@/components/color-picker/RuiColorPicker.vue';
 import RuiDateTimePicker, { type RuiDateTimePickerProps } from '@/components/date-time-picker/RuiDateTimePicker.vue';
 import RuiDivider, { type Props as DividerProps } from '@/components/divider/RuiDivider.vue';
 import RuiAutoComplete, { type AutoCompleteProps, type RuiAutoCompleteClassNames } from '@/components/forms/auto-complete/RuiAutoComplete.vue';
+import RuiCheckboxGroup, { type Props as CheckboxGroupProps } from '@/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue';
 import RuiCheckbox, { type Props as CheckboxProps } from '@/components/forms/checkbox/RuiCheckbox.vue';
 import RuiRadioGroup, { type Props as RadioGroupProps } from '@/components/forms/radio-button/radio-group/RuiRadioGroup.vue';
 import RuiRadio, { type RadioProps } from '@/components/forms/radio-button/radio/RuiRadio.vue';
@@ -67,6 +68,7 @@ export type {
   CalendarProps,
   CardHeaderProps,
   CardProps,
+  CheckboxGroupProps,
   CheckboxProps,
   ChipProps,
   DataTableColumn,
@@ -134,6 +136,7 @@ export {
   RuiCard,
   RuiCardHeader,
   RuiCheckbox,
+  RuiCheckboxGroup,
   RuiChip,
   RuiColorPicker,
   RuiDataTable,


### PR DESCRIPTION
## Summary
- Adds `RuiCheckboxGroup` — a multi-select grouping primitive with v-model array of selected values, mirroring `RuiRadioGroup`'s public API (`label`, `hint`, `errorMessages`, `successMessages`, `hideDetails`, `disabled`, `color`, `size`, `required`, `inline`).
- `RuiCheckbox` gains an optional generic `value` prop and joins a group via `provide`/`inject` when nested under `RuiCheckboxGroup`. Outside a group it stays a plain boolean checkbox (backward compatible).
- Includes Storybook stories, unit tests, an example app section, and e2e coverage.

Closes #50.

## Design notes
- Provide/inject (rather than slot-VNode iteration like `RuiRadioGroup`) keeps `RuiCheckbox`'s public `modelValue` typed as `boolean`, so existing internal consumers (`RuiDataTable`, `RuiTableHead`) are unaffected.
- The injected context uses `MaybeRefOrGetter<T>` + `toValue()` for group-level `disabled`/`color`/`size` propagation.
- Children inside a group auto-suppress their per-row `RuiFormTextDetail` so the group's own hint/error renders cleanly.

## Test plan
- [x] `pnpm typecheck` (lib + example) — clean
- [x] `pnpm lint` — clean (0 errors)
- [x] `pnpm --filter @rotki/ui-library test:run` — 1080/1080 unit tests pass
- [x] `pnpm --filter example test:e2e:dev forms/checkbox.spec.ts` — 5/5 pass
- [x] `pnpm --filter @rotki/ui-library build:prod` — builds cleanly, web-types regenerated
- [ ] Reviewer: spot-check Storybook entries (`Components/Forms/Checkbox/CheckboxGroup`)