### PR TITLE
fix(menu): forward anchorEl prop to useFloating

### DIFF
--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
@@ -39,6 +39,12 @@ export interface MenuProps {
   dense?: boolean;
   persistent?: boolean;
   disableAutoFocus?: boolean;
+  /**
+   * Optional external element to anchor the menu to, instead of the
+   * activator slot's wrapper. When set, the menu's position is computed
+   * against this element.
+   */
+  anchorEl?: HTMLElement;
 }
 
 defineOptions({
@@ -67,6 +73,7 @@ const {
   dense = false,
   persistent = false,
   disableAutoFocus = false,
+  anchorEl,
 } = defineProps<MenuProps>();
 
 defineSlots<{
@@ -103,6 +110,7 @@ const {
   () => disabled,
   () => openDelay,
   () => closeDelay,
+  () => anchorEl,
 );
 
 const { width } = useElementSize(activator);


### PR DESCRIPTION
## Summary

- Exposes `anchorEl?: HTMLElement` on `MenuProps` and forwards it to `useFloating` as the `virtualReference` argument.
- Restores `RuiCalendarMenu`'s ability to anchor the month/year picker against the clicked header element instead of the activator slot's wrapper.

The `anchor-el` attribute that `RuiCalendarMenu` passes to `<RuiMenu>` was silently dropped — `MenuProps` had no such prop and `useFloating` was never given the `virtualReference` it already supports. The attribute fell through to the root div as an unknown HTML attribute. This wires it through.

Closes #540

## Test plan

- [x] `pnpm typecheck` passes
- [x] Existing menu unit tests pass
- [ ] Manually verify in Storybook that `RuiCalendarMenu` opens anchored to the clicked title element