### PR TITLE
fix(icon): pin RuiIcon at --rui-icon-size in flex containers

### DIFF
--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -120,6 +120,21 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.classes()).toContain('h-[var(--rui-icon-size,1.5rem)]');
   });
 
+  it('should carry shrink-0 so a flex sibling cannot squeeze the icon below --rui-icon-size', () => {
+    wrapper = createWrapper({
+      props: {
+        name: 'lu-circle-arrow-down',
+      },
+    });
+
+    // Regression guard: in `RuiButton variant="list"` the label is `w-full`
+    // and `text-nowrap`. With a long label inside a width-bounded menu, a
+    // shrinkable SVG sibling collapses on the main axis (the height stays at
+    // the var-driven box, so the glyph renders as a sliver). `shrink-0`
+    // pins the icon at its `--rui-icon-size` regardless of sibling pressure.
+    expect(wrapper.classes()).toContain('shrink-0');
+  });
+
   it('should always carry the rui-icon marker class for parent-driven sizing', () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -21,7 +21,14 @@ const { registeredIcons } = useIcons();
 type SvgComponent = [tag: string, attrs: Record<string, string>];
 
 const iconStyles = tv({
-  base: 'w-[var(--rui-icon-size,1.5rem)] h-[var(--rui-icon-size,1.5rem)]',
+  // `shrink-0` keeps the icon at its declared `--rui-icon-size` when it sits
+  // in a flex container next to a long flex-grow sibling (e.g. a `w-full`
+  // button label in `variant="list"`). Without it, the SVG — even with an
+  // explicit width — gets compressed along the main axis when the row is
+  // narrower than the label's intrinsic width, while the height stays put,
+  // producing a sliver glyph. The icon's box is always intentionally driven
+  // by `--rui-icon-size`, so flex shrinking is never the desired behavior.
+  base: 'shrink-0 w-[var(--rui-icon-size,1.5rem)] h-[var(--rui-icon-size,1.5rem)]',
   variants: {
     color: {
       primary: 'text-rui-primary',


### PR DESCRIPTION
## Summary

A flex item's default `flex-shrink: 1` lets it compress below its declared width when a sibling exerts main-axis pressure — an explicit `width` doesn't prevent that. In `RuiButton variant="list"` the label is `w-full text-nowrap`, so a long label inside a width-bounded menu squeezes the `RuiIcon` SVG along the main axis while the height stays at the var-driven box, producing a sliver glyph (e.g. ~6×18 instead of 18×18).

`RuiIcon`'s box is always intentionally driven by `--rui-icon-size`, so flex shrinking is never the desired behavior. Adding `shrink-0` to the base classes pins every icon at its declared size for every consumer (list buttons, chips, toolbars) without per-call-site overrides.

### Repro before the fix

```vue
<RuiMenu menu-class="max-w-[15rem]">
  <RuiButton variant="list">
    <template #prepend><RuiIcon name="lu-eye" /></template>
    Exclude events from Accounting
  </RuiButton>
</RuiMenu>
```

The eye icon renders at ~6 × 18px because the long label is `w-full` and pushes the SVG below its declared width.

### Change

- `RuiIcon.vue`: prepend `shrink-0` to the base `iconStyles` slot.
- `RuiIcon.spec.ts`: regression guard asserting `shrink-0` is present so a future refactor can't silently drop it.

## Test plan

- [x] `pnpm test -- --run RuiIcon` — 1082 / 1082 pass
- [ ] Visual smoke in a long-label `variant="list"` menu (e.g. rotki's history-event action menu) — icon renders at 18×18 instead of being squeezed