### PR TITLE
fix(forms): wire hover border on activator-based inputs

### DIFF
--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -82,6 +82,7 @@ const baseFormats: Record<DateFormat, string> = {
 };
 
 const isOpen = ref<boolean>(false);
+const isHovered = ref<boolean>(false);
 const cursorPosition = ref<number>(0);
 const currentValue = ref<number>();
 
@@ -235,6 +236,7 @@ const ui = computed<ReturnType<typeof dateTimePickerStyles>>(() => dateTimePicke
   outlined: get(isOutlined),
   float: get(float),
   opened: get(isOpen),
+  hovered: get(isHovered),
   dense,
   disabled,
   readonly,
@@ -321,6 +323,8 @@ watch(anyMenuOpen, (value) => {
         data-id="activator"
         :aria-invalid="hasError"
         :tabindex="disabled || readonly ? -1 : 0"
+        @mouseenter="isHovered = true"
+        @mouseleave="isHovered = false"
         @click="setInputFocus()"
       >
         <span

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -172,6 +172,7 @@ const {
 );
 
 const isOpen = ref<boolean>(false);
+const isHovered = ref<boolean>(false);
 
 // Calculate multiple from modelValue directly to avoid circular dependency
 const multiple = computed<boolean>(() => Array.isArray(get(modelValue)));
@@ -317,6 +318,7 @@ const ui = computed<ReturnType<typeof autoCompleteStyles>>(() => autoCompleteSty
   outlined: get(outlined),
   float: get(float),
   opened: get(isOpen),
+  hovered: get(isHovered),
   dense,
   disabled,
   readonly: readOnly,
@@ -495,6 +497,8 @@ defineExpose({
           data-id="activator"
           :aria-invalid="hasError"
           :tabindex="disabled || readOnly ? -1 : 0"
+          @mouseenter="isHovered = true"
+          @mouseleave="isHovered = false"
           @click="focusSetInputFocus()"
           @focus="focusOnActivatorFocused()"
           @keydown.enter="onEnter($event)"

--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
@@ -105,6 +105,7 @@ defineSlots<{
 const menuRef = useTemplateRef<HTMLDivElement>('menuRef');
 const activator = useTemplateRef<HTMLDivElement>('activator');
 const { focused } = useFocus(activator);
+const isHovered = ref<boolean>(false);
 
 const { hasError, hasSuccess } = useFormTextDetail(
   () => errorMessages,
@@ -169,6 +170,7 @@ const ui = computed<ReturnType<typeof menuSelectStyles>>(() => menuSelectStyles(
   outlined: get(outlined),
   float: get(float),
   opened: get(isOpen),
+  hovered: get(isHovered),
   dense,
   disabled,
   readonly: readOnly,
@@ -221,6 +223,8 @@ function clear(): void {
           }"
           data-id="activator"
           :aria-invalid="hasError"
+          @mouseenter="isHovered = true"
+          @mouseleave="isHovered = false"
           @keydown.up.prevent="moveHighlight(true)"
           @keydown.down.prevent="moveHighlight(false)"
           @keydown.enter.prevent="applyHighlighted()"

--- a/packages/ui-library/src/components/forms/text-input-styles.ts
+++ b/packages/ui-library/src/components/forms/text-input-styles.ts
@@ -216,6 +216,8 @@ export const activatorStyles = tv({
     hasSuccess: {
       true: {},
     },
+    // Re-declare for type inference — actual styles are in textInputBase
+    hovered: { true: {} },
   },
   compoundVariants: [
     // Legend padding when label is floated


### PR DESCRIPTION
## Summary
- RuiAutoComplete, RuiMenuSelect, and RuiDateTimePicker share `activatorStyles`, which already defines an `outlined + hovered` border rule, but none of them tracked the hover state — so the hover-border-darken behavior present in RuiTextField/RuiTextArea was missing.
- Track `isHovered` via `mouseenter`/`mouseleave` on each activator and pass it into `ui()`.
- Re-declare the `hovered` variant in `activatorStyles` for type inference, mirroring the existing `filled` re-declaration.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:run` for AutoComplete / MenuSelect / DateTimePicker
- [ ] Visual: hover the outlined variant of each component and confirm the border darkens (matching RuiTextField/RuiTextArea), and that the focus/error/success states still take precedence.