### PR TITLE
fix(data-table): avoid spurious expand column on page change

### DIFF
--- a/apps/example/e2e/data-table.spec.ts
+++ b/apps/example/e2e/data-table.spec.ts
@@ -135,6 +135,24 @@ test.describe('data tables - pagination', () => {
     expect(textBefore).not.toEqual(textAfter);
   });
 
+  test('should not introduce an expand-button column on page change when expanded is not bound', async ({ page }) => {
+    const container = page.locator('[data-id=table-pagination-basic]');
+    const table = container.locator('[data-id=table]');
+    await expect(table).toBeVisible();
+
+    // No expand button on initial render
+    await expect(table.locator('tbody [data-id="expand-button"]')).toHaveCount(0);
+
+    // Trigger pagination
+    await container.locator('[data-id=table-pagination-next]').first().click();
+
+    // No expand button should appear after page change (regression: #onPaginate
+    // used to unconditionally reset `expanded` to [], flipping `expandable` to
+    // true and auto-adding an expand column even though no `expanded-item` slot
+    // was provided).
+    await expect(table.locator('tbody [data-id="expand-button"]')).toHaveCount(0);
+  });
+
   test('should navigate back with previous button', async ({ page }) => {
     const container = page.locator('[data-id=table-pagination-basic]');
     const table = container.locator('[data-id=table]');

--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -757,6 +757,28 @@ describe('components/tables/RuiDataTable.vue', () => {
       expect(wrapper.props().pagination?.page).toBe(1);
     });
 
+    it('should not emit update:expanded on page change when expanded is not bound', async () => {
+      wrapper = createWrapper({
+        props: {
+          'cols': columns,
+          'onUpdate:pagination': (e: any) => wrapper.setProps({ pagination: e }),
+          'pagination': { limit: 10, page: 1, total: 50 },
+          'rowAttr': 'id',
+          'rows': data,
+        },
+      });
+
+      expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').exists()).toBe(false);
+
+      const innerPagination = wrapper.findComponent(RuiTablePagination);
+      innerPagination.vm.$emit('update:modelValue', { limit: 10, page: 2, total: 50 });
+      await nextTick();
+
+      expect(wrapper.props().pagination?.page).toBe(2);
+      expect(wrapper.emitted('update:expanded')).toBeUndefined();
+      expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').exists()).toBe(false);
+    });
+
     it('should clear selection when toggling all off', async () => {
       wrapper = createWrapper({
         props: {

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -297,7 +297,8 @@ function onSort(payload: Parameters<typeof applySort>[0]): void {
 }
 
 function onPaginate(): void {
-  set(expanded, []);
+  if (get(expanded))
+    set(expanded, []);
   if (!multiPageSelect)
     onToggleAll(false);
   resetCheckboxShiftState();


### PR DESCRIPTION
## Summary

- `RuiDataTable`'s `onPaginate` unconditionally ran `set(expanded, [])` on every page change. For consumers that hadn't bound `v-model:expanded`, this wrote into `useModel`'s local cache and flipped `expandable` (`!!get(expanded)`) to `true`, causing `useTableColumns` to auto-append a non-functional expand column (chevron with no `expanded-item` slot to render).
- Guarded the reset with `if (get(expanded))` so consumers that opt out of expansion are unaffected; consumers that opt in still get pagination resetting their expanded rows.

## Test plan

- [x] Unit: new `RuiDataTable.spec.ts` test "should not emit update:expanded on page change when expanded is not bound" — emits `update:modelValue` on the inner `RuiTablePagination` and asserts no `update:expanded` fired and no `[data-id="expand-button"]` appears. Verified to fail without the fix.
- [x] E2E: new `data-table.spec.ts` test "should not introduce an expand-button column on page change when expanded is not bound" — paginates the basic table and asserts zero expand buttons. Verified to fail without the fix.
- [x] Existing 96 `RuiDataTable.spec.ts` unit tests still pass.