### PR TITLE
feat(file-upload): add RuiFileUpload component

### DIFF
--- a/apps/example/e2e/forms/file-upload.spec.ts
+++ b/apps/example/e2e/forms/file-upload.spec.ts
@@ -1,0 +1,99 @@
+import { Buffer } from 'node:buffer';
+import { expect, test } from '@playwright/test';
+
+test.describe('forms/FileUpload', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/file-uploads');
+  });
+
+  test('uploads a single csv file via the picker', async ({ page }) => {
+    await expect(page.locator('h2[data-id=file-uploads]')).toContainText('File Upload');
+
+    const section = page.getByTestId('single-csv');
+    const input = section.locator('input[type=file]');
+
+    await input.setInputFiles({
+      name: 'data.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from('a,b\n1,2\n'),
+    });
+
+    await expect(section.getByTestId('file-list')).toBeVisible();
+    await expect(section.getByTestId('file-list')).toContainText('data.csv');
+    await expect(section.getByTestId('single-csv-result')).toContainText('data.csv');
+  });
+
+  test('rejects files that do not match the accept filter', async ({ page }) => {
+    const section = page.getByTestId('single-csv');
+    const input = section.locator('input[type=file]');
+
+    await input.setInputFiles({
+      name: 'data.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('hello'),
+    });
+
+    await expect(section.locator('[data-error]')).toBeVisible();
+    await expect(section.getByTestId('file-list')).toHaveCount(0);
+  });
+
+  test('accepts multiple files when multiple is set', async ({ page }) => {
+    const section = page.getByTestId('multiple');
+    const input = section.locator('input[type=file]');
+
+    await input.setInputFiles([
+      { name: 'a.txt', mimeType: 'text/plain', buffer: Buffer.from('a') },
+      { name: 'b.txt', mimeType: 'text/plain', buffer: Buffer.from('b') },
+    ]);
+
+    await expect(section.getByTestId('multiple-result')).toContainText('2 file(s)');
+    await expect(section.getByTestId('file-item')).toHaveCount(2);
+  });
+
+  test('removes a file via the remove button', async ({ page }) => {
+    const section = page.getByTestId('multiple');
+    const input = section.locator('input[type=file]');
+
+    await input.setInputFiles([
+      { name: 'a.txt', mimeType: 'text/plain', buffer: Buffer.from('a') },
+      { name: 'b.txt', mimeType: 'text/plain', buffer: Buffer.from('b') },
+    ]);
+
+    await section.getByTestId('remove-file').first().click();
+    await expect(section.getByTestId('file-item')).toHaveCount(1);
+    await expect(section.getByTestId('multiple-result')).toContainText('1 file(s)');
+  });
+
+  test('renders the custom preview slot for images', async ({ page }) => {
+    const section = page.getByTestId('image-preview');
+    const input = section.locator('input[type=file]');
+
+    const pngBytes = Buffer.from(
+      '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000005000100'
+      + '0d0a2db40000000049454e44ae426082',
+      'hex',
+    );
+
+    await input.setInputFiles({
+      name: 'pic.png',
+      mimeType: 'image/png',
+      buffer: pngBytes,
+    });
+
+    await expect(section.getByTestId('image-preview-img')).toBeVisible();
+    await section.getByTestId('image-preview-remove').click();
+    await expect(section.getByTestId('image-preview-img')).toHaveCount(0);
+  });
+
+  test('shows external error messages', async ({ page }) => {
+    const section = page.getByTestId('external-error');
+    await expect(section.locator('[data-error]')).toBeVisible();
+    await expect(section).toContainText('Something went wrong upstream');
+  });
+
+  test('disables the input in disabled mode', async ({ page }) => {
+    const section = page.getByTestId('disabled');
+    await expect(section.locator('input[type=file]')).toBeDisabled();
+    await expect(section.locator('[data-disabled]')).toBeVisible();
+  });
+});

--- a/apps/example/src/App.vue
+++ b/apps/example/src/App.vue
@@ -19,6 +19,7 @@ const navigation = ref([
       { to: '/text-areas', title: 'Text Areas' },
       { to: '/sliders', title: 'Sliders' },
       { to: '/auto-completes', title: 'Auto Complete' },
+      { to: '/file-uploads', title: 'File Upload' },
       { to: '/steppers', title: 'Steppers' },
       { to: '/progress', title: 'Progress' },
       { to: '/loaders', title: 'Loaders' },

--- a/apps/example/src/pages/file-uploads.vue
+++ b/apps/example/src/pages/file-uploads.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import FileUploadView from '@/views/FileUploadView.vue';
+</script>
+
+<template>
+  <FileUploadView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -251,6 +251,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/file-uploads': RouteRecordInfo<
+      '/file-uploads',
+      '/file-uploads',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/icons': RouteRecordInfo<
       '/icons',
       '/icons',
@@ -621,6 +628,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/dividers.vue': {
       routes:
         | '/dividers'
+      views:
+        | never
+    }
+    'src/pages/file-uploads.vue': {
+      routes:
+        | '/file-uploads'
       views:
         | never
     }

--- a/apps/example/src/views/FileUploadView.vue
+++ b/apps/example/src/views/FileUploadView.vue
@@ -1,0 +1,169 @@
+<script lang="ts" setup>
+import { RuiButton, RuiFileUpload } from '@rotki/ui-library';
+import ComponentView from '@/components/ComponentView.vue';
+
+const singleFile = ref<File | undefined>(undefined);
+const multiFiles = ref<File[]>([]);
+const imageFile = ref<File | undefined>(undefined);
+const imagePreview = ref<string>('');
+const uploadedSuccess = ref<boolean>(false);
+const loadingState = ref<boolean>(false);
+const uploadProgress = ref<number | undefined>(undefined);
+
+function readPreview(file: File): void {
+  const reader = new FileReader();
+  reader.onloadend = () => {
+    set(imagePreview, String(reader.result));
+  };
+  reader.readAsDataURL(file);
+}
+
+watch(imageFile, (file) => {
+  if (file)
+    readPreview(file);
+  else
+    set(imagePreview, '');
+});
+
+function simulateUpload(): void {
+  set(loadingState, true);
+  set(uploadProgress, 0);
+  const handle = setInterval(() => {
+    const next = (get(uploadProgress) ?? 0) + 10;
+    if (next >= 100) {
+      clearInterval(handle);
+      set(uploadProgress, 100);
+      set(loadingState, false);
+      set(uploadProgress, undefined);
+      set(uploadedSuccess, true);
+      setTimeout(() => set(uploadedSuccess, false), 2000);
+      return;
+    }
+    set(uploadProgress, next);
+  }, 200);
+}
+</script>
+
+<template>
+  <ComponentView data-id="file-uploads">
+    <template #title>
+      File Upload
+    </template>
+
+    <div class="grid gap-8 md:grid-cols-2">
+      <div data-id="single-csv">
+        <h3 class="text-h6 mb-3">
+          Single CSV
+        </h3>
+        <RuiFileUpload
+          v-model="singleFile"
+          accept=".csv"
+          hint="Only .csv files are accepted"
+        />
+        <div
+          v-if="singleFile"
+          class="mt-2 text-sm text-rui-text-secondary"
+          data-id="single-csv-result"
+        >
+          Selected: {{ singleFile.name }}
+        </div>
+      </div>
+
+      <div data-id="multiple">
+        <h3 class="text-h6 mb-3">
+          Multiple files
+        </h3>
+        <RuiFileUpload
+          v-model="multiFiles"
+          multiple
+          hint="Drop one or more files"
+        />
+        <div
+          class="mt-2 text-sm text-rui-text-secondary"
+          data-id="multiple-result"
+        >
+          {{ multiFiles.length }} file(s) selected
+        </div>
+      </div>
+
+      <div data-id="image-preview">
+        <h3 class="text-h6 mb-3">
+          Image with preview slot
+        </h3>
+        <RuiFileUpload
+          v-model="imageFile"
+          accept="image/png,image/jpeg,image/webp"
+          :max-size="5 * 1024 * 1024"
+          hint="Up to 5 MB"
+        >
+          <template
+            v-if="imagePreview"
+            #preview="{ remove }"
+          >
+            <div class="flex items-center gap-3">
+              <img
+                :src="imagePreview"
+                alt="preview"
+                class="w-24 h-24 object-cover rounded-md"
+                data-id="image-preview-img"
+              />
+              <RuiButton
+                size="sm"
+                color="error"
+                variant="text"
+                data-id="image-preview-remove"
+                @click="remove()"
+              >
+                Remove
+              </RuiButton>
+            </div>
+          </template>
+        </RuiFileUpload>
+      </div>
+
+      <div data-id="loading-success">
+        <h3 class="text-h6 mb-3">
+          Loading / success state
+        </h3>
+        <RuiFileUpload
+          accept="*"
+          :loading="loadingState"
+          :progress="uploadProgress"
+          :uploaded="uploadedSuccess"
+          :model-value="undefined"
+          hint="Click Simulate to see determinate progress + success"
+        />
+        <RuiButton
+          class="mt-2"
+          size="sm"
+          color="primary"
+          data-id="simulate-upload"
+          @click="simulateUpload()"
+        >
+          Simulate upload
+        </RuiButton>
+      </div>
+
+      <div data-id="disabled">
+        <h3 class="text-h6 mb-3">
+          Disabled
+        </h3>
+        <RuiFileUpload
+          :model-value="undefined"
+          disabled
+          hint="Disabled state"
+        />
+      </div>
+
+      <div data-id="external-error">
+        <h3 class="text-h6 mb-3">
+          External error
+        </h3>
+        <RuiFileUpload
+          :model-value="undefined"
+          :error-messages="['Something went wrong upstream']"
+        />
+      </div>
+    </div>
+  </ComponentView>
+</template>

--- a/packages/ui-library/src/components/forms/file-upload/RuiFileUpload.spec.ts
+++ b/packages/ui-library/src/components/forms/file-upload/RuiFileUpload.spec.ts
@@ -1,0 +1,152 @@
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import RuiFileUpload from '@/components/forms/file-upload/RuiFileUpload.vue';
+
+function createWrapper(options?: ComponentMountingOptions<typeof RuiFileUpload>) {
+  return mount(RuiFileUpload, {
+    ...options,
+    global: { stubs: ['rui-icon', 'rui-progress'] },
+  });
+}
+
+function makeFile(name: string, options: { type?: string; size?: number } = {}) {
+  const { type = 'text/plain', size = 10 } = options;
+  const file = new File(['x'.repeat(size)], name, { type });
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+}
+
+function emitChange(wrapper: ReturnType<typeof createWrapper>, files: File[]): Promise<void> {
+  const input = wrapper.find<HTMLInputElement>('input[type=file]');
+  Object.defineProperty(input.element, 'files', {
+    value: files,
+    configurable: true,
+  });
+  return input.trigger('change');
+}
+
+describe('components/forms/file-upload/RuiFileUpload.vue', () => {
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the dropzone with default copy and no file', () => {
+    wrapper = createWrapper({ props: { modelValue: undefined } });
+    expect(wrapper.text()).toContain('Drag and drop or');
+    expect(wrapper.text()).toContain('click to upload');
+    expect(wrapper.find('[data-id=file-list]').exists()).toBeFalsy();
+  });
+
+  it('emits the selected file via v-model', async () => {
+    wrapper = createWrapper({ props: { modelValue: undefined } });
+    const file = makeFile('a.txt');
+    await emitChange(wrapper, [file]);
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([file]);
+  });
+
+  it('emits an array when multiple is true', async () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, multiple: true } });
+    const files = [makeFile('a.txt'), makeFile('b.txt')];
+    await emitChange(wrapper, files);
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([files]);
+  });
+
+  it('rejects multiple files when multiple is false and emits error', async () => {
+    wrapper = createWrapper({ props: { modelValue: undefined } });
+    await emitChange(wrapper, [makeFile('a.txt'), makeFile('b.txt')]);
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    const firstError = wrapper.emitted('error')?.[0]?.[0];
+    expect(firstError).toMatch(/one file/i);
+    expect(wrapper.text()).toMatch(/one file/i);
+  });
+
+  it('rejects files that do not match accept', async () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, accept: '.csv' } });
+    await emitChange(wrapper, [makeFile('a.txt', { type: 'text/plain' })]);
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    expect(wrapper.emitted('error')?.[0]?.[0]).toMatch(/\.csv/);
+  });
+
+  it('accepts image/* wildcard', async () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, accept: 'image/*' } });
+    const file = makeFile('a.png', { type: 'image/png' });
+    await emitChange(wrapper, [file]);
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([file]);
+  });
+
+  it('rejects files exceeding maxSize', async () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, maxSize: 5 } });
+    await emitChange(wrapper, [makeFile('big.txt', { size: 100 })]);
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    expect(wrapper.emitted('error')?.[0]?.[0]).toMatch(/maximum size/i);
+  });
+
+  it('renders external errorMessages without internal validation', () => {
+    wrapper = createWrapper({
+      props: { modelValue: undefined, errorMessages: ['external problem'] },
+    });
+    expect(wrapper.find('[data-error]').exists()).toBeTruthy();
+    expect(wrapper.text()).toContain('external problem');
+  });
+
+  it('shows uploaded state via data attribute', () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, uploaded: true } });
+    expect(wrapper.find('[data-uploaded]').exists()).toBeTruthy();
+  });
+
+  it('shows loading overlay', () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, loading: true } });
+    expect(wrapper.find('[data-id=loading]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id=progress-label]').exists()).toBeFalsy();
+  });
+
+  it('shows percentage label when progress is provided', () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, loading: true, progress: 42.6 } });
+    expect(wrapper.find('[data-id=progress-label]').text()).toBe('43%');
+  });
+
+  it('disables the input when disabled', () => {
+    wrapper = createWrapper({ props: { modelValue: undefined, disabled: true } });
+    expect(wrapper.find('input[type=file]').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-disabled]').exists()).toBeTruthy();
+  });
+
+  it('removeFile expose clears the v-model', async () => {
+    const file = makeFile('a.txt');
+    wrapper = createWrapper({ props: { modelValue: file } });
+    wrapper.vm.removeFile();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([undefined]);
+  });
+
+  it('renders a file list when files are selected', () => {
+    const file = makeFile('readme.md', { size: 2048 });
+    wrapper = createWrapper({ props: { modelValue: file } });
+    expect(wrapper.find('[data-id=file-list]').exists()).toBeTruthy();
+    expect(wrapper.text()).toContain('readme.md');
+    expect(wrapper.text()).toContain('2.0 KB');
+  });
+
+  it('renders the preview slot when provided', () => {
+    const file = makeFile('photo.png', { type: 'image/png' });
+    wrapper = createWrapper({
+      props: { modelValue: file },
+      slots: {
+        preview: '<div data-id="custom-preview">custom</div>',
+      },
+    });
+    expect(wrapper.find('[data-id=custom-preview]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-id=file-list]').exists()).toBeFalsy();
+  });
+
+  it('removes a single file from a multiple selection', async () => {
+    const files = [makeFile('a.txt'), makeFile('b.txt')];
+    wrapper = createWrapper({ props: { modelValue: files, multiple: true } });
+    const removeButtons = wrapper.findAll('[data-id=remove-file]');
+    expect(removeButtons.length).toBeGreaterThan(0);
+    await removeButtons[0]?.trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([[files[1]]]);
+  });
+});

--- a/packages/ui-library/src/components/forms/file-upload/RuiFileUpload.stories.ts
+++ b/packages/ui-library/src/components/forms/file-upload/RuiFileUpload.stories.ts
@@ -1,0 +1,119 @@
+import type { ComponentPropsAndSlots } from '@storybook/vue3-vite';
+import RuiFileUpload from '@/components/forms/file-upload/RuiFileUpload.vue';
+import preview from '~/.storybook/preview';
+
+function render(args: ComponentPropsAndSlots<typeof RuiFileUpload>) {
+  return {
+    components: { RuiFileUpload },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
+      return { args, modelValue };
+    },
+    template: `<RuiFileUpload v-model="modelValue" v-bind="args" />`,
+  };
+}
+
+const meta = preview.meta({
+  args: {
+    accept: '*',
+    errorMessages: [],
+    modelValue: undefined,
+  },
+  argTypes: {
+    accept: { control: 'text' },
+    clickToUploadText: { control: 'text' },
+    disabled: { control: 'boolean', table: { category: 'State' } },
+    errorMessages: { control: 'object' },
+    hideDetails: { control: 'boolean' },
+    hint: { control: 'text' },
+    loading: { control: 'boolean', table: { category: 'State' } },
+    maxSize: { control: 'number' },
+    progress: { control: { type: 'range', min: 0, max: 100, step: 1 } },
+    multiple: { control: 'boolean' },
+    noDrop: { control: 'boolean' },
+    replaceText: { control: 'text' },
+    uploaded: { control: 'boolean', table: { category: 'State' } },
+    uploadText: { control: 'text' },
+  },
+  component: RuiFileUpload,
+  parameters: {
+    docs: {
+      controls: { exclude: ['preview', 'icon', 'description'] },
+    },
+  },
+  render,
+  tags: ['autodocs'],
+  title: 'Components/Forms/FileUpload',
+});
+
+export const Default = meta.story({
+  args: {
+    accept: '.csv',
+    hint: 'Only .csv files are accepted',
+  },
+});
+
+export const Multiple = meta.story({
+  args: {
+    accept: '*',
+    multiple: true,
+    hint: 'Drop one or more files',
+  },
+});
+
+export const ImageOnly = meta.story({
+  args: {
+    accept: 'image/*',
+    maxSize: 5 * 1024 * 1024,
+    hint: 'Up to 5 MB, jpg/png/webp',
+  },
+});
+
+export const NoDrop = meta.story({
+  args: {
+    accept: 'image/*',
+    noDrop: true,
+    hint: 'Click only — drag and drop disabled',
+  },
+});
+
+export const Loading = meta.story({
+  args: {
+    loading: true,
+  },
+});
+
+export const Progress = meta.story({
+  args: {
+    loading: true,
+    progress: 42,
+  },
+});
+
+export const Uploaded = meta.story({
+  args: {
+    uploaded: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});
+
+export const WithErrorMessages = meta.story({
+  args: {
+    errorMessages: ['Something went wrong'],
+  },
+});
+
+export default meta;

--- a/packages/ui-library/src/components/forms/file-upload/RuiFileUpload.vue
+++ b/packages/ui-library/src/components/forms/file-upload/RuiFileUpload.vue
@@ -1,0 +1,339 @@
+<script setup lang="ts">
+import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
+import RuiProgress from '@/components/progress/RuiProgress.vue';
+import { useFormTextDetail } from '@/utils/form-text-detail';
+import { formatFileSize, getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
+
+export interface FileUploadProps {
+  /** File type filter (HTML accept attribute syntax). e.g. '.csv', 'image/*', '.png,.jpg' */
+  accept?: string;
+  /** Allow multiple file selection. */
+  multiple?: boolean;
+  disabled?: boolean;
+  /** Shows a loading overlay (consumer-driven, e.g. while uploading). */
+  loading?: boolean;
+  /** Upload progress 0-100. When provided alongside `loading`, the overlay shows a determinate progress bar with percentage. */
+  progress?: number;
+  /** Renders the success state border/icon. Consumer toggles back to false. */
+  uploaded?: boolean;
+  /** Optional max size per file in bytes; failures emit `error` and set internal error state. */
+  maxSize?: number;
+  /** External error messages (e.g. from Vuelidate). Shown via the standard form detail block. */
+  errorMessages?: string | string[];
+  /** Hint text below the dropzone. */
+  hint?: string;
+  /** Disable drag-and-drop; the dropzone becomes click-only (matches rotki.com use case). */
+  noDrop?: boolean;
+  /** Replace the default "Drag and drop or {button}" copy. */
+  uploadText?: string;
+  /** Label shown on the inline button when no file is selected. */
+  clickToUploadText?: string;
+  /** Label shown on the inline button when one or more files are already selected. */
+  replaceText?: string;
+  /** Hide the bottom hint/error details strip. */
+  hideDetails?: boolean;
+}
+
+defineOptions({
+  name: 'RuiFileUpload',
+  inheritAttrs: false,
+});
+
+const modelValue = defineModel<File | File[] | undefined>({ required: true });
+
+const {
+  accept = '*',
+  multiple = false,
+  disabled = false,
+  loading = false,
+  progress = undefined,
+  uploaded = false,
+  maxSize = undefined,
+  errorMessages = [],
+  hint = '',
+  noDrop = false,
+  uploadText = 'Drag and drop or',
+  clickToUploadText = 'click to upload',
+  replaceText = 'replace file',
+  hideDetails = false,
+} = defineProps<FileUploadProps>();
+
+const emit = defineEmits<{
+  error: [message: string];
+}>();
+
+defineSlots<{
+  preview?: (props: { files: File[]; remove: () => void }) => any;
+  icon?: () => any;
+  description?: () => any;
+}>();
+
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
+const input = useTemplateRef<HTMLInputElement>('input');
+const internalError = ref<string>('');
+
+const files = computed<File[]>(() => {
+  const value = get(modelValue);
+  if (!value)
+    return [];
+  return Array.isArray(value) ? value : [value];
+});
+
+const hasFiles = computed<boolean>(() => get(files).length > 0);
+
+const progressLabel = computed<string | undefined>(() => {
+  const value = progress;
+  return value === undefined ? undefined : `${Math.round(value)}%`;
+});
+
+const combinedErrorMessages = computed<string[]>(() => {
+  const external = Array.isArray(errorMessages) ? errorMessages : [errorMessages];
+  const internal = get(internalError);
+  return [...external.filter(Boolean), ...(internal ? [internal] : [])];
+});
+
+const { hasError } = useFormTextDetail(combinedErrorMessages, () => []);
+
+function matchesAccept(file: File, acceptString: string): boolean {
+  if (!acceptString || acceptString === '*' || acceptString === '*/*')
+    return true;
+
+  const fileName = file.name.toLowerCase();
+  const fileExtension = fileName.includes('.') ? fileName.slice(fileName.lastIndexOf('.')) : '';
+  const fileType = file.type.toLowerCase();
+  const acceptTypes = acceptString.split(',').map(value => value.trim().toLowerCase()).filter(Boolean);
+
+  return acceptTypes.some((type) => {
+    if (type.startsWith('.'))
+      return type === fileExtension;
+    if (type.endsWith('/*'))
+      return fileType.startsWith(type.slice(0, -1));
+    return type === fileType;
+  });
+}
+
+function reportError(message: string): void {
+  set(internalError, message);
+  emit('error', message);
+}
+
+function clearInternalError(): void {
+  set(internalError, '');
+}
+
+function validate(candidates: File[]): File[] | undefined {
+  if (candidates.length === 0)
+    return undefined;
+
+  if (!multiple && candidates.length > 1) {
+    reportError('Only one file can be uploaded');
+    return undefined;
+  }
+
+  for (const file of candidates) {
+    if (!matchesAccept(file, accept)) {
+      reportError(`Only ${accept} files are allowed`);
+      return undefined;
+    }
+    if (maxSize !== undefined && file.size > maxSize) {
+      reportError(`${file.name} exceeds the maximum size of ${formatFileSize(maxSize)}`);
+      return undefined;
+    }
+  }
+
+  return candidates;
+}
+
+function setFiles(candidates: File[]): void {
+  const validated = validate(candidates);
+  if (!validated)
+    return;
+  clearInternalError();
+  set(modelValue, multiple ? validated : validated[0]);
+}
+
+function removeFile(target?: File): void {
+  clearInternalError();
+  const inputEl = get(input);
+  if (inputEl)
+    inputEl.value = '';
+
+  if (!target || !multiple) {
+    set(modelValue, multiple ? [] : undefined);
+    return;
+  }
+
+  const remaining = get(files).filter(file => file !== target);
+  set(modelValue, remaining);
+}
+
+function onSelect(event: Event): void {
+  const target = event.target as HTMLInputElement;
+  if (!target?.files)
+    return;
+  setFiles(Array.from(target.files));
+}
+
+function onDrop(dropped: File[] | null): void {
+  if (disabled || noDrop || !dropped || dropped.length === 0)
+    return;
+  setFiles(dropped);
+}
+
+const { isOverDropZone } = useDropZone(wrapper, {
+  onDrop,
+});
+
+function openPicker(): void {
+  if (disabled)
+    return;
+  get(input)?.click();
+}
+
+watch(() => errorMessages, () => clearInternalError());
+
+defineExpose({
+  removeFile: () => removeFile(),
+  openPicker,
+});
+</script>
+
+<template>
+  <div v-bind="getRootAttrs($attrs)">
+    <div
+      ref="wrapper"
+      class="p-4 border border-rui-grey-300 dark:border-rui-grey-800 rounded-md w-full relative border-dashed transition"
+      :class="{
+        '!border-rui-primary bg-rui-primary/[0.08]': isOverDropZone && !disabled && !noDrop,
+        '!border-rui-error !border-solid bg-rui-error/[0.08]': hasError,
+        '!border-rui-success !border-solid bg-rui-success/[0.08]': uploaded,
+        'opacity-60 pointer-events-none': disabled,
+      }"
+      :data-disabled="disabled || undefined"
+      :data-uploaded="uploaded || undefined"
+      :data-error="hasError ? '' : undefined"
+      :data-drop-active="isOverDropZone || undefined"
+    >
+      <div
+        class="flex flex-col items-center justify-center gap-3"
+        :class="{ 'opacity-0': loading }"
+      >
+        <slot
+          name="preview"
+          :files="files"
+          :remove="() => removeFile()"
+        >
+          <div
+            v-if="hasFiles"
+            class="flex flex-col gap-1 w-full"
+            data-id="file-list"
+          >
+            <div
+              v-for="file in files"
+              :key="`${file.name}-${file.lastModified}`"
+              class="flex items-center gap-2 bg-rui-primary/[0.08] rounded-full pl-3 pr-1 py-1"
+              data-id="file-item"
+            >
+              <RuiIcon
+                name="lu-file"
+                color="primary"
+                size="20"
+              />
+              <div class="flex-1 overflow-hidden min-w-0">
+                <div
+                  class="text-sm leading-5 truncate"
+                  :title="file.name"
+                >
+                  {{ file.name }}
+                </div>
+                <div class="text-rui-text-secondary text-xs leading-3">
+                  {{ formatFileSize(file.size) }}
+                </div>
+              </div>
+              <button
+                type="button"
+                class="p-1 rounded-full hover:bg-rui-primary/[0.16] transition"
+                :disabled="disabled"
+                :aria-label="`Remove ${file.name}`"
+                data-id="remove-file"
+                @click="removeFile(file)"
+              >
+                <RuiIcon
+                  name="lu-x"
+                  size="16"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            v-else
+            class="h-10 w-10 rounded-full flex items-center justify-center"
+            :class="uploaded ? 'bg-rui-success/[0.12]' : 'bg-rui-primary/[0.12]'"
+          >
+            <slot name="icon">
+              <RuiIcon
+                :name="uploaded ? 'lu-circle-check' : 'lu-file-up'"
+                :color="uploaded ? 'success' : 'primary'"
+              />
+            </slot>
+          </div>
+        </slot>
+
+        <div class="text-center text-sm">
+          <slot name="description">
+            <div class="flex items-center justify-center gap-1 flex-wrap">
+              <span>{{ uploadText }}</span>
+              <button
+                type="button"
+                class="text-rui-primary underline disabled:no-underline disabled:text-rui-text-disabled"
+                :disabled="disabled"
+                data-id="open-picker"
+                @click="openPicker()"
+              >
+                {{ hasFiles ? replaceText : clickToUploadText }}
+              </button>
+            </div>
+          </slot>
+        </div>
+
+        <input
+          ref="input"
+          type="file"
+          :accept="accept"
+          :multiple="multiple"
+          :disabled="disabled"
+          hidden
+          data-id="file-input"
+          v-bind="getNonRootAttrs($attrs, ['class', 'onChange'])"
+          @change="onSelect($event)"
+        />
+      </div>
+
+      <div
+        v-if="loading"
+        class="flex flex-col items-center justify-center absolute h-full w-full top-0 left-0 gap-2"
+        data-id="loading"
+      >
+        <RuiProgress
+          circular
+          :variant="progress === undefined ? 'indeterminate' : 'determinate'"
+          :value="progress"
+          color="primary"
+          size="40"
+        />
+        <div
+          v-if="progressLabel"
+          v-text="progressLabel"
+          class="text-xs text-rui-text-secondary"
+          data-id="progress-label"
+        />
+      </div>
+    </div>
+    <RuiFormTextDetail
+      v-if="!hideDetails"
+      :error-messages="combinedErrorMessages"
+      :hint="hint"
+    />
+  </div>
+</template>

--- a/packages/ui-library/src/components/index.ts
+++ b/packages/ui-library/src/components/index.ts
@@ -24,6 +24,7 @@ import RuiDivider, { type Props as DividerProps } from '@/components/divider/Rui
 import RuiAutoComplete, { type AutoCompleteProps, type RuiAutoCompleteClassNames } from '@/components/forms/auto-complete/RuiAutoComplete.vue';
 import RuiCheckboxGroup, { type Props as CheckboxGroupProps } from '@/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue';
 import RuiCheckbox, { type Props as CheckboxProps } from '@/components/forms/checkbox/RuiCheckbox.vue';
+import RuiFileUpload, { type FileUploadProps } from '@/components/forms/file-upload/RuiFileUpload.vue';
 import RuiRadioGroup, { type Props as RadioGroupProps } from '@/components/forms/radio-button/radio-group/RuiRadioGroup.vue';
 import RuiRadio, { type RadioProps } from '@/components/forms/radio-button/radio/RuiRadio.vue';
 import RuiRevealableTextField, { type Props as RevealableTextFieldProps } from '@/components/forms/revealable-text-field/RuiRevealableTextField.vue';
@@ -81,6 +82,7 @@ export type {
   DialogProps,
   DividerProps,
   ExpandButtonProps,
+  FileUploadProps,
   FooterStepperProps,
   GroupData,
   IconProps,
@@ -145,6 +147,7 @@ export {
   RuiDateTimePicker,
   RuiDialog,
   RuiDivider,
+  RuiFileUpload,
   RuiFooterStepper,
   RuiIcon,
   RuiLogo,

--- a/packages/ui-library/src/utils/helpers.ts
+++ b/packages/ui-library/src/utils/helpers.ts
@@ -108,3 +108,21 @@ export function transformPropsUnit(value?: string | number): string | undefined 
     return value;
   return `${value}px`;
 }
+
+/**
+ * Formats a byte count into a human-readable string (e.g. "1.2 MB").
+ */
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0)
+    return '0 B';
+  if (bytes < 1024)
+    return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`;
+}


### PR DESCRIPTION
## Summary
- Adds `RuiFileUpload`, a generic file picker covering both existing
  in-house implementations (`rotki/frontend` `FileUpload.vue` and
  `rotki.com` `ImageUploadPreview.vue`). DnD + click upload, optional
  `multiple`, accept/maxSize validation with `error` event, external
  `errorMessages` for Vuelidate-style flows, `loading`/`progress` overlay
  with determinate percentage, `uploaded` success state (default icon
  swaps to a green check), and `preview`/`icon`/`description` slots so
  consumers can drop in image previews or override copy without forking.
  No i18n strings in the library.
- Adds the standard story set, example app demo page (single CSV,
  multiple, image preview slot, simulated upload with progress,
  disabled, external error) and Playwright e2e coverage.

Closes #388

## Test plan
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run typecheck` — clean (library + example)
- [x] `pnpm --filter @rotki/ui-library run test:run --testNamePattern=\"RuiFileUpload\"` — 16/16
- [x] `pnpm run build:prod`
- [x] `pnpm run test:e2e file-upload.spec.ts` — 7/7
- [x] Visual smoke at \`/file-uploads\` in light + dark mode via chrome-devtools MCP
- [ ] Storybook visual check (\`pnpm run storybook\` → Components/Forms/FileUpload)