### PR TITLE
fix(date-time-picker): clear typed-digit buffer on segment switch

### DIFF
--- a/apps/example/e2e/datetimepicker.spec.ts
+++ b/apps/example/e2e/datetimepicker.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 test.describe('datetimepicker inside parent menu', () => {
   test.beforeEach(async ({ page }) => {
@@ -54,5 +54,100 @@ test.describe('datetimepicker inside parent menu', () => {
     await page.mouse.click(5, 5);
 
     await expect(parentContent).toBeHidden();
+  });
+});
+
+test.describe('datetimepicker segment typing', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/datetimepickers');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('Escape');
+  });
+
+  // Helper to read the visible input value
+  async function readValue(page: Page): Promise<string> {
+    return page.getByRole('textbox').first().inputValue();
+  }
+
+  // Helper to click on a specific segment of the visible input by character offset.
+  // Range is computed from the format "DD/MM/YYYY HH:mm":
+  //   DD=0..2, MM=3..5, YYYY=6..10, HH=11..13, mm=14..16
+  async function selectSegment(page: Page, start: number, end: number): Promise<void> {
+    const input = page.getByRole('textbox').first();
+    // Measure the pixel x-offset of the midpoint between `start` and `end` so the click
+    // lands inside the desired segment. The component reads the click position via
+    // document.caretPositionFromPoint, so accurate coordinates matter.
+    const offsetX = await input.evaluate((el, args) => {
+      if (!(el instanceof HTMLInputElement))
+        throw new Error('expected input element');
+      const style = window.getComputedStyle(el);
+      const canvas = document.createElement('canvas');
+      const ctx = canvas.getContext('2d');
+      if (!ctx)
+        throw new Error('canvas 2d context unavailable');
+      ctx.font = `${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+      const beforeWidth = ctx.measureText(el.value.slice(0, args.start)).width;
+      const segmentWidth = ctx.measureText(el.value.slice(args.start, args.end)).width;
+      return beforeWidth + segmentWidth / 2;
+    }, { start, end });
+
+    const box = await input.boundingBox();
+    if (!box)
+      throw new Error('input bounding box unavailable');
+    await page.mouse.click(box.x + offsetX, box.y + box.height / 2);
+  }
+
+  test('typing "12" in hour with existing value yields hour 12, not 13', async ({ page }) => {
+    // Initial value is "02/01/2023 20:20"
+    await expect(page.getByRole('textbox').first()).toHaveValue('02/01/2023 20:20');
+
+    await page.getByRole('textbox').first().click();
+    // Select the HH segment ("20")
+    await selectSegment(page, 11, 13);
+
+    await page.keyboard.press('1');
+    expect(await readValue(page)).toMatch(/01:20$/);
+
+    await page.keyboard.press('2');
+    expect(await readValue(page)).toMatch(/12:20$/);
+  });
+
+  test('switching segments via click resets in-progress digit buffer', async ({ page }) => {
+    await expect(page.getByRole('textbox').first()).toHaveValue('02/01/2023 20:20');
+
+    await page.getByRole('textbox').first().click();
+    await selectSegment(page, 11, 13);
+
+    // Type "1" in HH — does not auto-advance yet (length < 2)
+    await page.keyboard.press('1');
+    expect(await readValue(page)).toMatch(/01:20$/);
+
+    // Click into the minute segment instead of letting HH auto-advance
+    await selectSegment(page, 14, 16);
+
+    // Typing "3" must set mm=3 (not 13). Before the fix the leftover "1" from HH
+    // would combine with "3" and produce mm=13.
+    await page.keyboard.press('3');
+    expect(await readValue(page)).toMatch(/01:03$/);
+  });
+
+  test('typing in the minute segment never alters the hour', async ({ page }) => {
+    await expect(page.getByRole('textbox').first()).toHaveValue('02/01/2023 20:20');
+
+    await page.getByRole('textbox').first().click();
+    // Type "1" in HH first to seed the in-progress buffer
+    await selectSegment(page, 11, 13);
+    await page.keyboard.press('1');
+
+    // Click to minute segment and type three digits
+    await selectSegment(page, 14, 16);
+    await page.keyboard.press('4');
+    await page.keyboard.press('5');
+
+    // Minute should be 45; hour must remain whatever we set it to (01), not change
+    expect(await readValue(page)).toMatch(/^02\/01\/2023 01:45$/);
   });
 });

--- a/packages/ui-library/src/components/date-time-picker/use-keyboard-handler.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-keyboard-handler.spec.ts
@@ -205,6 +205,141 @@ describe('use-keyboard-handler', () => {
     });
   });
 
+  describe('segment switching resets in-progress digit buffer', () => {
+    function makeInputWithSelection(value: string, start: number, end: number): HTMLInputElement {
+      const input = document.createElement('input');
+      input.value = value;
+      Object.defineProperty(input, 'selectionStart', { value: start, writable: true, configurable: true });
+      Object.defineProperty(input, 'selectionEnd', { value: end, writable: true, configurable: true });
+      return input;
+    }
+
+    it('should not carry a partially typed HH digit into mm when clicking minute segment', () => {
+      const segmentValues: Record<DateTimeSegmentType, number | undefined> = {
+        DD: 15,
+        HH: 14,
+        MM: 6,
+        SSS: 0,
+        YYYY: 2023,
+        mm: 30,
+        ss: 0,
+      };
+      const currentValue = ref<number | undefined>(undefined);
+      const cursorPosition = ref<number>(0);
+      const hhInput = makeInputWithSelection('15/06/2023 14:30', 11, 13);
+
+      const setValue = vi.fn((segment: DateTimeSegmentType, value?: number) => {
+        segmentValues[segment] = value;
+        currentValue.value = value;
+      });
+
+      const { handler } = createMockOptions({
+        currentValue,
+        cursorPosition,
+        setValue,
+        textInput: ref<HTMLInputElement | undefined>(hhInput),
+      });
+
+      // Type "1" in HH segment → HH=1, currentValue=1, no auto-navigate (length < 2)
+      const key1 = new KeyboardEvent('keydown', { key: '1' });
+      Object.defineProperty(key1, 'target', { value: hhInput });
+      handler.handleKeyDown(key1);
+      expect(segmentValues.HH).toBe(1);
+      expect(currentValue.value).toBe(1);
+
+      // User clicks on minute segment via mouse (selection 14-16)
+      const mmInput = makeInputWithSelection('15/06/2023 01:30', 14, 16);
+      const click = new MouseEvent('click', { clientX: 0, clientY: 0 });
+      Object.defineProperty(click, 'target', { value: mmInput });
+      handler.handleClick(click);
+
+      // currentValue must be cleared so the next digit doesn't combine with "1"
+      expect(currentValue.value).toBeUndefined();
+
+      // Type "3" in mm — should become 3, not 13
+      const key3 = new KeyboardEvent('keydown', { key: '3' });
+      Object.defineProperty(key3, 'target', { value: mmInput });
+      handler.handleKeyDown(key3);
+      expect(segmentValues.mm).toBe(3);
+    });
+
+    it('should reset currentValue when handleMouseDown selects a segment', () => {
+      const currentValue = ref<number | undefined>(7);
+      const mmInput = makeInputWithSelection('15/06/2023 14:30', 14, 16);
+
+      const { handler } = createMockOptions({ currentValue });
+
+      const event = new MouseEvent('mousedown', { clientX: 50, clientY: 10 });
+      Object.defineProperty(event, 'target', { value: mmInput });
+      handler.handleMouseDown(event);
+
+      expect(currentValue.value).toBeUndefined();
+    });
+
+    it('should reset currentValue when setSegment switches segments programmatically', () => {
+      const currentValue = ref<number | undefined>(4);
+      const mockInput = makeInputWithSelection('15/06/2023 14:30', 0, 0);
+
+      const { handler } = createMockOptions({
+        currentValue,
+        textInput: ref<HTMLInputElement | undefined>(mockInput),
+      });
+
+      handler.setSegment('mm');
+
+      expect(currentValue.value).toBeUndefined();
+    });
+
+    it('should not let a leftover mm digit bleed into HH after switching back', () => {
+      const segmentValues: Record<DateTimeSegmentType, number | undefined> = {
+        DD: 15,
+        HH: 14,
+        MM: 6,
+        SSS: 0,
+        YYYY: 2023,
+        mm: 30,
+        ss: 0,
+      };
+      const currentValue = ref<number | undefined>(undefined);
+      const cursorPosition = ref<number>(0);
+      const mmInput = makeInputWithSelection('15/06/2023 14:30', 14, 16);
+
+      const setValue = vi.fn((segment: DateTimeSegmentType, value?: number) => {
+        segmentValues[segment] = value;
+        currentValue.value = value;
+      });
+
+      const { handler } = createMockOptions({
+        currentValue,
+        cursorPosition,
+        setValue,
+        textInput: ref<HTMLInputElement | undefined>(mmInput),
+      });
+
+      // Type "2" in mm → mm=2, currentValue=2
+      const key2 = new KeyboardEvent('keydown', { key: '2' });
+      Object.defineProperty(key2, 'target', { value: mmInput });
+      handler.handleKeyDown(key2);
+      expect(segmentValues.mm).toBe(2);
+
+      // Switch to HH via the menu's setSegment (e.g. clicking "Select hours" tab)
+      handler.setSegment('HH');
+      expect(currentValue.value).toBeUndefined();
+
+      // Type "1" then "2" expecting HH=12 (not 212 or 13 or anything else)
+      const hhInput = makeInputWithSelection('15/06/2023 14:02', 11, 13);
+      const k1 = new KeyboardEvent('keydown', { key: '1' });
+      Object.defineProperty(k1, 'target', { value: hhInput });
+      handler.handleKeyDown(k1);
+      expect(segmentValues.HH).toBe(1);
+
+      const k2 = new KeyboardEvent('keydown', { key: '2' });
+      Object.defineProperty(k2, 'target', { value: hhInput });
+      handler.handleKeyDown(k2);
+      expect(segmentValues.HH).toBe(12);
+    });
+  });
+
   describe('handleClick', () => {
     it('should set cursor position to clicked segment', () => {
       const cursorPosition = ref<number>(0);

--- a/packages/ui-library/src/components/date-time-picker/use-keyboard-handler.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-keyboard-handler.ts
@@ -81,6 +81,7 @@ export function useKeyboardHandler(options: KeyboardHandlerOptions) {
   function setSegment(segmentType: DateTimeSegmentType): void {
     const segments = get(segmentPositions).find(segment => segment.type === segmentType);
     if (segments) {
+      set(currentValue, undefined);
       setCursorPosition(segments);
     }
   }
@@ -244,6 +245,10 @@ export function useKeyboardHandler(options: KeyboardHandlerOptions) {
       return;
     const currentSegment = getCurrentSegment(getClickPosition(event, event.target, true));
     if (currentSegment) {
+      // Reset in-progress digit buffer: switching segments must not carry typed digits over,
+      // otherwise a leftover digit from another segment combines with the next keystroke
+      // (e.g. type "1" in HH, click mm, type "3" → mm becomes 13 instead of 3).
+      set(currentValue, undefined);
       clickedSegment = currentSegment;
     }
   }
@@ -253,6 +258,7 @@ export function useKeyboardHandler(options: KeyboardHandlerOptions) {
       return;
     const currentSegment = getCurrentSegment(getClickPosition(event, event.target, true));
     if (currentSegment) {
+      set(currentValue, undefined);
       clickedSegment = currentSegment;
       set(cursorPosition, currentSegment.end);
       event.target.setSelectionRange(currentSegment.start, currentSegment.end);


### PR DESCRIPTION
## Summary

- The in-progress digit buffer (`currentValue` in `use-keyboard-handler.ts`) was only cleared on arrow-key navigation. Switching segments via mouse click or via the time picker's hour/minute tabs (which call `setSegment`) left a leftover digit that silently combined with the next keystroke.
- Repro: with cursor in HH, type `1` (no auto-advance since length < 2), click into the minute segment, type `3` — minute becomes `13` instead of `3`. The symmetric case explains the reported "typing in the minute updates the hour" symptom.
- Fix: reset `currentValue` in `handleClick`, `handleMouseDown`, and `setSegment` so segment switches start with a clean buffer, mirroring `navigateSegments`.

## Test plan

- [x] New unit tests in `use-keyboard-handler.spec.ts` covering click-switch, mousedown-switch, programmatic `setSegment`, and the cross-segment digit bleed.
- [x] New Playwright tests in `apps/example/e2e/datetimepicker.spec.ts`: typing `12` in hour yields `12`, switching segments mid-type resets the buffer, typing in the minute segment never alters the hour. (The middle test was confirmed to fail against the unpatched build.)
- [x] Full unit suite passes (1093 tests).
- [x] Full e2e suite passes.
- [x] `pnpm typecheck` clean.