### PR TITLE
fix(menu): forward placement via options to RuiMenu

### DIFF
--- a/packages/ui-library/src/components/calendar/RuiCalendarMenu.vue
+++ b/packages/ui-library/src/components/calendar/RuiCalendarMenu.vue
@@ -9,6 +9,7 @@ import {
 } from '@/components/calendar/state';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
+import { type FloatingOptions, Placement } from '@/composables/floating';
 import { tv } from '@/utils/tv';
 import RuiButton from '../buttons/button/RuiButton.vue';
 
@@ -28,6 +29,8 @@ const { viewMonth, viewYear } = defineProps<{
 const emit = defineEmits<{
   select: [MonthYearSelection];
 }>();
+
+const MENU_OPTIONS: FloatingOptions = { placement: Placement.bottomStart };
 
 // Core reactive state - minimal
 const viewMode = ref<'months' | 'years'>('months');
@@ -234,7 +237,7 @@ watch(
   <RuiMenu
     v-model="modelValue"
     :anchor-el="anchorEl"
-    placement="bottom-start"
+    :options="MENU_OPTIONS"
   >
     <div class="w-64 shadow-lg overflow-hidden">
       <div class="flex items-center justify-center p-1 font-medium text-gray-800 dark:text-gray-200 border-b border-rui-grey-200 dark:border-rui-grey-800 cursor-pointer hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800">

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -9,6 +9,7 @@ import { useInputHandler } from '@/components/date-time-picker/use-input-handler
 import { useKeyboardHandler } from '@/components/date-time-picker/use-keyboard-handler';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
+import { type FloatingOptions, Placement } from '@/composables/floating';
 import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 import { cn } from '@/utils/tv';
@@ -74,6 +75,8 @@ const {
 defineSlots<{
   'menu-content': () => any;
 }>();
+
+const MENU_OPTIONS: FloatingOptions = { placement: Placement.bottomStart };
 
 const baseFormats: Record<DateFormat, string> = {
   'day-first': 'DD/MM/YYYY HH:mm',
@@ -300,7 +303,7 @@ watch(anyMenuOpen, (value) => {
     v-model="isOpen"
     v-bind="getRootAttrs($attrs, [])"
     :class="ui.wrapper({ class: cn($attrs.class) })"
-    placement="bottom-start"
+    :options="MENU_OPTIONS"
     :dense="dense"
     :hint="hint"
     :disabled="disabled"

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -13,6 +13,7 @@ import {
   useDropdownMenu,
   useDropdownOptionProperty,
 } from '@/composables/dropdown-menu';
+import { type FloatingOptions, Placement } from '@/composables/floating';
 import {
   useAutoCompleteFocus,
   useAutoCompleteKeyboardNavigation,
@@ -466,6 +467,11 @@ watch(() => options, (curr, old) => {
   setSelected(get(value));
 });
 
+const menuFloatingOptions = computed<FloatingOptions>(() => ({
+  placement: Placement.bottomStart,
+  ...menuOptions?.options,
+}));
+
 defineExpose({
   closeMenu,
   focus: focusSetInputFocus,
@@ -479,7 +485,7 @@ defineExpose({
     v-model="isOpen"
     v-bind="{ ...getRootAttrs($attrs, []), ...menuOptions }"
     :class="ui.wrapper({ class: cn($attrs.class) })"
-    placement="bottom-start"
+    :options="menuFloatingOptions"
     :close-on-content-click="false"
     :full-width="true"
     :persist-on-activator-click="true"

--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
@@ -6,6 +6,7 @@ import RuiIcon from '@/components/icons/RuiIcon.vue';
 import RuiMenu, { type MenuProps } from '@/components/overlays/menu/RuiMenu.vue';
 import RuiProgress from '@/components/progress/RuiProgress.vue';
 import { type KeyOfType, useDropdownMenu } from '@/composables/dropdown-menu';
+import { type FloatingOptions, Placement } from '@/composables/floating';
 import { useFormTextDetail } from '@/utils/form-text-detail';
 import { getNonRootAttrs, getRootAttrs } from '@/utils/helpers';
 import { cn } from '@/utils/tv';
@@ -183,6 +184,11 @@ const highlightedClass = menuSelectStyles({}).highlighted();
 function clear(): void {
   set(modelValue, undefined);
 }
+
+const menuFloatingOptions = computed<FloatingOptions>(() => ({
+  placement: Placement.bottomStart,
+  ...menuOptions?.options,
+}));
 </script>
 
 <template>
@@ -190,7 +196,7 @@ function clear(): void {
     v-model="isOpen"
     v-bind="{ ...getRootAttrs($attrs, []), ...menuOptions }"
     :class="ui.wrapper({ class: cn($attrs.class) })"
-    placement="bottom-start"
+    :options="menuFloatingOptions"
     :close-on-content-click="true"
     :full-width="true"
     :error-messages="errorMessages"


### PR DESCRIPTION
## Summary

- Forward `placement` through `options.placement` from RuiAutoComplete, RuiMenuSelect, RuiCalendarMenu, and RuiDateTimePicker. The bare `placement="bottom-start"` attribute was silently dropped because `MenuProps` has no top-level `placement` prop, so all four consumers were defaulting to `Placement.bottom` (center) — the root cause of #539.
- Hoist the `:options` value to a stable reference: a module-level const for the static cases (calendar, date-time picker) and a `computed` for the cases that merge with consumer-provided `menuOptions.options` (auto-complete, menu-select). This prevents the `options` prop identity from changing on every parent re-render (e.g. autocomplete keystrokes) and re-triggering `useFloating`'s watchEffect — which would otherwise tear down and recreate the Floating UI `autoUpdate` listener.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm --filter @rotki/ui-library run test:run` (1129 passed)
- [ ] Storybook: open `Components/Forms/AutoComplete/WithDisabledItems` with `?full=1`, click activator, confirm the menu opens at the activator's left edge without scrollback or horizontal scrollbar flash.
- [ ] Spot check: RuiMenuSelect, RuiCalendarMenu, RuiDateTimePicker still open at `bottom-start` of their activators.

Closes #539

Related: #540 (separate `anchor-el` prop falls through similarly on RuiCalendarMenu).