### PR TITLE
feat(auto-complete): add placeholder and footer slots

### DIFF
--- a/apps/example/e2e/forms/autocomplete.spec.ts
+++ b/apps/example/e2e/forms/autocomplete.spec.ts
@@ -781,3 +781,78 @@ test.describe('auto-complete - grouping', () => {
     await expect(ac.locator('input')).toHaveValue('Indonesia');
   });
 });
+
+test.describe('auto-complete - slots (placeholder & footer)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/auto-completes/slots');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  test('should be reachable from the index navigation', async ({ page }) => {
+    await page.goto('/auto-completes');
+    await expect(page.locator('[data-id="link-/auto-completes/slots"]')).toBeVisible();
+    await page.locator('[data-id="link-/auto-completes/slots"]').click();
+    await expect(page.locator('[data-id=auto-completes-slots]')).toBeVisible();
+  });
+
+  test('should render the placeholder slot when no value is set and input is not focused', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-slots-placeholder]');
+    const placeholder = ac.locator('[data-id=placeholder]');
+    await expect(placeholder).toBeVisible();
+    await expect(placeholder).toContainText('Find a country…');
+  });
+
+  test('should hide the placeholder slot once the activator is focused', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-slots-placeholder]');
+    await expect(ac.locator('[data-id=placeholder]')).toBeVisible();
+
+    await ac.locator('[data-id=activator]').click();
+    await expect(ac.locator('[data-id=placeholder]')).toBeHidden();
+  });
+
+  test('should hide the placeholder slot after a value is selected', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-slots-placeholder]');
+    await ac.locator('[data-id=activator]').click();
+
+    const menu = page.locator('div[role=menu]');
+    await menu.locator('button', { hasText: 'Germany' }).first().click();
+
+    await expect(ac.locator('input')).toHaveValue('Germany');
+    // Blur back so the resting state is checked.
+    await page.locator('[data-id=auto-completes-slots] h2').click();
+    await expect(ac.locator('[data-id=placeholder]')).toBeHidden();
+  });
+
+  test('should render the footer slot when the menu is open', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-slots-footer]');
+    await expect(page.locator('div[role=menu] [data-id=footer]')).toHaveCount(0);
+
+    await ac.locator('[data-id=activator]').click();
+
+    const footer = page.locator('div[role=menu] [data-id=footer]');
+    await expect(footer).toBeVisible();
+    await expect(footer).toContainText('↑↓ navigate');
+    await expect(footer).toContainText('items');
+  });
+
+  test('should keep the footer visible when the search input has no matches', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-slots-footer]');
+    await ac.locator('[data-id=activator]').click();
+
+    await ac.locator('input').fill('zzzzzznomatch');
+
+    await expect(page.locator('div[role=menu] [data-id=footer]')).toBeVisible();
+  });
+
+  test('should render placeholder and footer slots together', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-slots-combined]');
+    await expect(ac.locator('[data-id=placeholder]')).toContainText('Search countries');
+
+    await ac.locator('[data-id=activator]').click();
+    const footer = page.locator('div[role=menu] [data-id=footer]');
+    await expect(footer).toContainText('Tip: start typing');
+  });
+});

--- a/apps/example/src/pages/auto-completes/slots.vue
+++ b/apps/example/src/pages/auto-completes/slots.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import AutoCompleteSlotsView from '@/views/auto-completes/AutoCompleteSlotsView.vue';
+</script>
+
+<template>
+  <AutoCompleteSlotsView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -111,6 +111,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/auto-completes/slots': RouteRecordInfo<
+      '/auto-completes/slots',
+      '/auto-completes/slots',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/avatars': RouteRecordInfo<
       '/avatars',
       '/avatars',
@@ -515,6 +522,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/auto-completes/selection.vue': {
       routes:
         | '/auto-completes/selection'
+      views:
+        | never
+    }
+    'src/pages/auto-completes/slots.vue': {
+      routes:
+        | '/auto-completes/slots'
       views:
         | never
     }

--- a/apps/example/src/views/auto-completes/AutoCompleteSlotsView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteSlotsView.vue
@@ -1,0 +1,99 @@
+<script lang="ts" setup>
+import { RuiAutoComplete, RuiIcon } from '@rotki/ui-library/components';
+import { createOptions } from '@/data/options';
+
+const options = createOptions();
+
+const placeholderValue = ref<number>();
+const footerValue = ref<number>();
+const combinedValue = ref<number>();
+</script>
+
+<template>
+  <div data-id="auto-completes-slots">
+    <h2 class="text-2xl font-bold mb-6">
+      Custom Slots — Placeholder &amp; Footer
+    </h2>
+
+    <div class="grid gap-6 grid-cols-2">
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="placeholderValue"
+          clearable
+          :options="options"
+          key-attr="id"
+          text-attr="label"
+          label="Custom placeholder slot"
+          data-id="ac-slots-placeholder"
+        >
+          <template #placeholder>
+            <span class="flex items-center gap-2 text-rui-text-secondary">
+              <RuiIcon
+                name="lu-search"
+                size="16"
+              />
+              <span class="italic">Find a country…</span>
+            </span>
+          </template>
+        </RuiAutoComplete>
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="footerValue"
+          clearable
+          :options="options"
+          key-attr="id"
+          text-attr="label"
+          label="Custom footer slot"
+          data-id="ac-slots-footer"
+        >
+          <template #footer>
+            <div
+              class="flex items-center justify-between px-3 py-2 text-xs text-rui-text-secondary"
+              data-id="footer-hint"
+            >
+              <span>↑↓ navigate · ↵ select · esc close</span>
+              <span class="font-mono">{{ options.length }} items</span>
+            </div>
+          </template>
+        </RuiAutoComplete>
+      </div>
+
+      <div class="py-4 col-span-2">
+        <RuiAutoComplete
+          v-model="combinedValue"
+          clearable
+          variant="outlined"
+          :options="options"
+          key-attr="id"
+          text-attr="label"
+          label="Both slots combined"
+          data-id="ac-slots-combined"
+        >
+          <template #placeholder="{ disabled }">
+            <span
+              class="flex items-center gap-2"
+              :class="disabled ? 'text-rui-text-disabled' : 'text-rui-primary'"
+            >
+              <RuiIcon
+                name="lu-globe"
+                size="16"
+              />
+              <span>Search countries</span>
+            </span>
+          </template>
+          <template #footer>
+            <div class="flex items-center gap-2 px-3 py-2 text-xs text-rui-text-secondary">
+              <RuiIcon
+                name="lu-info"
+                size="14"
+              />
+              <span>Tip: start typing to narrow results.</span>
+            </div>
+          </template>
+        </RuiAutoComplete>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/example/src/views/auto-completes/index.vue
+++ b/apps/example/src/views/auto-completes/index.vue
@@ -51,6 +51,12 @@ const sections = [
     route: '/auto-completes/grouping',
     icon: 'lu-layers',
   },
+  {
+    title: 'Slots',
+    description: 'Custom placeholder and footer slots',
+    route: '/auto-completes/slots',
+    icon: 'lu-puzzle',
+  },
 ];
 </script>
 

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -1462,4 +1462,155 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
       expect(wrapper.emitted('update:modelValue')).toBeFalsy();
     });
   });
+
+  describe('placeholder slot', () => {
+    it('should render the placeholder slot when no value is set and input is not focused', () => {
+      wrapper = createWrapper<string | undefined, SelectOption>({
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options,
+          textAttr: 'label',
+        },
+        slots: {
+          placeholder: '<span class="custom-placeholder">Pick a country</span>',
+        },
+      });
+
+      const placeholder = wrapper.find('[data-id=placeholder] .custom-placeholder');
+      expect(placeholder.exists()).toBe(true);
+      expect(placeholder.text()).toBe('Pick a country');
+    });
+
+    it('should hide the placeholder slot when a value is set', () => {
+      const option4 = options[4];
+      assert(option4);
+      wrapper = createWrapper<string, SelectOption>({
+        props: {
+          keyAttr: 'id',
+          modelValue: option4.id,
+          options,
+          textAttr: 'label',
+        },
+        slots: {
+          placeholder: '<span class="custom-placeholder">Pick a country</span>',
+        },
+      });
+
+      expect(wrapper.find('[data-id=placeholder]').exists()).toBe(false);
+    });
+
+    it('should hide the placeholder slot when the input is focused', async () => {
+      wrapper = createWrapper<string | undefined, SelectOption>({
+        attachTo: document.body,
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options,
+          textAttr: 'label',
+        },
+        slots: {
+          placeholder: '<span class="custom-placeholder">Pick a country</span>',
+        },
+      });
+
+      expect(wrapper.find('[data-id=placeholder]').exists()).toBe(true);
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.runAllTimersAsync();
+
+      expect(wrapper.find('[data-id=placeholder]').exists()).toBe(false);
+    });
+
+    it('should expose disabled and readOnly to the placeholder slot', () => {
+      wrapper = createWrapper<string | undefined, SelectOption>({
+        props: {
+          disabled: true,
+          keyAttr: 'id',
+          modelValue: undefined,
+          options,
+          readOnly: true,
+          textAttr: 'label',
+        },
+        slots: {
+          placeholder: '<span class="custom-placeholder" :data-disabled="params.disabled" :data-readonly="params.readOnly">x</span>',
+        },
+      });
+
+      const placeholder = wrapper.find<HTMLElement>('.custom-placeholder');
+      expect(placeholder.exists()).toBe(true);
+      expect(placeholder.attributes('data-disabled')).toBe('true');
+      expect(placeholder.attributes('data-readonly')).toBe('true');
+    });
+  });
+
+  describe('footer slot', () => {
+    it('should render the footer slot below the menu list when the menu is open', async () => {
+      wrapper = createWrapper<string | undefined, SelectOption>({
+        attachTo: document.body,
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options,
+          textAttr: 'label',
+        },
+        slots: {
+          footer: '<div class="custom-footer">↑↓ navigate · ↵ select</div>',
+        },
+      });
+
+      expect(queryByDataId('footer')).toBeFalsy();
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+      expect(queryByRole('menu')).toBeTruthy();
+
+      const footer = queryByDataId('footer');
+      assertExists(footer);
+      expect(footer.querySelector('.custom-footer')?.textContent).toBe('↑↓ navigate · ↵ select');
+    });
+
+    it('should render the footer slot when there are no matching options', async () => {
+      wrapper = createWrapper<string | undefined, SelectOption>({
+        attachTo: document.body,
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options,
+          textAttr: 'label',
+        },
+        slots: {
+          footer: '<div class="custom-footer">hint</div>',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('zzzzznomatch');
+      await vi.runAllTimersAsync();
+
+      const footer = queryByDataId('footer');
+      assertExists(footer);
+      expect(footer.querySelector('.custom-footer')).toBeTruthy();
+    });
+
+    it('should not render footer container when slot is not provided', async () => {
+      wrapper = createWrapper<string | undefined, SelectOption>({
+        attachTo: document.body,
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+      expect(queryByRole('menu')).toBeTruthy();
+
+      expect(queryByDataId('footer')).toBeFalsy();
+    });
+  });
 });

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.stories.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.stories.ts
@@ -1,7 +1,9 @@
 import type { ComponentPropsAndSlots, Decorator } from '@storybook/vue3-vite';
 import { expect, waitFor, within } from 'storybook/test';
-import { options, type SelectOption } from '@/__test__/options';
+import { groupedOptions, type GroupedSelectOption, options, type SelectOption } from '@/__test__/options';
+import RuiChip from '@/components/chips/RuiChip.vue';
 import RuiAutoComplete from '@/components/forms/auto-complete/RuiAutoComplete.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
 import preview from '~/.storybook/preview';
 
 type AutoCompleteProps = ComponentPropsAndSlots<typeof RuiAutoComplete<string, SelectOption>>;
@@ -416,6 +418,172 @@ export const Required = meta.story({
     required: true,
     textAttr: 'label',
     variant: 'outlined',
+  },
+});
+
+// @ts-expect-error Grouped uses GroupedSelectOption[] options instead of SelectOption[]
+export const Grouped = meta.story({
+  args: {
+    groupBy: 'category',
+    keyAttr: 'id',
+    modelValue: undefined,
+    options: groupedOptions,
+    textAttr: 'label',
+    variant: 'outlined',
+  },
+  async play({ canvas, userEvent }) {
+    const body = within(document.body);
+    const combobox = canvas.getByRole('combobox');
+    await userEvent.click(combobox);
+    await waitFor(() => expect(body.getByRole('menu')).toBeVisible());
+
+    const menu = body.getByRole('menu');
+    await waitFor(() => expect(within(menu).getByText('Europe')).toBeVisible());
+    expect(within(menu).getByText('Asia')).toBeVisible();
+    expect(within(menu).getByText('Africa')).toBeVisible();
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(body.queryByRole('menu')).toBeNull());
+  },
+});
+
+// @ts-expect-error GroupedCustomHeader uses GroupedSelectOption[] options
+export const GroupedCustomHeader = meta.story({
+  args: {
+    groupBy: 'category',
+    keyAttr: 'id',
+    modelValue: undefined,
+    options: groupedOptions,
+    textAttr: 'label',
+    variant: 'outlined',
+  },
+  render: args => ({
+    components: { RuiAutoComplete: RuiAutoComplete<string, GroupedSelectOption>, RuiChip },
+    setup() {
+      const modelValue = computed({
+        get: () => args.modelValue,
+        // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+        set: (val) => { args.modelValue = val; },
+      });
+      return { args, modelValue };
+    },
+    template: `
+      <RuiAutoComplete v-bind="args" v-model="modelValue">
+        <template #group-header="{ group, items }">
+          <div class="px-3 py-2 bg-rui-primary/10 flex items-center justify-between">
+            <span class="font-bold text-rui-primary">{{ group }}</span>
+            <RuiChip size="sm">{{ items.length }}</RuiChip>
+          </div>
+        </template>
+      </RuiAutoComplete>
+    `,
+  }),
+});
+
+// @ts-expect-error WithDisabledItems uses GroupedSelectOption[] options with `disabled` field
+export const WithDisabledItems = meta.story({
+  args: {
+    itemDisabled: 'disabled',
+    keyAttr: 'id',
+    modelValue: undefined,
+    options: [
+      { category: 'A', id: '1', label: 'Available row' },
+      { category: 'A', disabled: true, id: '2', label: 'Disabled row' },
+      { category: 'A', id: '3', label: 'Another available row' },
+      { category: 'A', disabled: true, id: '4', label: 'Also disabled' },
+      { category: 'A', id: '5', label: 'Final available row' },
+    ] satisfies GroupedSelectOption[],
+    textAttr: 'label',
+    variant: 'outlined',
+  },
+  async play({ canvas, userEvent }) {
+    const body = within(document.body);
+    const combobox = canvas.getByRole('combobox');
+    await userEvent.click(combobox);
+    await waitFor(() => expect(body.getByRole('menu')).toBeVisible());
+
+    // ArrowDown should skip the disabled row and land on the next available.
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowDown}');
+
+    const menu = body.getByRole('menu');
+    const highlighted = menu.querySelector('button[data-highlighted="true"]');
+    expect(highlighted?.textContent).toContain('Another available row');
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(body.queryByRole('menu')).toBeNull());
+  },
+});
+
+export const PlaceholderSlot = meta.story({
+  args: {
+    keyAttr: 'id',
+    modelValue: undefined,
+    textAttr: 'label',
+    variant: 'outlined',
+  },
+  render: args => ({
+    components: { RuiAutoComplete: RuiAutoComplete<string, SelectOption>, RuiIcon },
+    setup() {
+      const modelValue = computed({
+        get: () => args.modelValue,
+        // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+        set: (val) => { args.modelValue = val; },
+      });
+      return { args, modelValue };
+    },
+    template: `
+      <RuiAutoComplete v-bind="args" v-model="modelValue">
+        <template #placeholder>
+          <span class="flex items-center gap-2 text-rui-text-secondary">
+            <RuiIcon name="lu-search" size="16" />
+            <span class="italic">Find a country…</span>
+          </span>
+        </template>
+      </RuiAutoComplete>
+    `,
+  }),
+});
+
+export const FooterSlot = meta.story({
+  args: {
+    keyAttr: 'id',
+    modelValue: undefined,
+    textAttr: 'label',
+    variant: 'outlined',
+  },
+  render: args => ({
+    components: { RuiAutoComplete: RuiAutoComplete<string, SelectOption> },
+    setup() {
+      const modelValue = computed({
+        get: () => args.modelValue,
+        // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+        set: (val) => { args.modelValue = val; },
+      });
+      return { args, modelValue };
+    },
+    template: `
+      <RuiAutoComplete v-bind="args" v-model="modelValue">
+        <template #footer>
+          <div class="flex items-center justify-between px-3 py-2 text-xs text-rui-text-secondary">
+            <span>↑↓ navigate · ↵ select · esc close</span>
+            <span class="font-mono">{{ args.options.length }} items</span>
+          </div>
+        </template>
+      </RuiAutoComplete>
+    `,
+  }),
+  async play({ canvas, userEvent }) {
+    const body = within(document.body);
+    const combobox = canvas.getByRole('combobox');
+    await userEvent.click(combobox);
+    await waitFor(() => expect(body.getByRole('menu')).toBeVisible());
+
+    const menu = body.getByRole('menu');
+    await waitFor(() => expect(within(menu).getByText(/navigate/)).toBeVisible());
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(body.queryByRole('menu')).toBeNull());
   },
 });
 

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -141,6 +141,8 @@ const slots = defineSlots<{
   'item.append'?: (props: { disabled: boolean; item: TItem; active: boolean }) => any;
   'group-header'?: (props: { group: string; items: TItem[] }) => any;
   'no-data'?: () => any;
+  'placeholder'?: (props: { disabled: boolean; readOnly: boolean }) => any;
+  'footer'?: () => any;
 }>();
 
 const { getText, getIdentifier } = useDropdownOptionProperty<TValue, TItem>({
@@ -309,6 +311,11 @@ const { hasError, hasSuccess } = useFormTextDetail(
 );
 
 const valueSet = computed<boolean>(() => get(value).length > 0);
+
+// True when the consumer's #placeholder slot is taking over the resting
+// content area, so the outlined/resting label must hide to avoid overlapping
+// the slot content.
+const placeholderSlotActive = computed<boolean>(() => Boolean(slots.placeholder) && !get(valueSet) && !get(searchInputFocused));
 
 const usedPlaceholder = computed<string>(() => {
   if (get(searchInputFocused))
@@ -523,7 +530,7 @@ defineExpose({
           @keydown.end.prevent="highlightedIndex = optionsWithSelectedHidden.length - 1"
         >
           <span
-            v-if="outlined || (!valueSet && !searchInputFocused)"
+            v-if="(outlined || (!valueSet && !searchInputFocused)) && !placeholderSlotActive"
             :class="[
               ui.label(),
               { 'pr-2': !valueSet && !open && outlined },
@@ -546,6 +553,23 @@ defineExpose({
             data-id="value"
             :class="ui.value()"
           >
+            <!--
+              Placeholder slot occupies the same flex space the input takes
+              when focused, so transitioning into the focused state doesn't
+              shift the activator's content. pointer-events-none is required
+              so clicks pass through to the activator (otherwise the slot
+              swallows the first click and the menu needs two taps to open).
+            -->
+            <div
+              v-if="!valueSet && !searchInputFocused && slots.placeholder"
+              data-id="placeholder"
+              class="flex-1 min-w-0 pointer-events-none"
+            >
+              <slot
+                name="placeholder"
+                v-bind="{ disabled, readOnly }"
+              />
+            </div>
             <template
               v-for="(item, i) in value"
               :key="getIdentifier(item)"
@@ -789,6 +813,20 @@ defineExpose({
               {{ noDataText }}
             </div>
           </slot>
+        </div>
+        <!--
+          The scroll container above reserves ~15px on the right for the
+          scrollbar gutter. We render an equivalent right-padding here so the
+          footer's content aligns with the option rows' content rather than
+          the menu's outer edge. `pr-[var(--rui-scrollbar-gutter,15px)]`
+          lets consumers override if their theme reserves a different width.
+        -->
+        <div
+          v-if="slots.footer"
+          class="bg-white dark:bg-rui-grey-900 border-t border-black/[0.12] dark:border-white/[0.12] pr-[var(--rui-scrollbar-gutter,15px)] -mb-2"
+          data-id="footer"
+        >
+          <slot name="footer" />
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Summary

Two additive slots so consumers can customize the look of `RuiAutoComplete` without having to reimplement the input layout, focus handling, keyboard navigation, or chip rendering. Plus five new Storybook stories covering the new surface from PR 1 (#537) and this PR.

Refs: #536 (PR 2 of the picker-gap series — follow-up to #537).

### New slots

- **`#placeholder`** — rendered inside the activator's value area when no value is selected and the input is not focused. Receives `{ disabled, readOnly }` so consumers can adjust styling per state. The wrapper uses `flex-1 min-w-0` so it occupies the same flex space the input takes when focused — that's load-bearing, not cosmetic; without it the value-area content shifts and resizes on focus. The wrapper is also `pointer-events-none` so clicks pass straight through to the activator and don't swallow the menu-open click (same reason — a comment in the template explains both).
- **`#footer`** — rendered as a strip below the menu list. Stays visible when the option list scrolls and when the search yields no matching options. Intended for keyboard hints, item counts, or action links. Right-padding matches the scroll container's scrollbar gutter (`pr-[var(--rui-scrollbar-gutter,15px)]`) so the footer's content visually aligns with the option rows above instead of extending past them.

### Label/placeholder interaction

When the `#placeholder` slot is provided and the activator is in its resting empty state, the default resting label is suppressed (via a `placeholderSlotActive` computed) so the two don't visually overlap. The floated label position is unchanged — when the user focuses or selects a value, the label renders normally.

When neither slot is used, behavior is byte-identical for existing consumers (TableFilter, SettingsSearch, etc.).

## Stories

Five new Storybook stories so the new surface is reviewable without an integration:

- `Grouped` — groupBy via string key, default group headers (from PR 1)
- `GroupedCustomHeader` — `#group-header` slot with item counts (from PR 1)
- `WithDisabledItems` — `itemDisabled` skipping in arrow-key navigation (from PR 1)
- `PlaceholderSlot` — custom `#placeholder` with icon (PR 2)
- `FooterSlot` — keyboard-hint strip with item count (PR 2)

## Tests

- **7 new unit tests** in `RuiAutoComplete.spec.ts`:
  - placeholder slot renders when no value is set and input is unfocused
  - placeholder slot hidden when a value is set
  - placeholder slot hidden once the activator is focused
  - placeholder slot exposes `{ disabled, readOnly }` correctly
  - footer slot renders when the menu is open
  - footer slot persists when search has no matches
  - footer container is absent when slot is not provided

  Full suite: 1129/1129 unit pass.

- **7 new e2e tests** in `apps/example/e2e/forms/autocomplete.spec.ts` covering the same surface end-to-end. Full file: 61/61 pass.

## Known follow-up (not in this PR)

While reviewing in Storybook, we surfaced a positioning glitch in `RuiMenu` that's reproducible on small inline option fixtures: the menu opens at the viewport center on the first frame and Floating UI walks its `left` value back to the activator's edge over ~20 animation frames, briefly causing horizontal overflow on the canvas. This is a pre-existing `RuiMenu` / Floating UI integration issue (not introduced by this PR — confirmed by repro absence on stories using the larger imported fixture). To be tracked and fixed in a separate focused PR. The disabled-items story still demonstrates the feature correctly; the glitch is purely visual.

## Test plan

- [x] `pnpm test:run` — 1129/1129 unit pass
- [x] `pnpm test:e2e forms/autocomplete.spec.ts` — 61/61 pass
- [x] `pnpm run build:types` — clean
- [x] Manual smoke at `/auto-completes/slots` in the example app
- [x] Manual smoke in Storybook: `PlaceholderSlot`, `FooterSlot`, `Grouped`, `GroupedCustomHeader`, `WithDisabledItems`