### PR TITLE
fix(auto-complete): do not submit form on enter when no match

### DIFF
--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -480,6 +480,157 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     expect(submitFunc).toBeCalledTimes(1);
   });
 
+  it('should not submit form on enter when menu is open with no matches and customValue is false', async () => {
+    const form = document.createElement('form');
+    const submitFunc = vi.fn();
+    form.onsubmit = submitFunc;
+
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: form,
+      props: {
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    // Open the menu and type text that matches no option.
+    const activator = wrapper.find('div[data-id="activator"]');
+    await activator.trigger('focus');
+    await activator.trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const input = wrapper.find('input');
+    await input.setValue('zzzzzzzz');
+    await vi.runAllTimersAsync();
+
+    await activator.trigger('keydown.enter');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(submitFunc).not.toHaveBeenCalled();
+  });
+
+  it('should not submit form on enter when menu is open and no option is highlighted', async () => {
+    const form = document.createElement('form');
+    const submitFunc = vi.fn();
+    form.onsubmit = submitFunc;
+
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: form,
+      props: {
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    // Open menu without typing or navigating; nothing is highlighted because
+    // autoSelectFirst is false and the user has not pressed arrow keys.
+    const activator = wrapper.find('div[data-id="activator"]');
+    await activator.trigger('focus');
+    await activator.trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    await activator.trigger('keydown.enter');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(submitFunc).not.toHaveBeenCalled();
+  });
+
+  it('should prevent default on enter when menu is open with no actionable selection', async () => {
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: document.body,
+      props: {
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    const activator = wrapper.find('div[data-id="activator"]');
+    await activator.trigger('focus');
+    await activator.trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const input = wrapper.find('input');
+    await input.setValue('zzzzzzzz');
+    await vi.runAllTimersAsync();
+
+    const enterEvent = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter',
+    });
+    activator.element.dispatchEvent(enterEvent);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(enterEvent.defaultPrevented).toBe(true);
+  });
+
+  it('should apply highlighted option (and not submit) on enter when menu is open and an option is highlighted', async () => {
+    const form = document.createElement('form');
+    const submitFunc = vi.fn();
+    form.onsubmit = submitFunc;
+
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: form,
+      props: {
+        autoSelectFirst: true,
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    // Open the menu — autoSelectFirst will highlight the first option.
+    const activator = wrapper.find('div[data-id="activator"]');
+    await activator.trigger('focus');
+    await activator.trigger('click');
+    await vi.runAllTimersAsync();
+
+    await activator.trigger('keydown.enter');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+    expect(submitFunc).not.toHaveBeenCalled();
+  });
+
+  it('should apply custom value (and not submit) on enter when customValue is true and search has no match', async () => {
+    const form = document.createElement('form');
+    const submitFunc = vi.fn();
+    form.onsubmit = submitFunc;
+
+    wrapper = createWrapper<string | undefined, SelectOption>({
+      attachTo: form,
+      props: {
+        customValue: true,
+        keyAttr: 'id',
+        modelValue: undefined,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    const activator = wrapper.find('div[data-id="activator"]');
+    await activator.trigger('focus');
+    await activator.trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const input = wrapper.find('input');
+    await input.setValue('zzzzzzzz');
+    await vi.runAllTimersAsync();
+
+    await activator.trigger('keydown.enter');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted()).toHaveProperty('update:modelValue');
+    expect(submitFunc).not.toHaveBeenCalled();
+  });
+
   it('should only show placeholder when input is focused', async () => {
     wrapper = createWrapper<string | undefined, SelectOption>({
       attachTo: document.body,

--- a/packages/ui-library/src/composables/forms/auto-complete/keyboard-navigation.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/keyboard-navigation.ts
@@ -101,51 +101,74 @@ export function useAutoCompleteKeyboardNavigation<TItem>(
     form?.dispatchEvent(new Event('submit'));
   }
 
-  function handleOpenMenuEnter(event: KeyboardEvent): boolean {
+  function tryApplyHighlight(event: KeyboardEvent): boolean {
     const filteredOptions = get(deps.filteredOptions);
     const highlightedIndex = get(deps.highlightedIndex);
+    if (highlightedIndex <= -1 || filteredOptions.length === 0)
+      return false;
+
+    deps.applyHighlighted();
+    event.preventDefault();
+    return true;
+  }
+
+  function tryApplyCustom(event: KeyboardEvent, requireEmptyOptions: boolean): boolean {
     const customValue = toValue(options.customValue);
-    const multiple = toValue(options.multiple);
     const internalSearch = get(deps.internalSearch);
+    if (!customValue || !internalSearch)
+      return false;
 
-    const userNavigated = get(deps.userNavigated);
-
-    if (userNavigated && highlightedIndex > -1 && filteredOptions.length > 0) {
-      deps.applyHighlighted();
-      event.preventDefault();
-      return true;
+    const filteredOptions = get(deps.filteredOptions);
+    if (requireEmptyOptions) {
+      if (filteredOptions.length > 0)
+        return false;
+    }
+    else {
+      const highlightedIndex = get(deps.highlightedIndex);
+      if (highlightedMatchesSearch(filteredOptions, highlightedIndex, internalSearch))
+        return false;
     }
 
-    if (customValue && internalSearch && !highlightedMatchesSearch(filteredOptions, highlightedIndex, internalSearch)) {
-      applyCustomValue(event, multiple);
-      return true;
-    }
+    applyCustomValue(event, toValue(options.multiple));
+    return true;
+  }
 
-    if (highlightedIndex > -1 && filteredOptions.length > 0) {
-      deps.applyHighlighted();
-      event.preventDefault();
+  function handleOpenMenuEnter(event: KeyboardEvent): boolean {
+    // Prefer the user's explicit navigation.
+    if (get(deps.userNavigated) && tryApplyHighlight(event))
       return true;
-    }
 
-    if (filteredOptions.length === 0 && customValue && internalSearch) {
-      applyCustomValue(event, multiple);
+    // Fall back to a typed custom value when it differs from the highlight.
+    if (tryApplyCustom(event, false))
       return true;
-    }
 
-    return false;
+    // Use the (auto-)highlighted option if there is one.
+    if (tryApplyHighlight(event))
+      return true;
+
+    // No options matched but custom values are allowed — accept the typed text.
+    return tryApplyCustom(event, true);
   }
 
   function onEnter(event: KeyboardEvent): void {
-    if (get(deps.isOpen) && handleOpenMenuEnter(event))
+    if (get(deps.isOpen)) {
+      if (handleOpenMenuEnter(event))
+        return;
+
+      // Menu is open but no actionable selection (e.g. typed text with no
+      // matches and customValue=false, or no highlighted option). Swallow
+      // Enter so it does not bubble up and submit a surrounding form.
+      event.preventDefault();
       return;
+    }
 
     // Nothing selected, menu closed: open menu
-    if (!get(deps.isOpen) && get(deps.value).length === 0) {
+    if (get(deps.value).length === 0) {
       set(deps.isOpen, true);
       return event.preventDefault();
     }
 
-    // Fallback: submit parent form
+    // Menu closed with a value selected: let Enter submit the parent form.
     submitClosestForm();
   }
 


### PR DESCRIPTION
## Summary

Pressing Enter in `RuiAutoComplete` while the menu is open with **no actionable selection** (typed text with no matches and `customValue=false`, or no highlighted option) currently falls through to a parent-form `submit` dispatch. Inside a dialog (e.g. rotki's `HistoryEventFormDialog` → `BigDialog`), this submits/closes the surrounding dialog instead of just consuming the keystroke.

The form-submit fallback was added in b27327e to make Enter submit a parent form when the autocomplete already has a value — that intent is preserved. The fix scopes the fallback to the menu-closed path only.

### Repro

1. Open any rotki dialog containing a `RuiAutoComplete` (e.g. EVM history event edit, counterparty field).
2. Type text that does not match any option (e.g. `asdf`).
3. Press Enter.

**Expected:** the keystroke is consumed; dialog stays open.
**Actual:** the surrounding form submits and the dialog closes (or the discard-changes prompt appears).

### Changes

- `composables/forms/auto-complete/keyboard-navigation.ts` — restructure `onEnter`:
  - Menu open + no actionable selection → `preventDefault()` and return (do **not** submit).
  - Menu closed + no value → open the menu (unchanged).
  - Menu closed + value selected → `submitClosestForm()` (preserves b27327e behavior).
- Extract `tryApplyHighlight` and `tryApplyCustom` from `handleOpenMenuEnter` to drop its cyclomatic complexity below the lint threshold without changing behavior. Note: branch 4 (the `requireEmptyOptions` custom-value path) appears unreachable because branch 2 already covers it; preserved as-is to avoid mixing a behavior assertion into this fix.

### Tests

Added 5 regression cases in `RuiAutoComplete.spec.ts` next to the existing form-submit test:

1. No submit when menu open with typed text and no matches (`customValue=false`).
2. No submit when menu open with no highlighted option (no `autoSelectFirst`, no nav).
3. Enter is `defaultPrevented` when menu open with no actionable selection.
4. Highlighted option is applied (and form not submitted) when `autoSelectFirst=true`.
5. Custom value is applied (and form not submitted) when `customValue=true` with non-matching search.

The original `'should trigger form submit when pressing enter on activator'` case still passes — it covers the intended menu-closed-with-value path.

## Test plan

- [x] `pnpm run test:run` — full suite green (1098/1098)
- [x] `pnpm exec eslint` clean on changed files
- [ ] Manual repro in rotki dev environment: counterparty field in EVM history event edit dialog no longer closes the dialog on Enter with no match