### PR TITLE
feat(auto-complete): add groupBy, itemDisabled, and group-header slot

### DIFF
--- a/apps/example/e2e/forms/autocomplete.spec.ts
+++ b/apps/example/e2e/forms/autocomplete.spec.ts
@@ -646,3 +646,138 @@ test.describe('auto-complete - advanced', () => {
     await expect(ac.locator('input')).toHaveValue('MyCustomBlur');
   });
 });
+
+test.describe('auto-complete - grouping', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/auto-completes/grouping');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  test('should be reachable from the index navigation', async ({ page }) => {
+    await page.goto('/auto-completes');
+    await expect(page.locator('[data-id="link-/auto-completes/grouping"]')).toBeVisible();
+    await page.locator('[data-id="link-/auto-completes/grouping"]').click();
+    await expect(page.locator('[data-id=auto-completes-grouping]')).toBeVisible();
+  });
+
+  test('should render group headers when groupBy is a string key', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-string]');
+    await ac.locator('[data-id=activator]').click();
+
+    const menu = page.locator('div[role=menu]');
+    await expect(menu).toBeVisible();
+
+    const headers = menu.locator('[data-id=group-header]');
+    await expect(headers).toHaveCount(3);
+    await expect(headers.nth(0)).toContainText('Europe');
+    await expect(headers.nth(1)).toContainText('Asia');
+    await expect(headers.nth(2)).toContainText('Africa');
+  });
+
+  test('should render group headers when groupBy is a function', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-fn]');
+    const activator = ac.locator('[data-id=activator]');
+    await activator.focus();
+    await activator.click();
+
+    const headers = page.locator('div[role=menu] [data-id=group-header]');
+    await expect(headers).toHaveCount(3);
+    await expect(headers.nth(0)).toContainText('EUROPE');
+    await expect(headers.nth(1)).toContainText('ASIA');
+    await expect(headers.nth(2)).toContainText('AFRICA');
+  });
+
+  test('should render the custom #group-header slot with group and items', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-custom-header]');
+    await ac.locator('[data-id=activator]').click();
+
+    const customEurope = page.locator('[data-id="custom-header-Europe"]');
+    await expect(customEurope).toBeVisible();
+    await expect(customEurope).toContainText('Europe');
+    await expect(customEurope).toContainText('3');
+
+    const customAsia = page.locator('[data-id="custom-header-Asia"]');
+    await expect(customAsia).toContainText('Asia');
+    await expect(customAsia).toContainText('2');
+
+    const customAfrica = page.locator('[data-id="custom-header-Africa"]');
+    await expect(customAfrica).toContainText('Africa');
+    await expect(customAfrica).toContainText('1');
+  });
+
+  test('should select an option from inside a group', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-string]');
+    await ac.locator('[data-id=activator]').click();
+
+    const menu = page.locator('div[role=menu]');
+    await menu.locator('button', { hasText: 'Spain' }).click();
+
+    await expect(ac.locator('input')).toHaveValue('Spain');
+  });
+
+  test('should mark disabled items with data-disabled and prevent selection on click', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-disabled]');
+    await ac.locator('[data-id=activator]').click();
+
+    const menu = page.locator('div[role=menu]');
+    await expect(menu).toBeVisible();
+
+    const disabledItems = menu.locator('button[data-disabled="true"]');
+    await expect(disabledItems).toHaveCount(2);
+
+    // Clicking a disabled item should not select it (force needed because it's disabled).
+    await disabledItems.first().click({ force: true });
+
+    // Menu should remain open and input value should still be empty.
+    await expect(ac.locator('input')).toHaveValue('');
+  });
+
+  test('should skip disabled items when navigating with arrow keys', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-disabled]');
+    const activator = ac.locator('[data-id=activator]');
+    await activator.click();
+
+    const menu = page.locator('div[role=menu]');
+    await expect(menu).toBeVisible();
+
+    // First arrow down highlights Germany (first non-disabled).
+    await activator.press('ArrowDown');
+    let highlighted = menu.locator('button[data-highlighted="true"]');
+    await expect(highlighted).toContainText('Germany');
+
+    // Next arrow down should skip "France (disabled)" and land on Spain.
+    await activator.press('ArrowDown');
+    highlighted = menu.locator('button[data-highlighted="true"]');
+    await expect(highlighted).toContainText('Spain');
+
+    // Next arrow down should skip "India (disabled)" and land on Indonesia.
+    await activator.press('ArrowDown');
+    highlighted = menu.locator('button[data-highlighted="true"]');
+    await expect(highlighted).toContainText('Indonesia');
+
+    // Enter selects Indonesia.
+    await activator.press('Enter');
+    await expect(ac.locator('input')).toHaveValue('Indonesia');
+  });
+
+  test('should combine grouping with disabled items', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-grouped-disabled]');
+    await ac.locator('[data-id=activator]').click();
+
+    const menu = page.locator('div[role=menu]');
+    await expect(menu).toBeVisible();
+
+    // Two groups (Europe + Asia) are present.
+    await expect(menu.locator('[data-id=group-header]')).toHaveCount(2);
+
+    // Two disabled items.
+    await expect(menu.locator('button[data-disabled="true"]')).toHaveCount(2);
+
+    // Selecting an enabled item still works.
+    await menu.locator('button', { hasText: 'Indonesia' }).click();
+    await expect(ac.locator('input')).toHaveValue('Indonesia');
+  });
+});

--- a/apps/example/src/pages/auto-completes/grouping.vue
+++ b/apps/example/src/pages/auto-completes/grouping.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import AutoCompleteGroupingView from '@/views/auto-completes/AutoCompleteGroupingView.vue';
+</script>
+
+<template>
+  <AutoCompleteGroupingView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -76,6 +76,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/auto-completes/grouping': RouteRecordInfo<
+      '/auto-completes/grouping',
+      '/auto-completes/grouping',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/auto-completes/keyboard': RouteRecordInfo<
       '/auto-completes/keyboard',
       '/auto-completes/keyboard',
@@ -478,6 +485,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/auto-completes/custom.vue': {
       routes:
         | '/auto-completes/custom'
+      views:
+        | never
+    }
+    'src/pages/auto-completes/grouping.vue': {
+      routes:
+        | '/auto-completes/grouping'
       views:
         | never
     }

--- a/apps/example/src/views/auto-completes/AutoCompleteGroupingView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteGroupingView.vue
@@ -1,0 +1,125 @@
+<script lang="ts" setup>
+import { RuiAutoComplete, RuiChip } from '@rotki/ui-library/components';
+
+interface CountryOption {
+  id: number;
+  label: string;
+  continent: string;
+  disabled?: boolean;
+}
+
+const countries: CountryOption[] = [
+  { continent: 'Europe', id: 1, label: 'Germany' },
+  { continent: 'Europe', id: 2, label: 'France' },
+  { continent: 'Europe', id: 3, label: 'Spain' },
+  { continent: 'Asia', id: 4, label: 'India' },
+  { continent: 'Asia', id: 5, label: 'Indonesia' },
+  { continent: 'Africa', id: 6, label: 'Nigeria' },
+];
+
+const flatOptions: CountryOption[] = [
+  { continent: 'Europe', id: 1, label: 'Germany' },
+  { continent: 'Europe', disabled: true, id: 2, label: 'France (disabled)' },
+  { continent: 'Europe', id: 3, label: 'Spain' },
+  { continent: 'Asia', disabled: true, id: 4, label: 'India (disabled)' },
+  { continent: 'Asia', id: 5, label: 'Indonesia' },
+];
+
+const groupedValue = ref<number>();
+const groupedFnValue = ref<number>();
+
+function groupByContinentUpper(item: CountryOption): string {
+  return item.continent.toUpperCase();
+}
+const customHeaderValue = ref<number>();
+const disabledValue = ref<number>();
+const groupedDisabledValue = ref<number>();
+</script>
+
+<template>
+  <div data-id="auto-completes-grouping">
+    <h2 class="text-2xl font-bold mb-6">
+      Grouping &amp; Disabled Items
+    </h2>
+
+    <div class="grid gap-6 grid-cols-2">
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="groupedValue"
+          clearable
+          :options="countries"
+          group-by="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Grouped by string key"
+          data-id="ac-grouping-string"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="groupedFnValue"
+          clearable
+          :options="countries"
+          :group-by="groupByContinentUpper"
+          key-attr="id"
+          text-attr="label"
+          label="Grouped by function (uppercased)"
+          data-id="ac-grouping-fn"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="customHeaderValue"
+          clearable
+          :options="countries"
+          group-by="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Custom #group-header slot"
+          data-id="ac-grouping-custom-header"
+        >
+          <template #group-header="{ group, items }">
+            <div
+              class="px-3 py-2 bg-rui-primary/10 flex items-center justify-between"
+              :data-id="`custom-header-${group}`"
+            >
+              <span class="font-bold text-rui-primary">{{ group }}</span>
+              <RuiChip size="sm">
+                {{ items.length }}
+              </RuiChip>
+            </div>
+          </template>
+        </RuiAutoComplete>
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="disabledValue"
+          clearable
+          :options="flatOptions"
+          item-disabled="disabled"
+          key-attr="id"
+          text-attr="label"
+          label="Flat list with disabled items"
+          data-id="ac-grouping-disabled"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="groupedDisabledValue"
+          clearable
+          :options="flatOptions"
+          group-by="continent"
+          item-disabled="disabled"
+          key-attr="id"
+          text-attr="label"
+          label="Grouped with disabled items"
+          data-id="ac-grouping-grouped-disabled"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/example/src/views/auto-completes/index.vue
+++ b/apps/example/src/views/auto-completes/index.vue
@@ -45,6 +45,12 @@ const sections = [
     route: '/auto-completes/advanced',
     icon: 'lu-settings',
   },
+  {
+    title: 'Grouping',
+    description: 'Group headers, custom group slot, disabled items',
+    route: '/auto-completes/grouping',
+    icon: 'lu-layers',
+  },
 ];
 </script>
 

--- a/packages/ui-library/src/__test__/options.ts
+++ b/packages/ui-library/src/__test__/options.ts
@@ -1,5 +1,16 @@
 export interface SelectOption { id: string; label: string }
 
+export interface GroupedSelectOption { id: string; label: string; category: string; disabled?: boolean }
+
+export const groupedOptions: GroupedSelectOption[] = [
+  { category: 'Europe', id: '1', label: 'Germany' },
+  { category: 'Europe', id: '2', label: 'France' },
+  { category: 'Europe', id: '3', label: 'Spain' },
+  { category: 'Asia', id: '4', label: 'India' },
+  { category: 'Asia', id: '5', label: 'Indonesia' },
+  { category: 'Africa', id: '6', label: 'Nigeria' },
+];
+
 export const options: SelectOption[] = [
   { id: '1', label: 'Germany' },
   { id: '2', label: 'Nigeria' },

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -1,6 +1,6 @@
 import { type ComponentMountingOptions, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { options, type SelectOption } from '@/__test__/options';
+import { groupedOptions, type GroupedSelectOption, options, type SelectOption } from '@/__test__/options';
 import RuiChip from '@/components/chips/RuiChip.vue';
 import RuiAutoComplete from '@/components/forms/auto-complete/RuiAutoComplete.vue';
 import RuiProgress from '@/components/progress/RuiProgress.vue';
@@ -1249,5 +1249,217 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     wrapper.vm.closeMenu();
     await vi.runAllTimersAsync();
     expect(queryByRole('menu')).toBeFalsy();
+  });
+
+  describe('groupBy', () => {
+    it('should render group headers when groupBy is a string key', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+      expect(queryByRole('menu')).toBeTruthy();
+
+      const headers = Array.from(document.body.querySelectorAll('[data-id="group-header"]'));
+      expect(headers).toHaveLength(3);
+      expect(headers.map(h => h.textContent?.trim())).toEqual(['Europe', 'Asia', 'Africa']);
+    });
+
+    it('should render group headers when groupBy is a function', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: (item: GroupedSelectOption): string => item.category.toUpperCase(),
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const headers = Array.from(document.body.querySelectorAll('[data-id="group-header"]'));
+      expect(headers.map(h => h.textContent?.trim())).toEqual(['EUROPE', 'ASIA', 'AFRICA']);
+    });
+
+    it('should not render group headers when groupBy is undefined', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+      expect(queryByRole('menu')).toBeTruthy();
+
+      expect(queryByDataId('group-header')).toBeFalsy();
+    });
+
+    it('should render a custom #group-header slot', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          textAttr: 'label',
+        },
+        slots: {
+          'group-header': '<span class="custom-header">{{ params.group }} ({{ params.items.length }})</span>',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const customHeaders = Array.from(document.body.querySelectorAll('.custom-header'));
+      expect(customHeaders).toHaveLength(3);
+      expect(customHeaders[0]?.textContent).toBe('Europe (3)');
+      expect(customHeaders[1]?.textContent).toBe('Asia (2)');
+      expect(customHeaders[2]?.textContent).toBe('Africa (1)');
+    });
+  });
+
+  describe('itemDisabled', () => {
+    it('should not emit update:modelValue when clicking a disabled item', async () => {
+      const flatOptions: GroupedSelectOption[] = [
+        { category: 'A', id: '1', label: 'Alpha' },
+        { category: 'A', disabled: true, id: '2', label: 'Bravo' },
+        { category: 'A', id: '3', label: 'Charlie' },
+      ];
+
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          itemDisabled: 'disabled',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: flatOptions,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const disabledButton = queryBody<HTMLButtonElement>('[data-disabled="true"]');
+      assertExists(disabledButton);
+      disabledButton.click();
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    });
+
+    it('should skip disabled items when navigating with arrow keys', async () => {
+      const flatOptions: GroupedSelectOption[] = [
+        { category: 'A', id: '1', label: 'Alpha' },
+        { category: 'A', disabled: true, id: '2', label: 'Bravo' },
+        { category: 'A', id: '3', label: 'Charlie' },
+      ];
+
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          itemDisabled: 'disabled',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: flatOptions,
+          textAttr: 'label',
+        },
+      });
+
+      const activator = wrapper.find('[data-id=activator]');
+      await activator.trigger('focus');
+      await activator.trigger('click');
+      await vi.runAllTimersAsync();
+
+      await activator.trigger('keydown.down');
+      await vi.advanceTimersToNextTimerAsync();
+
+      let highlighted = queryBody<HTMLButtonElement>('[data-highlighted="true"]');
+      assertExists(highlighted);
+      expect(highlighted.innerHTML).toContain('Alpha');
+
+      await activator.trigger('keydown.down');
+      await vi.advanceTimersToNextTimerAsync();
+
+      highlighted = queryBody<HTMLButtonElement>('[data-highlighted="true"]');
+      assertExists(highlighted);
+      expect(highlighted.innerHTML).toContain('Charlie');
+    });
+
+    it('should not infinite-loop when all items are disabled', async () => {
+      const flatOptions: GroupedSelectOption[] = [
+        { category: 'A', disabled: true, id: '1', label: 'Alpha' },
+        { category: 'A', disabled: true, id: '2', label: 'Bravo' },
+        { category: 'A', disabled: true, id: '3', label: 'Charlie' },
+      ];
+
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          itemDisabled: 'disabled',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: flatOptions,
+          textAttr: 'label',
+        },
+      });
+
+      const activator = wrapper.find('[data-id=activator]');
+      await activator.trigger('click');
+      await vi.runAllTimersAsync();
+
+      await activator.trigger('keydown.down');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const highlighted = queryBody<HTMLButtonElement>('[data-highlighted="true"]');
+      expect(highlighted).toBeFalsy();
+    });
+
+    it('should not emit update:modelValue when pressing Enter on a disabled highlighted row', async () => {
+      const flatOptions: GroupedSelectOption[] = [
+        { category: 'A', disabled: true, id: '1', label: 'Alpha' },
+        { category: 'A', id: '2', label: 'Bravo' },
+      ];
+
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          autoSelectFirst: true,
+          itemDisabled: 'disabled',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: flatOptions,
+          textAttr: 'label',
+        },
+      });
+
+      const activator = wrapper.find('[data-id=activator]');
+      await activator.trigger('focus');
+      await activator.trigger('click');
+      await vi.runAllTimersAsync();
+
+      await activator.trigger('keydown.enter');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    });
   });
 });

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -7,6 +7,8 @@ import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu, { type MenuProps } from '@/components/overlays/menu/RuiMenu.vue';
 import RuiProgress from '@/components/progress/RuiProgress.vue';
 import {
+  type GroupBy,
+  type ItemDisabled,
   type KeyOfType,
   useDropdownMenu,
   useDropdownOptionProperty,
@@ -69,6 +71,8 @@ export interface AutoCompleteProps<TValue, TItem> {
   required?: boolean;
   hideSearchInput?: boolean;
   hideSelectionWrapper?: boolean;
+  groupBy?: GroupBy<TItem>;
+  itemDisabled?: ItemDisabled<TItem>;
 }
 
 defineOptions({
@@ -114,6 +118,8 @@ const {
   required = false,
   hideSearchInput = false,
   hideSelectionWrapper = false,
+  groupBy,
+  itemDisabled,
 } = defineProps<AutoCompleteProps<TValue, TItem>>();
 
 const slots = defineSlots<{
@@ -133,6 +139,7 @@ const slots = defineSlots<{
   'item.prepend'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
   'item'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
   'item.append'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
+  'group-header'?: (props: { group: string; items: TItem[] }) => any;
   'no-data'?: () => any;
 }>();
 
@@ -214,6 +221,9 @@ const {
   applyHighlighted,
   optionsWithSelectedHidden,
   userNavigated,
+  groupedOptions,
+  isGrouped,
+  isItemDisabled,
 } = useDropdownMenu<TValue, TItem>({
   itemHeight: resolvedItemHeight,
   keyAttr,
@@ -228,6 +238,8 @@ const {
   isOpen,
   getText,
   getIdentifier,
+  groupBy: () => groupBy,
+  itemDisabled: () => itemDisabled,
 });
 
 const {
@@ -663,6 +675,65 @@ defineExpose({
           @keydown.down.prevent="moveHighlight(false)"
         >
           <div
+            v-if="isGrouped"
+            ref="menuRef"
+          >
+            <template
+              v-for="(bucket, bucketIndex) in groupedOptions"
+              :key="bucket.group || `group-${bucketIndex}`"
+            >
+              <div
+                class="sticky top-0 z-10 bg-white dark:bg-rui-grey-900"
+                data-id="group-header"
+              >
+                <slot
+                  name="group-header"
+                  v-bind="{ group: bucket.group, items: bucket.items }"
+                >
+                  <div class="px-3 py-1 text-xs uppercase tracking-wide text-rui-text-secondary">
+                    {{ bucket.group }}
+                  </div>
+                </slot>
+              </div>
+              <RuiButton
+                v-for="item in bucket.items"
+                :key="getIdentifier(item)?.toString()"
+                :active="isActiveItem(item)"
+                :aria-selected="isActiveItem(item)"
+                :size="dense ? 'sm' : undefined"
+                :disabled="isItemDisabled(item)"
+                tabindex="0"
+                variant="list"
+                :data-highlighted="optionsWithSelectedHidden.indexOf(item) === highlightedIndex"
+                :data-disabled="isItemDisabled(item) || undefined"
+                :class="{
+                  [highlightedClass]: !isActiveItem(item) && optionsWithSelectedHidden.indexOf(item) === highlightedIndex,
+                }"
+                @click="!isItemDisabled(item) && setValue(item)"
+              >
+                <template #prepend>
+                  <slot
+                    name="item.prepend"
+                    v-bind="{ disabled: isItemDisabled(item), item, active: isActiveItem(item) }"
+                  />
+                </template>
+                <slot
+                  name="item"
+                  v-bind="{ disabled: isItemDisabled(item), item, active: isActiveItem(item) }"
+                >
+                  {{ getText(item) }}
+                </slot>
+                <template #append>
+                  <slot
+                    name="item.append"
+                    v-bind="{ disabled: isItemDisabled(item), item, active: isActiveItem(item) }"
+                  />
+                </template>
+              </RuiButton>
+            </template>
+          </div>
+          <div
+            v-else
             v-bind="wrapperProps"
             ref="menuRef"
           >
@@ -672,30 +743,32 @@ defineExpose({
               :active="isActiveItem(item)"
               :aria-selected="isActiveItem(item)"
               :size="dense ? 'sm' : undefined"
+              :disabled="isItemDisabled(item)"
               tabindex="0"
               variant="list"
               :data-highlighted="highlightedIndex === _index"
+              :data-disabled="isItemDisabled(item) || undefined"
               :class="{
                 [highlightedClass]: !isActiveItem(item) && highlightedIndex === _index,
               }"
-              @click="setValue(item)"
+              @click="!isItemDisabled(item) && setValue(item)"
             >
               <template #prepend>
                 <slot
                   name="item.prepend"
-                  v-bind="{ disabled, item, active: isActiveItem(item) }"
+                  v-bind="{ disabled: isItemDisabled(item), item, active: isActiveItem(item) }"
                 />
               </template>
               <slot
                 name="item"
-                v-bind="{ disabled, item, active: isActiveItem(item) }"
+                v-bind="{ disabled: isItemDisabled(item), item, active: isActiveItem(item) }"
               >
                 {{ getText(item) }}
               </slot>
               <template #append>
                 <slot
                   name="item.append"
-                  v-bind="{ disabled, item, active: isActiveItem(item) }"
+                  v-bind="{ disabled: isItemDisabled(item), item, active: isActiveItem(item) }"
                 />
               </template>
             </RuiButton>

--- a/packages/ui-library/src/composables/dropdown-menu.ts
+++ b/packages/ui-library/src/composables/dropdown-menu.ts
@@ -13,6 +13,15 @@ export interface DropdownItemAttr<TValue, TItem> {
   textAttr?: keyof TItem | ((item: TItem) => string);
 }
 
+export type GroupBy<TItem> = keyof TItem | ((item: TItem) => string);
+
+export type ItemDisabled<TItem> = keyof TItem | ((item: TItem) => boolean);
+
+export interface DropdownOptionGroup<TItem> {
+  group: string;
+  items: TItem[];
+}
+
 export interface DropdownOptions<TValue, TItem> {
   options: MaybeRefOrGetter<TItem[]>;
   dense?: MaybeRefOrGetter<boolean>;
@@ -31,6 +40,8 @@ export interface DropdownOptions<TValue, TItem> {
   isOpen?: Ref<boolean>;
   getText?: (item: TItem) => string | undefined;
   getIdentifier?: (item: TItem) => any;
+  groupBy?: MaybeRefOrGetter<GroupBy<TItem> | undefined>;
+  itemDisabled?: MaybeRefOrGetter<ItemDisabled<TItem> | undefined>;
 }
 
 export function useDropdownOptionProperty<TValue, TItem>({
@@ -88,6 +99,8 @@ export function useDropdownMenu<TValue, TItem>({
   setValue,
   textAttr,
   value,
+  groupBy,
+  itemDisabled,
 }: DropdownOptions<TValue, TItem>) {
   const { getIdentifier: defaultGetIdentifier, getText: defaultGetText } = useDropdownOptionProperty({
     keyAttr,
@@ -117,6 +130,47 @@ export function useDropdownMenu<TValue, TItem>({
       return options;
 
     return options.filter(item => !isActiveItem(item));
+  });
+
+  function getGroupKey(item: TItem): string {
+    const group = toValue(groupBy);
+    if (!group)
+      return '';
+
+    if (typeof group === 'function')
+      return group(item);
+
+    return String(item[group] ?? '');
+  }
+
+  function isItemDisabled(item: TItem): boolean {
+    const itemDisabledValue = toValue(itemDisabled);
+    if (!itemDisabledValue)
+      return false;
+
+    if (typeof itemDisabledValue === 'function')
+      return itemDisabledValue(item);
+
+    return Boolean(item[itemDisabledValue]);
+  }
+
+  const isGrouped = computed<boolean>(() => toValue(groupBy) !== undefined);
+
+  const groupedOptions = computed<DropdownOptionGroup<TItem>[]>(() => {
+    if (!get(isGrouped))
+      return [];
+
+    const buckets = new Map<string, TItem[]>();
+    for (const item of get(options)) {
+      const key = getGroupKey(item);
+      const list = buckets.get(key);
+      if (list)
+        list.push(item);
+      else
+        buckets.set(key, [item]);
+    }
+
+    return Array.from(buckets.entries()).map(([group, items]) => ({ group, items }));
   });
 
   const { containerProps, list, scrollTo, wrapperProps } = useVirtualList<TItem>(options, {
@@ -269,18 +323,27 @@ export function useDropdownMenu<TValue, TItem>({
 
     set(userNavigated, true);
 
-    let position = get(highlightedIndex);
+    const items = get(options);
+    const total = items.length;
+    if (total === 0)
+      return;
+
     const move = up ? -1 : 1;
+    let position = get(highlightedIndex);
 
-    position += move;
+    for (let step = 0; step < total; step++) {
+      position += move;
+      if (position >= total)
+        position = 0;
+      else if (position < 0)
+        position = total - 1;
 
-    const total = get(options).length;
-
-    if (position >= total)
-      set(highlightedIndex, 0);
-    else if (position < 0)
-      set(highlightedIndex, total - 1);
-    else set(highlightedIndex, position);
+      const candidate = items[position];
+      if (candidate !== undefined && !isItemDisabled(candidate)) {
+        set(highlightedIndex, position);
+        return;
+      }
+    }
   };
 
   const applyHighlighted = (): void => {
@@ -292,7 +355,7 @@ export function useDropdownMenu<TValue, TItem>({
       return;
 
     const entry = get(options)[highlightedIndexVal];
-    if (entry !== undefined)
+    if (entry !== undefined && !isItemDisabled(entry))
       setValue(entry);
   };
 
@@ -301,8 +364,11 @@ export function useDropdownMenu<TValue, TItem>({
     containerProps,
     getIdentifier,
     getText,
+    groupedOptions,
     highlightedIndex,
     isActiveItem,
+    isGrouped,
+    isItemDisabled,
     isOpen,
     itemIndexInValue,
     menuWidth,


### PR DESCRIPTION
## Summary

Adds three additive features to `RuiAutoComplete` to support grouped pickers without forking the component. Closes part of the gaps that surfaced while building rotki's `HistoryEventActionPicker` (rotki/rotki#12002).

Refs: #536

- **`groupBy?: keyof TItem | ((item) => string)`** — renders items into sticky group headers in first-encountered order. Grouped mode bypasses virtualization on purpose (header rows break the uniform-height assumption); intended for pickers with <100 items.
- **`itemDisabled?: keyof TItem | ((item) => boolean)`** — disables individual rows. Arrow keys skip disabled rows (with an all-disabled guard to avoid infinite loops), and Enter on a disabled highlighted row is a no-op.
- **`#group-header` slot** — exposes `{ group, items }` for custom header rendering; default is a small uppercase label.

When neither new prop is set, behavior is byte-identical for existing consumers (TableFilter, SettingsSearch, BinancePairsSelector, etc.). The only subtle change is that the `#item` / `#item.prepend` / `#item.append` slot bindings now expose per-item `disabled` instead of the component-level `disabled` prop — unobservable in practice, since the menu can't open when the component is disabled.

## What's in the diff

- `src/composables/dropdown-menu.ts` — `GroupBy<TItem>` / `ItemDisabled<TItem>` types, `getGroupKey`, `isItemDisabled`, `groupedOptions`, `isGrouped`, and disabled-aware `moveHighlight` / `applyHighlighted`.
- `src/components/forms/auto-complete/RuiAutoComplete.vue` — two new props, the `#group-header` slot, a `v-if="isGrouped"` template branch for the grouped (non-virtualized) layout. Existing virtualized branch kept as `v-else` and gains `:disabled` + click-guard for per-row disable.
- Example app: new `/auto-completes/grouping` page with five autocompletes covering string-key + function `groupBy`, custom slot, flat disabled, and combined grouped+disabled.

## Tests

- **8 new unit tests** in `RuiAutoComplete.spec.ts` (string-key grouping, function grouping, no headers when undefined, custom `#group-header` slot, click on disabled does nothing, arrow keys skip disabled, all-disabled doesn't infinite-loop, Enter on disabled highlighted no-op). Full suite: 1122/1122 pass.
- **8 new e2e tests** in `apps/example/e2e/forms/autocomplete.spec.ts` covering the same surface end-to-end against the production build.

## Known issue (out of scope)

Vue's SFC compiler can't fully extract runtime types for `keyof TItem | Function` and falls back to `Function`, which prints a dev-mode `[Vue warn]: Invalid prop` when consumers pass a string key. Functionally harmless (warning is stripped in prod, value passes through), but cosmetic noise. The proper fix needs either widening to `string | Function` (loses `keyof TItem` strictness) or a runtime override; left for a follow-up so this PR stays scope-tight.

## Follow-ups (not in this PR)

- `#footer` and `#trigger` slots — PR 2
- Storybook stories for the three new behaviors — separate small PR or rolled into PR 2

## Test plan

- [x] `pnpm test:run` — 1122/1122 pass
- [x] `pnpm test:e2e` — all autocomplete e2e tests pass, including 8 new ones
- [x] `pnpm run build:types` — clean
- [x] Manual smoke at `/auto-completes/grouping` in the example app
- [ ] Visual: confirm sticky header looks right against `RuiMenu` background in both light + dark themes (the header uses `bg-white dark:bg-rui-grey-900`; if your theme uses a different menu background, a `TODO(theme)` comment marks where to swap in a token)