### PR TITLE
feat(data-table): mobile-friendly stacked card mode

### DIFF
--- a/apps/example/e2e/data-table-mobile.spec.ts
+++ b/apps/example/e2e/data-table-mobile.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('data tables - mobile', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/data-tables/mobile');
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Close the mobile sort menu if it was left open.
+    await page.keyboard.press('Escape');
+  });
+
+  test('should hide the header and render inline cell labels in the stacked layout', async ({ page }) => {
+    const table = page.locator('[data-id=table-mobile-forced] [data-id=table]');
+    await expect(table).toBeVisible();
+
+    // Column headers are hidden in the stacked layout.
+    await expect(table.locator('thead')).toHaveCount(0);
+
+    // Each visible cell carries its own inline label.
+    await expect(table.locator('[data-id=cell-label]').first()).toBeVisible();
+    await expect(
+      table.locator('[data-id=cell-label]').filter({ hasText: 'Full name' }).first(),
+    ).toBeVisible();
+  });
+
+  test('should drop columns flagged mobileHidden', async ({ page }) => {
+    const table = page.locator('[data-id=table-mobile-forced] [data-id=table]');
+    await expect(table).toBeVisible();
+
+    // The ID column is flagged mobileHidden, so no cell label for it.
+    await expect(table.locator('[data-id=cell-label]').filter({ hasText: /^ID$/ })).toHaveCount(0);
+  });
+
+  test('should sort through the mobile sort menu', async ({ page }) => {
+    const wrapper = page.locator('[data-id=table-mobile-forced]');
+    const activator = wrapper.locator('[data-id=table-mobile-sort-activator]');
+    await expect(activator).toBeVisible();
+
+    const firstNameValue = wrapper.locator('[data-id=row]').first().locator('[data-id=cell-label]').filter({ hasText: 'Full name' }).locator('xpath=following-sibling::*');
+    const initial = await firstNameValue.textContent();
+
+    // Open the sort menu and toggle the "Full name" column (asc -> desc).
+    await activator.click();
+    await page.getByTestId('table-mobile-sort-option-name').click();
+
+    const toggled = await firstNameValue.textContent();
+    expect(toggled).not.toEqual(initial);
+  });
+
+  test('should collapse pagination to prev/next only', async ({ page }) => {
+    const wrapper = page.locator('[data-id=table-mobile-forced]');
+
+    await expect(wrapper.locator('[data-id=table-pagination-prev]').first()).toBeVisible();
+    await expect(wrapper.locator('[data-id=table-pagination-next]').first()).toBeVisible();
+    // First/last jump buttons are dropped on mobile.
+    await expect(wrapper.locator('[data-id=table-pagination-first]')).toHaveCount(0);
+    await expect(wrapper.locator('[data-id=table-pagination-last]')).toHaveCount(0);
+  });
+
+  test('should hide the verbose pagination section labels on mobile', async ({ page }) => {
+    const limitSection = page.locator('[data-id=table-mobile-forced] [data-id=table-pagination-limit-section]').first();
+    // The "Rows per page:" label is present but hidden so the toolbar stays on one line.
+    await expect(limitSection.getByText('Rows per page:')).toBeHidden();
+  });
+
+  test('should pin the action into the card header', async ({ page }) => {
+    const firstCard = page.locator('[data-id=table-mobile-forced] [data-id=row]').first();
+    const header = firstCard.locator('[data-id=mobile-card-header]');
+    await expect(header).toBeVisible();
+    // The action (ellipsis) lives in the header, not as a stacked body row.
+    await expect(header.locator('button')).toBeVisible();
+    // No inline label sits beside the action in the header.
+    await expect(header.locator('[data-id=cell-label]')).toHaveCount(0);
+  });
+
+  test('should place checkbox, action and expand toggle in the card header', async ({ page }) => {
+    const firstCard = page.locator('[data-id=table-mobile-sticky] [data-id=row]').first();
+    const header = firstCard.locator('[data-id=mobile-card-header]');
+    await expect(header).toBeVisible();
+    // Selection checkbox is in the header.
+    await expect(header.locator('input[type=checkbox]')).toHaveCount(1);
+    // Two header buttons: the action and the expand toggle.
+    await expect(header.locator('button')).toHaveCount(2);
+  });
+
+  test('should move expansion into the header and attach the panel below the card', async ({ page }) => {
+    const wrapper = page.locator('[data-id=table-mobile-sticky]');
+    const firstCard = wrapper.locator('[data-id=row]').first();
+    const header = firstCard.locator('[data-id=mobile-card-header]');
+
+    // Expand via the toggle in the header (last button on the right).
+    await header.locator('button').last().click();
+
+    const panel = wrapper.locator('[data-id=row-expanded]').first();
+    await expect(panel).toBeVisible();
+    await expect(panel.locator('[data-id=expanded-panel-content]')).toBeVisible();
+  });
+
+  test('should keep the toolbar pinned when sticky-header is set', async ({ page }) => {
+    const toolbar = page.locator('[data-id=table-mobile-sticky] [data-id=table-mobile-toolbar-sticky]');
+    await expect(toolbar).toHaveCSS('position', 'sticky');
+  });
+
+  test('should auto-switch the viewport table to cards below the breakpoint', async ({ page }) => {
+    const table = page.locator('[data-id=table-mobile-auto] [data-id=table-auto]');
+    // Default viewport (1280px) is above the 768px breakpoint → normal table.
+    await expect(table.locator('thead')).toHaveCount(1);
+
+    await page.setViewportSize({ width: 400, height: 800 });
+    // Below the breakpoint → stacked cards, column header gone.
+    await expect(table.locator('thead')).toHaveCount(0);
+    await expect(table.locator('[data-id=mobile-card-header]').first()).toBeVisible();
+
+    // Restore the default viewport for later tests.
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+
+  test('should switch to cards based on container width, independent of the window', async ({ page }) => {
+    // The window is 1280px wide, but this table sits in a 360px box and uses
+    // mobileBreakpointBasis="container", so it renders as stacked cards.
+    const container = page.locator('[data-id=table-mobile-container] [data-id=table-container]');
+    await expect(container.locator('thead')).toHaveCount(0);
+    await expect(container.locator('[data-id=mobile-card-header]').first()).toBeVisible();
+
+    // The viewport-based auto-switch table stays a normal table at this width.
+    const auto = page.locator('[data-id=table-mobile-auto] [data-id=table-auto]');
+    await expect(auto.locator('thead')).toHaveCount(1);
+  });
+});

--- a/apps/example/src/pages/data-tables/mobile.vue
+++ b/apps/example/src/pages/data-tables/mobile.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import DataTableMobileView from '@/views/data-tables/DataTableMobileView.vue';
+</script>
+
+<template>
+  <DataTableMobileView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -223,6 +223,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/data-tables/mobile': RouteRecordInfo<
+      '/data-tables/mobile',
+      '/data-tables/mobile',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/data-tables/pagination': RouteRecordInfo<
       '/data-tables/pagination',
       '/data-tables/pagination',
@@ -625,6 +632,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/data-tables/grouping.vue': {
       routes:
         | '/data-tables/grouping'
+      views:
+        | never
+    }
+    'src/pages/data-tables/mobile.vue': {
+      routes:
+        | '/data-tables/mobile'
       views:
         | never
     }

--- a/apps/example/src/views/data-tables/DataTableMobileView.vue
+++ b/apps/example/src/views/data-tables/DataTableMobileView.vue
@@ -1,0 +1,194 @@
+<script lang="ts" setup>
+import type { ExtendedUser } from '@/data/tables';
+import {
+  type DataTableColumn,
+  type DataTableSortData,
+  RuiButton,
+  RuiDataTable,
+  RuiIcon,
+  type TablePaginationData,
+} from '@rotki/ui-library/components';
+import { fixedRows } from '@/data/table-configs';
+
+// A trimmed column set with one column hidden in the stacked mobile layout.
+const columns: DataTableColumn<ExtendedUser>[] = [
+  { key: 'id', label: 'ID', mobileHidden: true },
+  { key: 'name', label: 'Full name', sortable: true },
+  { key: 'email', label: 'Email address', sortable: true },
+  { key: 'phone', align: 'end', label: 'Phone' },
+  { key: 'action', label: '', mobileHeader: true },
+];
+
+const sort = ref<DataTableSortData<ExtendedUser>>({ column: 'name', direction: 'asc' });
+const pagination = ref<TablePaginationData>({ limit: 5, page: 1, total: fixedRows.length });
+
+const expanded = ref<ExtendedUser[]>([]);
+const selected = ref<ExtendedUser['id'][]>([]);
+</script>
+
+<template>
+  <div data-id="data-tables-mobile">
+    <h2 class="text-2xl font-bold mb-6">
+      Mobile
+    </h2>
+
+    <div class="grid grid-cols-1 gap-12">
+      <!-- Forced stacked layout -->
+      <div
+        class="flex flex-col space-y-3 max-w-md"
+        data-id="table-mobile-forced"
+      >
+        <h4>Stacked card layout (forced)</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Each row becomes a card of label/value pairs. Headers move into the
+          sort menu and the pagination collapses to prev/next. The
+          <code>ID</code> column is hidden via <code>mobileHidden</code>.
+        </p>
+        <RuiDataTable
+          v-model:sort="sort"
+          v-model:pagination="pagination"
+          :rows="fixedRows"
+          :cols="columns"
+          mobile
+          row-attr="id"
+          outlined
+          data-id="table"
+        >
+          <template #item.action>
+            <RuiButton
+              icon
+              variant="text"
+              size="sm"
+            >
+              <RuiIcon
+                name="lu-ellipsis"
+                color="primary"
+              />
+            </RuiButton>
+          </template>
+        </RuiDataTable>
+      </div>
+
+      <!-- Automatic switch at a breakpoint -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-mobile-auto"
+      >
+        <h4>Automatic switch (mobileBreakpoint)</h4>
+        <p class="text-sm text-rui-text-secondary">
+          Resize the viewport below 768px: the table switches to the stacked
+          layout on its own.
+        </p>
+        <RuiDataTable
+          :rows="fixedRows"
+          :cols="columns"
+          :mobile-breakpoint="768"
+          :pagination="{ limit: 5, page: 1, total: fixedRows.length }"
+          :sort="{ column: 'name', direction: 'asc' }"
+          row-attr="id"
+          outlined
+          data-id="table-auto"
+        >
+          <template #item.action>
+            <RuiButton
+              icon
+              variant="text"
+              size="sm"
+            >
+              <RuiIcon
+                name="lu-ellipsis"
+                color="primary"
+              />
+            </RuiButton>
+          </template>
+        </RuiDataTable>
+      </div>
+
+      <!-- Container-based switch: narrow region of a wide window -->
+      <div
+        class="flex flex-col space-y-3"
+        data-id="table-mobile-container"
+      >
+        <h4>Container-based switch (mobileBreakpointBasis="container")</h4>
+        <p class="text-sm text-rui-text-secondary">
+          This table lives in a fixed 360px box. With
+          <code>mobile-breakpoint-basis="container"</code> it switches to the
+          stacked layout based on its own width, even when the window is wide.
+        </p>
+        <div class="w-[360px] border border-dashed border-black/20 p-2">
+          <RuiDataTable
+            :rows="fixedRows"
+            :cols="columns"
+            :mobile-breakpoint="500"
+            mobile-breakpoint-basis="container"
+            :pagination="{ limit: 5, page: 1, total: fixedRows.length }"
+            :sort="{ column: 'name', direction: 'asc' }"
+            row-attr="id"
+            outlined
+            data-id="table-container"
+          >
+            <template #item.action>
+              <RuiButton
+                icon
+                variant="text"
+                size="sm"
+              >
+                <RuiIcon
+                  name="lu-ellipsis"
+                  color="primary"
+                />
+              </RuiButton>
+            </template>
+          </RuiDataTable>
+        </div>
+      </div>
+
+      <!-- Sticky toolbar + expandable rows -->
+      <div
+        class="flex flex-col space-y-3 max-w-md"
+        data-id="table-mobile-sticky"
+      >
+        <h4>Sticky toolbar + expandable rows</h4>
+        <p class="text-sm text-rui-text-secondary">
+          With <code>sticky-header</code> the pagination + sort toolbar stays
+          pinned while the card list scrolls. The expand toggle moves into the
+          card header and the expanded panel attaches beneath the card.
+        </p>
+        <RuiDataTable
+          v-model="selected"
+          v-model:expanded="expanded"
+          :rows="fixedRows"
+          :cols="columns"
+          mobile
+          sticky-header
+          :pagination="{ limit: 5, page: 1, total: fixedRows.length }"
+          :sort="{ column: 'name', direction: 'asc' }"
+          row-attr="id"
+          outlined
+          data-id="table-sticky"
+        >
+          <template #item.action>
+            <RuiButton
+              icon
+              variant="text"
+              size="sm"
+            >
+              <RuiIcon
+                name="lu-ellipsis"
+                color="primary"
+              />
+            </RuiButton>
+          </template>
+          <template #expanded-item="{ row }">
+            <div
+              class="p-2 text-sm"
+              data-id="expanded-panel-content"
+            >
+              Details for {{ row.name }} ({{ row.email }})
+            </div>
+          </template>
+        </RuiDataTable>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/example/src/views/data-tables/index.vue
+++ b/apps/example/src/views/data-tables/index.vue
@@ -57,6 +57,12 @@ const sections = [
     route: '/data-tables/custom-slots',
     icon: 'lu-square-dashed-bottom-code',
   },
+  {
+    title: 'Mobile',
+    description: 'Stacked card layout, mobile sort menu, and compact pagination',
+    route: '/data-tables/mobile',
+    icon: 'lu-smartphone',
+  },
 ];
 </script>
 

--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -1,7 +1,7 @@
-import type { DeepReadonly } from 'vue';
 import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
 import { type ComponentMountingOptions, mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type DeepReadonly, h } from 'vue';
 import RuiButton from '@/components/buttons/button/RuiButton.vue';
 import RuiDataTable from '@/components/tables/RuiDataTable.vue';
 import RuiTablePagination from '@/components/tables/RuiTablePagination.vue';
@@ -2185,6 +2185,342 @@ describe('components/tables/RuiDataTable.vue', () => {
       });
 
       expect(wrapper.find('table tbody').exists()).toBeTruthy();
+    });
+  });
+
+  describe('mobile stacked layout', () => {
+    it('should keep the default table layout when neither mobile prop is set', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('table thead').exists()).toBeTruthy();
+      expect(wrapper.find('[data-id=cell-label]').exists()).toBeFalsy();
+    });
+
+    it('should hide the header and render inline cell labels when mobile is forced on', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('table thead').exists()).toBeFalsy();
+
+      const labels = wrapper.findAll('[data-id=cell-label]');
+      expect(labels.length).toBeGreaterThan(0);
+      expect(labels.map(label => label.text())).toContain('Full name');
+    });
+
+    it('should drop columns flagged mobileHidden in the stacked layout', () => {
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+        { key: 'email', label: 'Email address', mobileHidden: true },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      const labels = wrapper.findAll('[data-id=cell-label]').map(label => label.text());
+      expect(labels).toContain('Full name');
+      expect(labels).not.toContain('Email address');
+    });
+
+    it('should pin columns flagged mobileHeader to the card header in the stacked layout', () => {
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+        { key: 'action', mobileHeader: true },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: {
+          'item.action': '<span data-id="row-action">action</span>',
+        },
+      });
+
+      const header = wrapper.find('[data-id=mobile-card-header]');
+      expect(header.exists()).toBeTruthy();
+      // The action lives in the header, not as a stacked label/value body row.
+      expect(header.find('[data-id=row-action]').exists()).toBeTruthy();
+    });
+
+    it('should not render a card header when there is nothing to pin', () => {
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('[data-id=mobile-card-header]').exists()).toBeFalsy();
+    });
+
+    it('should expose a mobile sort control only when sorting is enabled', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      // No `sort` model provided → no mobile sort control.
+      expect(wrapper.find('[data-id=table-mobile-sort]').exists()).toBeFalsy();
+    });
+
+    it('should render the mobile sort activator reflecting the active column', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+          sort: { column: 'name', direction: 'asc' },
+        },
+      });
+
+      const activator = wrapper.find('[data-id=table-mobile-sort-activator]');
+      expect(activator.exists()).toBeTruthy();
+      // Active single-column sort surfaces the column label on the activator.
+      expect(activator.text()).toContain('Full name');
+    });
+
+    it('should auto-switch to the stacked layout when the width is below mobileBreakpoint', () => {
+      // jsdom renders at ~1024px. A breakpoint far above that means the table
+      // should switch to cards on its own. Guards the auto-switch, which used
+      // to never fire because an absent Boolean `mobile` prop coerces to false.
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          mobileBreakpoint: 5000,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('table thead').exists()).toBeFalsy();
+      expect(wrapper.find('[data-id=cell-label]').exists()).toBeTruthy();
+    });
+
+    it('should stay a normal table when the width is above mobileBreakpoint', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          mobileBreakpoint: 1,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('table thead').exists()).toBeTruthy();
+    });
+
+    it('should not render a card header for a mobileHeader column with no content', () => {
+      // Flagged mobileHeader, but no `item.action` slot is provided and `action`
+      // is not a row key, so there is nothing to pin: no empty header bar.
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+        { key: 'action', mobileHeader: true },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('[data-id=mobile-card-header]').exists()).toBeFalsy();
+    });
+
+    it('should fall back to the global mobileBreakpoint default, overridable per table', () => {
+      const globalDefaults = createTableDefaults({ limits: [5, 10], mobileBreakpoint: 5000 });
+
+      // No per-table breakpoint → inherits the global 5000 → stacked cards.
+      const globalWrapper = mount(RuiDataTable<User>, {
+        props: { cols: columns, rowAttr: 'id', rows: data },
+        global: { provide: { [TableSymbol.valueOf()]: globalDefaults } },
+      });
+      expect(globalWrapper.find('table thead').exists()).toBeFalsy();
+      globalWrapper.unmount();
+
+      // Per-table breakpoint overrides the global → normal table.
+      const overrideWrapper = mount(RuiDataTable<User>, {
+        props: { cols: columns, mobileBreakpoint: 1, rowAttr: 'id', rows: data },
+        global: { provide: { [TableSymbol.valueOf()]: globalDefaults } },
+      });
+      expect(overrideWrapper.find('table thead').exists()).toBeTruthy();
+      overrideWrapper.unmount();
+    });
+
+    it('should keep only the outermost table toolbar sticky when tables are nested', () => {
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          stickyHeader: true,
+          expanded: data.slice(0, 1),
+          pagination: { limit: 5, page: 1, total: data.length },
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: {
+          'expanded-item': () => h(RuiDataTable<User>, {
+            cols,
+            mobile: true,
+            stickyHeader: true,
+            pagination: { limit: 5, page: 1, total: data.length },
+            rowAttr: 'id',
+            rows: data,
+          }),
+        },
+      });
+
+      const toolbars = wrapper.findAll('[data-id=table-mobile-toolbar-sticky]');
+      expect(toolbars).toHaveLength(2);
+
+      // The nested toolbar (inside the expanded row) does not pin.
+      const nested = wrapper.find('[data-id=row-expanded] [data-id=table-mobile-toolbar-sticky]');
+      expect(nested.classes()).toContain('contents');
+      expect(nested.classes()).not.toContain('sticky');
+
+      // The outermost toolbar pins.
+      const outer = toolbars.find(toolbar => !toolbar.element.closest('[data-id=row-expanded]'));
+      assert(outer);
+      expect(outer.classes()).toContain('sticky');
+    });
+
+    it('should render a custom item slot for a body column in the stacked layout', () => {
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: {
+          'item.name': '<span data-id="custom-name">custom cell</span>',
+        },
+      });
+
+      // The custom cell slot renders once per rendered card.
+      const rowCount = wrapper.findAll('[data-id=row]').length;
+      const custom = wrapper.findAll('[data-id=custom-name]');
+      expect(rowCount).toBeGreaterThan(0);
+      expect(custom).toHaveLength(rowCount);
+      expect(custom[0]?.text()).toBe('custom cell');
+
+      // It is a body cell, not the pinned header (nothing to pin here).
+      expect(wrapper.find('[data-id=mobile-card-header]').exists()).toBeFalsy();
+
+      // The column keeps its inline label alongside the custom content.
+      const labels = wrapper.findAll('[data-id=cell-label]').map(label => label.text());
+      expect(labels).toContain('Full name');
+    });
+
+    it('should route a mobileHeader column custom slot to the header, not the body', () => {
+      const cols: TableColumn<User>[] = [
+        { key: 'id', label: 'ID' },
+        { key: 'name', label: 'Full name' },
+        { key: 'action', mobileHeader: true },
+      ];
+
+      wrapper = createWrapper({
+        props: {
+          cols,
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: {
+          'item.action': '<span data-id="row-action">action</span>',
+        },
+      });
+
+      const firstCard = wrapper.findAll('[data-id=row]')[0];
+      assert(firstCard);
+      const header = firstCard.find('[data-id=mobile-card-header]');
+      expect(header.exists()).toBeTruthy();
+      // The slot content lives in the header, not among the stacked body cells.
+      expect(header.find('[data-id=row-action]').exists()).toBeTruthy();
+      const bodyCells = firstCard.findAll('td:not([data-id=mobile-card-header]) [data-id=row-action]');
+      expect(bodyCells).toHaveLength(0);
+    });
+  });
+
+  describe('mobile pagination', () => {
+    it('should drop the first/last jump buttons in mobile mode', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          mobile: true,
+          pagination: { limit: 5, page: 1, total: 50 },
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('[data-id=table-pagination-first]').exists()).toBeFalsy();
+      expect(wrapper.find('[data-id=table-pagination-last]').exists()).toBeFalsy();
+      // Prev/next remain available.
+      expect(wrapper.find('[data-id=table-pagination-prev]').exists()).toBeTruthy();
+      expect(wrapper.find('[data-id=table-pagination-next]').exists()).toBeTruthy();
+    });
+
+    it('should keep the first/last jump buttons in the default layout', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          pagination: { limit: 5, page: 1, total: 50 },
+          rowAttr: 'id',
+          rows: data,
+        },
+      });
+
+      expect(wrapper.find('[data-id=table-pagination-first]').exists()).toBeTruthy();
+      expect(wrapper.find('[data-id=table-pagination-last]').exists()).toBeTruthy();
     });
   });
 });

--- a/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.stories.ts
@@ -229,6 +229,7 @@ const columns: TableColumn<User>[] = [
   },
   {
     key: 'action',
+    mobileHeader: true,
   },
 ];
 
@@ -597,6 +598,23 @@ export const GroupedWithExpandButtonEnd = meta.story({
       { column: 'name', direction: 'asc' },
       { column: 'email', direction: 'asc' },
     ],
+  },
+});
+
+export const Mobile = meta.story({
+  args: {
+    cols: columns,
+    mobile: true,
+    modelValue: [],
+    pagination: { limit: 5, page: 1, total: 50 },
+    rows: data,
+    sort: [{ column: 'name', direction: 'asc' }],
+  },
+  async play({ canvas }) {
+    // Column headers are hidden in the stacked layout; each cell carries its
+    // own inline label instead, and sorting moves into the mobile sort menu.
+    await expect(canvas.queryByRole('columnheader')).toBeNull();
+    await expect(canvas.getAllByText('Full name')[0]).toBeVisible();
   },
 });
 

--- a/packages/ui-library/src/components/tables/RuiDataTable.vue
+++ b/packages/ui-library/src/components/tables/RuiDataTable.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup generic="T extends object, IdType extends keyof T = keyof T">
 import type { GroupHeader } from '@/composables/tables/data-table/types';
 import { dataTableStyles } from '@/components/tables/data-table-styles';
-import { type DataTableClasses, provideDataTableContext } from '@/components/tables/data-table/context';
+import { type DataTableClasses, provideDataTableContext, provideDataTableNested, useDataTableNested } from '@/components/tables/data-table/context';
 import RuiDataTableBody from '@/components/tables/data-table/RuiDataTableBody.vue';
+import RuiDataTableMobileSort from '@/components/tables/data-table/RuiDataTableMobileSort.vue';
 import RuiTableHead, {
   type GroupData,
   type TableColumn,
@@ -110,6 +111,26 @@ export interface Props<T, K extends keyof T> {
   disabledRows?: readonly T[];
   multiPageSelect?: boolean;
   itemClass?: ((item: T) => string) | string;
+  /**
+   * Render each row as a stacked card instead of a table row once the measured
+   * width is narrower than this width (in pixels). Columns flagged with
+   * `mobileHidden` are dropped in this layout. Falls back to the global
+   * `mobileBreakpoint` table default; leave both unset to keep the default table
+   * layout at every width.
+   */
+  mobileBreakpoint?: number;
+  /**
+   * What the `mobileBreakpoint` is measured against: the browser `viewport`
+   * (default) or this table's own `container` width. Use `container` when the
+   * table lives in a narrow region of a wider window. Falls back to the global
+   * `mobileBreakpointBasis` table default.
+   */
+  mobileBreakpointBasis?: 'viewport' | 'container';
+  /**
+   * Force the stacked mobile card layout on (`true`) or off (`false`),
+   * regardless of `mobileBreakpoint`. Leave unset to derive it from the width.
+   */
+  mobile?: boolean;
 }
 
 defineOptions({
@@ -153,6 +174,9 @@ const {
   disabledRows,
   multiPageSelect = false,
   itemClass = '',
+  mobileBreakpoint,
+  mobileBreakpointBasis,
+  mobile,
 } = defineProps<Props<T, IdType>>();
 
 const emit = defineEmits<{
@@ -181,9 +205,55 @@ const slots = defineSlots<Partial<
 
 const tableDefaults = useTable();
 
+const tableWrapper = useTemplateRef<HTMLElement>('tableWrapper');
+const { width: windowWidth } = useWindowSize();
+const { width: containerWidth } = useElementSize(tableWrapper);
+
+// Per-table props win, then the global table defaults.
+const resolvedMobileBreakpoint = computed<number | undefined>(() => {
+  if (mobileBreakpoint !== undefined)
+    return mobileBreakpoint;
+  const globalBreakpoint = tableDefaults.mobileBreakpoint;
+  return globalBreakpoint === undefined ? undefined : get(globalBreakpoint);
+});
+const resolvedMobileBasis = computed<'viewport' | 'container'>(() => {
+  if (mobileBreakpointBasis !== undefined)
+    return mobileBreakpointBasis;
+  const globalBasis = tableDefaults.mobileBreakpointBasis;
+  return globalBasis === undefined ? 'viewport' : get(globalBasis);
+});
+
+const isMobile = computed<boolean>(() => {
+  const breakpoint = get(resolvedMobileBreakpoint);
+  // Vue coerces an absent Boolean prop to `false`, so `mobile` cannot be used to
+  // detect "unset". When no breakpoint is configured, `mobile` is the manual
+  // switch (defaulting to desktop). When a breakpoint is configured it drives
+  // the layout, and `mobile === true` can still force the stacked layout on.
+  if (breakpoint === undefined)
+    return mobile;
+  if (mobile)
+    return true;
+  // Before the container is measured, `containerWidth` is 0; fall back to the
+  // viewport so the layout does not flash to mobile on first paint.
+  const width = get(resolvedMobileBasis) === 'container'
+    ? (get(containerWidth) || get(windowWidth))
+    : get(windowWidth);
+  return width < breakpoint;
+});
+
 const stickyHeaderOffset = computed<number | undefined>(() =>
   stickyOffset !== undefined ? stickyOffset : get(tableDefaults.stickyOffset),
 );
+
+// Nested tables (e.g. rendered inside an expanded row) must not pin their own
+// toolbar: only the outermost table sticks, otherwise the bars stack and
+// collide. Detect nesting via inject, then mark descendants as nested.
+const isNestedTable = useDataTableNested();
+provideDataTableNested();
+
+// On mobile there is no column header to pin, so `stickyHeader` instead keeps
+// the pagination + sort toolbar pinned to the top while the card list scrolls.
+const stickyMobileToolbar = computed<boolean>(() => stickyHeader && get(isMobile) && !isNestedTable);
 
 const table = useTemplateRef<HTMLTableElement>('table');
 const tableScroller = useTemplateRef<HTMLElement>('tableScroller');
@@ -265,8 +335,13 @@ const { columns, colspan, headerSlots, cellValue } = useTableColumns<T, IdType>(
   groupKeys,
   selectedData,
   slots,
+  isMobile,
   tdResolver: options => get(ui).td(options),
 });
+
+const showMobileSort = computed<boolean>(() =>
+  get(isMobile) && !!get(sortData) && get(columns).some(column => column.sortable),
+);
 
 const ITEM_SLOT_PREFIX = 'item.';
 
@@ -330,6 +405,7 @@ const ui = computed<ReturnType<typeof dataTableStyles>>(() => dataTableStyles({
   rounded,
   dense,
   striped,
+  mobile: get(isMobile),
 }));
 
 const classes = computed<DataTableClasses>(() => {
@@ -355,9 +431,11 @@ provideDataTableContext<T, IdType>({
   colspan,
   expandable,
   groupKey,
+  isMobile,
   selectedData,
   // Static values
   cellValue,
+  columnAttr,
   dense,
   getRowId: (row: T) => row[rowAttr],
   itemSlotKeys,
@@ -378,22 +456,43 @@ provideDataTableContext<T, IdType>({
 
 <template>
   <div
+    ref="tableWrapper"
     :class="ui.wrapper()"
     data-id="table-wrapper"
   >
-    <RuiTablePagination
-      v-if="paginationData && !hideDefaultHeader"
-      v-model="paginationData"
-      :dense="dense"
-      :loading="loading"
-      :disable-per-page="disablePerPage"
-      :ranges-threshold="rangesThreshold"
-      data-id="table-pagination"
-      @update:model-value="onPaginate()"
-    />
+    <div
+      :class="stickyMobileToolbar ? 'sticky z-10 bg-white dark:bg-[#121212] pt-2' : 'contents'"
+      :style="stickyMobileToolbar ? { top: `${stickyHeaderOffset ?? 0}px` } : undefined"
+      data-id="table-mobile-toolbar-sticky"
+    >
+      <RuiTablePagination
+        v-if="paginationData && !hideDefaultHeader"
+        v-model="paginationData"
+        :dense="dense"
+        :loading="loading"
+        :mobile="isMobile"
+        :disable-per-page="disablePerPage"
+        :ranges-threshold="rangesThreshold"
+        data-id="table-pagination"
+        @update:model-value="onPaginate()"
+      />
+      <div
+        v-if="showMobileSort"
+        class="flex justify-end p-2"
+        data-id="table-mobile-toolbar"
+      >
+        <RuiDataTableMobileSort
+          :columns="columns"
+          :column-attr="columnAttr"
+          :sorted-map="sortedMap"
+          :dense="dense"
+          @sort="onSort($event)"
+        />
+      </div>
+    </div>
     <div
       ref="tableScroller"
-      :class="ui.scroller()"
+      :class="[ui.scroller(), isMobile && !showMobileSort ? 'pt-2' : '']"
       data-id="table-scroller"
     >
       <table
@@ -402,6 +501,7 @@ provideDataTableContext<T, IdType>({
         :aria-busy="loading"
       >
         <RuiTableHead
+          v-if="!isMobile"
           :loading="loading"
           :indeterminate="indeterminate"
           :capitalize-headers="!cols"
@@ -430,7 +530,7 @@ provideDataTableContext<T, IdType>({
           </template>
         </RuiTableHead>
         <RuiTableHead
-          v-if="stickyHeader"
+          v-if="stickyHeader && !isMobile"
           :loading="loading"
           :capitalize-headers="!cols"
           :colspan="colspan"
@@ -545,6 +645,7 @@ provideDataTableContext<T, IdType>({
       v-model="paginationData"
       :dense="dense"
       :loading="loading"
+      :mobile="isMobile"
       :disable-per-page="disablePerPage"
       :ranges-threshold="rangesThreshold"
       data-id="table-pagination"

--- a/packages/ui-library/src/components/tables/RuiTableHead.vue
+++ b/packages/ui-library/src/components/tables/RuiTableHead.vue
@@ -24,6 +24,16 @@ export interface BaseTableColumn<T> {
   tdClass?: string;
   colspan?: string | number;
   rowspan?: string | number;
+  /**
+   * hide this column when the table is rendered in its stacked mobile layout
+   */
+  mobileHidden?: boolean;
+  /**
+   * pin this column to the card header (top row) in the stacked mobile layout
+   * instead of rendering it as a label/value pair. Intended for action columns
+   * such as an overflow menu. Ignored on non-mobile layouts.
+   */
+  mobileHeader?: boolean;
 
   [key: string]: any;
 }

--- a/packages/ui-library/src/components/tables/RuiTablePagination.vue
+++ b/packages/ui-library/src/components/tables/RuiTablePagination.vue
@@ -14,6 +14,11 @@ export interface Props {
   disablePerPage?: boolean;
   loading?: boolean;
   /**
+   * Render a compact, touch-friendly layout: the sections spread across the
+   * full width and the first/last jump buttons are dropped to save space.
+   */
+  mobile?: boolean;
+  /**
    * Maximum number of pages before the jump-to-page dropdown is replaced
    * with a numeric input. Set to `0` to always use the input, or a very
    * large number to always use the dropdown. Defaults to `500` — past that
@@ -29,6 +34,7 @@ const {
   loading = false,
   disablePerPage = false,
   rangesThreshold = 500,
+  mobile = false,
 } = defineProps<Props>();
 
 const paginationStyles = tv({
@@ -47,10 +53,17 @@ const paginationStyles = tv({
         wrapper: 'gap-x-2',
       },
     },
+    mobile: {
+      true: {
+        wrapper: 'flex-nowrap justify-between gap-x-2 gap-y-0',
+        ranges: 'pr-0',
+        sectionLabel: 'hidden',
+      },
+    },
   },
 });
 
-const ui = computed<ReturnType<typeof paginationStyles>>(() => paginationStyles({ dense }));
+const ui = computed<ReturnType<typeof paginationStyles>>(() => paginationStyles({ dense, mobile }));
 
 const tableDefaults = useTable();
 
@@ -153,6 +166,7 @@ function commitPageInput(): void {
       data-id="table-pagination-navigation"
     >
       <RuiButton
+        v-if="!mobile"
         :size="dense ? 'sm' : undefined"
         :disabled="!hasPrev || loading"
         variant="text"
@@ -183,6 +197,7 @@ function commitPageInput(): void {
         <RuiIcon name="lu-chevron-right" />
       </RuiButton>
       <RuiButton
+        v-if="!mobile"
         :size="dense ? 'sm' : undefined"
         :disabled="!hasNext || loading"
         variant="text"

--- a/packages/ui-library/src/components/tables/data-table-styles.ts
+++ b/packages/ui-library/src/components/tables/data-table-styles.ts
@@ -33,5 +33,15 @@ export const dataTableStyles = tv({
       expandable: { tr: 'bg-[#f9fafb] hover:bg-[#f9fafb] dark:bg-[#121212] dark:hover:bg-[#121212]' },
       group: { tr: 'bg-black/[0.02] dark:bg-white/[0.02]' },
     },
+    mobile: {
+      true: {
+        wrapper: 'divide-y-0 border-0 rounded-none overflow-visible',
+        scroller: 'overflow-visible [clip-path:none]',
+        table: 'block min-w-0 max-w-none w-full whitespace-normal divide-y-0 border-0',
+        tbody: 'block divide-y-0',
+        tr: 'block',
+        td: 'block px-4 py-2',
+      },
+    },
   },
 });

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableCell.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableCell.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup generic="T extends object">
 import type { TableColumn } from '@/components/tables/RuiTableHead.vue';
-import { useDataTableColumns, useDataTableExpansion } from '@/components/tables/data-table/context';
+import { useDataTableColumns, useDataTableExpansion, useDataTableStyling } from '@/components/tables/data-table/context';
 import RuiExpandButton from '@/components/tables/RuiExpandButton.vue';
 
-defineProps<{
+const { column } = defineProps<{
   column: TableColumn<T>;
   row: T;
   index: number;
@@ -14,8 +14,15 @@ defineSlots<{
   default?: (props: { column: TableColumn<T>; row: T; index: number }) => any;
 }>();
 
-const { cellValue } = useDataTableColumns<T>();
+const { cellValue, columnAttr } = useDataTableColumns<T>();
 const { isExpanded, onToggleExpand } = useDataTableExpansion<T>();
+const { isMobile } = useDataTableStyling();
+
+const mobileLabel = computed<string>(() => {
+  const label = column[columnAttr];
+  return label === undefined || label === null ? '' : String(label);
+});
+const showMobileLabel = computed<boolean>(() => get(isMobile) && column.key !== 'expand' && get(mobileLabel).length > 0);
 </script>
 
 <template>
@@ -23,23 +30,34 @@ const { isExpanded, onToggleExpand } = useDataTableExpansion<T>();
     :class="[
       column.tdClass,
       column.cellClass,
+      isMobile ? 'flex items-start justify-between gap-4 text-right' : '',
     ]"
     :colspan="column.colspan ?? 1"
     :rowspan="column.rowspan ?? 1"
   >
-    <slot
-      :column="column"
-      :row="row"
-      :index="index"
+    <span
+      v-if="showMobileLabel"
+      aria-hidden="true"
+      class="shrink-0 text-left font-medium text-rui-text-secondary"
+      data-id="cell-label"
     >
-      <RuiExpandButton
-        v-if="column.key === 'expand'"
-        :expanded="rowId !== undefined && isExpanded(rowId)"
-        @click="onToggleExpand(row)"
-      />
-      <template v-else>
-        {{ cellValue(row, column.key) }}
-      </template>
-    </slot>
+      {{ mobileLabel }}
+    </span>
+    <div :class="isMobile ? 'min-w-0 ml-auto' : 'contents'">
+      <slot
+        :column="column"
+        :row="row"
+        :index="index"
+      >
+        <RuiExpandButton
+          v-if="column.key === 'expand'"
+          :expanded="rowId !== undefined && isExpanded(rowId)"
+          @click="onToggleExpand(row)"
+        />
+        <template v-else>
+          {{ cellValue(row, column.key) }}
+        </template>
+      </slot>
+    </div>
   </td>
 </template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableExpandedRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableExpandedRow.vue
@@ -10,12 +10,18 @@ defineSlots<{
   'expanded-item': (props: { row: T; index: number }) => any;
 }>();
 
-const { classes, colspan } = useDataTableStyling();
+const { classes, colspan, isMobile } = useDataTableStyling();
+
+// On mobile the expanded content attaches beneath its card: matching side
+// borders and a rounded, bordered bottom edge. The top border is intentionally
+// left off — the parent card's flattened bottom edge acts as the divider.
+// `!border-b` defeats the `divide-y-0` on the mobile tbody.
+const mobileExpandedClass = 'block border-x !border-b border-black/[0.12] dark:border-white/[0.12] rounded-b-lg mb-3 overflow-hidden';
 </script>
 
 <template>
   <tr
-    :class="classes.trExpandable"
+    :class="[classes.trExpandable, isMobile ? mobileExpandedClass : '']"
     data-id="row-expanded"
   >
     <td

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableGroupRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableGroupRow.vue
@@ -21,7 +21,12 @@ defineSlots<{
   'group.header.content'?: (props: { header: GroupHeader<T>; groupKey: string }) => any;
 }>();
 
-const { classes, colspan } = useDataTableStyling();
+const { classes, colspan, isMobile } = useDataTableStyling();
+
+// On mobile the group header reads as a rounded section label: separated from
+// the previous group's cards above and its own cards below, aligned to the
+// card content padding.
+const mobileGroupClass = 'mt-6 first:mt-0 mb-2 rounded-lg';
 const {
   groupExpandButtonPosition,
   groupKey,
@@ -36,7 +41,7 @@ const isOpen = computed<boolean>(() => isExpandedGroup(row.group));
 
 <template>
   <tr
-    :class="classes.trGroup"
+    :class="[classes.trGroup, isMobile ? mobileGroupClass : '']"
     data-id="row-group"
   >
     <!-- eslint-disable-next-line vue/require-explicit-slots -- defined via Partial<Record<...>> in defineSlots -->
@@ -48,8 +53,7 @@ const isOpen = computed<boolean>(() => isExpandedGroup(row.group));
       :toggle="() => onToggleExpandGroup(row.group, row.identifier)"
     >
       <td
-        :class="classes.td"
-        class="!p-2"
+        :class="[classes.td, isMobile ? '!px-4 !py-2' : '!p-2']"
         :colspan="colspan"
       >
         <div class="flex items-center gap-2">

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableMobileSort.spec.ts
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableMobileSort.spec.ts
@@ -1,0 +1,97 @@
+import type { SortColumn, TableColumn, TableRowKey } from '@/components/tables/RuiTableHead.vue';
+import { type ComponentMountingOptions, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RuiDataTableMobileSort from '@/components/tables/data-table/RuiDataTableMobileSort.vue';
+import { assertExists, cleanupElements, queryByDataId } from '~/tests/helpers/dom-helpers';
+
+interface User {
+  id: number;
+  name: string;
+  title: string;
+}
+
+const columns: TableColumn<User>[] = [
+  { key: 'id', label: 'ID' },
+  { align: 'end', key: 'name', label: 'Full name', sortable: true },
+  { key: 'title', label: 'Job position', sortable: true },
+];
+
+function sortedMapFor(column?: TableRowKey<User>, direction: 'asc' | 'desc' = 'asc'): Partial<Record<TableRowKey<User>, SortColumn<User>>> {
+  return column ? { [column]: { column, direction } } : {};
+}
+
+function createWrapper(
+  options?: ComponentMountingOptions<typeof RuiDataTableMobileSort<User>>,
+) {
+  return mount(RuiDataTableMobileSort<User>, {
+    ...options,
+    props: {
+      columns,
+      sortedMap: sortedMapFor(),
+      ...options?.props,
+    },
+  });
+}
+
+describe('components/tables/data-table/RuiDataTableMobileSort.vue', () => {
+  let wrapper: ReturnType<typeof createWrapper>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    cleanupElements('*', document.body);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should label the activator "Sort" when nothing is sorted', () => {
+    wrapper = createWrapper();
+    expect(wrapper.find('[data-id=table-mobile-sort-activator]').text()).toContain('Sort');
+  });
+
+  it('should label the activator with the active column', () => {
+    wrapper = createWrapper({ props: { columns, sortedMap: sortedMapFor('name', 'asc') } });
+    expect(wrapper.find('[data-id=table-mobile-sort-activator]').text()).toContain('Full name');
+  });
+
+  it('should render one menu option per sortable column only', async () => {
+    wrapper = createWrapper({ props: { columns, sortedMap: sortedMapFor('name') } });
+
+    await wrapper.find('[data-id=table-mobile-sort-activator]').trigger('click');
+    await vi.runAllTimersAsync();
+
+    expect(queryByDataId('table-mobile-sort-option-name')).toBeTruthy();
+    expect(queryByDataId('table-mobile-sort-option-title')).toBeTruthy();
+    // Non-sortable columns get no option.
+    expect(queryByDataId('table-mobile-sort-option-id')).toBeFalsy();
+  });
+
+  it('should emit the column default direction so the sort composable can cycle', async () => {
+    wrapper = createWrapper({ props: { columns, sortedMap: sortedMapFor('name', 'asc') } });
+
+    await wrapper.find('[data-id=table-mobile-sort-activator]').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const option = queryByDataId<HTMLElement>('table-mobile-sort-option-name');
+    assertExists(option);
+    option.click();
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted('sort')).toStrictEqual([[{ direction: 'asc', key: 'name' }]]);
+  });
+
+  it('should mark the active option with its direction for styling hooks', async () => {
+    wrapper = createWrapper({ props: { columns, sortedMap: sortedMapFor('title', 'desc') } });
+
+    await wrapper.find('[data-id=table-mobile-sort-activator]').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const active = queryByDataId('table-mobile-sort-option-title');
+    assertExists(active);
+    expect(active.getAttribute('data-active')).toBe('true');
+    expect(active.getAttribute('data-direction')).toBe('desc');
+  });
+});

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableMobileSort.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableMobileSort.vue
@@ -1,0 +1,108 @@
+<script lang="ts" setup generic="T extends object">
+import type { SortColumn, TableColumn, TableRowKey } from '@/components/tables/RuiTableHead.vue';
+import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
+import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
+import { SortDirection } from '@/components/tables/table-props';
+
+const {
+  columns,
+  columnAttr = 'label',
+  sortedMap,
+  dense = false,
+} = defineProps<{
+  columns: TableColumn<T>[];
+  columnAttr?: keyof TableColumn<T>;
+  sortedMap: Partial<Record<TableRowKey<T>, SortColumn<T>>>;
+  dense?: boolean;
+}>();
+
+const emit = defineEmits<{
+  sort: [value: { key: TableRowKey<T>; direction?: SortDirection }];
+}>();
+
+const sortableColumns = computed<TableColumn<T>[]>(() => columns.filter(column => column.sortable));
+
+function columnLabel(column: TableColumn<T>): string {
+  const label = column[columnAttr];
+  return label === undefined || label === null ? String(column.key) : String(label);
+}
+
+function sortDirection(key: TableColumn<T>['key']): SortDirection | undefined {
+  return sortedMap[key as TableRowKey<T>]?.direction;
+}
+
+function isActive(key: TableColumn<T>['key']): boolean {
+  return (key as TableRowKey<T>) in sortedMap;
+}
+
+const activeLabel = computed<string>(() => {
+  const active = get(sortableColumns).filter(column => isActive(column.key));
+  if (active.length === 0)
+    return 'Sort';
+  if (active.length === 1)
+    return columnLabel(active[0]!);
+  return `${active.length} sorts`;
+});
+
+// Mirror RuiTableHead: emit the column's configured default direction so the
+// sort composable performs the same asc → desc → none cycle on repeat taps.
+function onSelect(column: TableColumn<T>): void {
+  emit('sort', {
+    key: column.key as TableRowKey<T>,
+    direction: (column.direction as SortDirection | undefined) ?? SortDirection.asc,
+  });
+}
+</script>
+
+<template>
+  <RuiMenu
+    :dense="dense"
+    :options="{ placement: 'bottom-end' }"
+    data-id="table-mobile-sort"
+  >
+    <template #activator="{ attrs }">
+      <RuiButton
+        :size="dense ? 'sm' : undefined"
+        variant="outlined"
+        v-bind="attrs"
+        data-id="table-mobile-sort-activator"
+      >
+        <template #prepend>
+          <RuiIcon
+            name="lu-arrow-up-down"
+            size="18"
+          />
+        </template>
+        {{ activeLabel }}
+      </RuiButton>
+    </template>
+    <div class="py-1 min-w-40">
+      <RuiButton
+        v-for="column in sortableColumns"
+        :key="column.key.toString()"
+        variant="text"
+        size="sm"
+        class="!justify-between w-full !rounded-none"
+        :data-id="`table-mobile-sort-option-${column.key}`"
+        :data-active="isActive(column.key)"
+        :data-direction="sortDirection(column.key)"
+        @click="onSelect(column)"
+      >
+        {{ columnLabel(column) }}
+        <template #append>
+          <RuiIcon
+            v-if="isActive(column.key)"
+            name="lu-arrow-down"
+            :class="sortDirection(column.key) === 'asc' ? 'rotate-180' : ''"
+            size="16"
+          />
+          <span
+            v-else
+            class="w-4"
+          />
+        </template>
+      </RuiButton>
+    </div>
+  </RuiMenu>
+</template>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
@@ -4,6 +4,7 @@ import RuiCheckbox from '@/components/forms/checkbox/RuiCheckbox.vue';
 import { useDataTableColumns, useDataTableExpansion, useDataTableRowIdentity, useDataTableSelection, useDataTableStyling } from '@/components/tables/data-table/context';
 import RuiDataTableCell from '@/components/tables/data-table/RuiDataTableCell.vue';
 import RuiDataTableExpandedRow from '@/components/tables/data-table/RuiDataTableExpandedRow.vue';
+import RuiExpandButton from '@/components/tables/RuiExpandButton.vue';
 
 const {
   row,
@@ -19,10 +20,10 @@ const slots = defineSlots<Partial<
   }
 >>();
 
-const { classes, dense } = useDataTableStyling();
-const { columns, itemSlotKeys } = useDataTableColumns<T>();
+const { classes, dense, isMobile } = useDataTableStyling();
+const { cellValue, columns, itemSlotKeys } = useDataTableColumns<T>();
 const { isDisabledRow, isSelected, onCheckboxClick, onSelect, selectedData } = useDataTableSelection<T>();
-const { expandable, isExpanded } = useDataTableExpansion<T>();
+const { expandable, isExpanded, onToggleExpand } = useDataTableExpansion<T>();
 const { getRowId, itemClass } = useDataTableRowIdentity<T>();
 
 const rowId = computed<T[keyof T]>(() => getRowId(row));
@@ -30,16 +31,110 @@ const selected = computed<boolean>(() => isSelected(get(rowId)));
 const disabled = computed<boolean>(() => isDisabledRow(get(rowId)));
 const expanded = computed<boolean>(() => get(expandable) && !!slots['expanded-item'] && isExpanded(get(rowId)));
 const rowClass = computed<string>(() => typeof itemClass === 'string' ? itemClass : itemClass(row));
+
+// A column is pinned to the mobile card header when it is flagged `mobileHeader`
+// (typically an action column) or when it is the auto-generated expand column.
+function isMobileHeaderColumn(column: TableColumn<T>): boolean {
+  return !!column.mobileHeader || column.key === 'expand';
+}
+
+// A pinned column only earns a spot in the header if it actually renders
+// something: the expand toggle, a provided item slot, or a non-empty cell value.
+// Without this, a pinned column with no content (e.g. an action column whose
+// `#item.action` slot is not provided in a nested table) would leave an empty
+// header bar with just its divider line.
+function mobileHeaderColumnHasContent(column: TableColumn<T>): boolean {
+  if (column.key === 'expand')
+    return true;
+  if (itemSlotKeys.has(column.key.toString()))
+    return true;
+  const value = cellValue(row, column.key);
+  return value !== undefined && value !== null && value !== '';
+}
+
+// In the stacked mobile layout, header columns render in the card header row
+// instead of as a label/value pair. Everything else stacks below in the body.
+const mobileHeaderColumns = computed<TableColumn<T>[]>(() =>
+  get(isMobile) ? get(columns).filter(column => isMobileHeaderColumn(column) && mobileHeaderColumnHasContent(column)) : [],
+);
+const bodyColumns = computed<TableColumn<T>[]>(() =>
+  get(isMobile) ? get(columns).filter(column => !isMobileHeaderColumn(column)) : get(columns),
+);
+const showMobileHeader = computed<boolean>(() =>
+  get(isMobile) && (!!get(selectedData) || get(mobileHeaderColumns).length > 0),
+);
+
+// `!border-y` defeats the `divide-y-0` on the mobile tbody, which otherwise
+// zeroes the top/bottom border on every card except the first one. When the
+// card is expanded, its bottom edge flattens so the expanded panel attaches
+// flush beneath it.
+const mobileCardClass = computed<string>(() => {
+  const shared = 'relative flex flex-col border !border-y border-black/[0.12] dark:border-white/[0.12] overflow-hidden';
+  // These bindings are not run through tailwind-merge, so avoid emitting
+  // conflicting utilities (mb-0 vs mb-3, rounded-b-none vs rounded-lg): pick the
+  // right one per state instead.
+  return get(expanded)
+    ? `${shared} rounded-t-lg mb-0`
+    : `${shared} rounded-lg mb-3 last:mb-0`;
+});
 </script>
 
 <template>
   <tr
-    :class="[selected ? classes.trSelected : classes.tr, rowClass]"
+    :class="[selected ? classes.trSelected : classes.tr, rowClass, isMobile ? mobileCardClass : '']"
     :aria-selected="selectedData ? selected : undefined"
     data-id="row"
   >
+    <!-- Mobile card header: checkbox on the left, pinned action columns on the right -->
     <td
-      v-if="selectedData"
+      v-if="showMobileHeader"
+      class="flex items-center justify-between gap-2 px-4 py-2 border-b border-black/[0.12] dark:border-white/[0.12]"
+      data-id="mobile-card-header"
+    >
+      <RuiCheckbox
+        v-if="selectedData"
+        :data-id="`table-toggle-check-${index}`"
+        :model-value="selected"
+        :disabled="disabled"
+        :size="dense ? 'sm' : undefined"
+        color="primary"
+        class="select-none"
+        hide-details
+        @update:model-value="onSelect($event, rowId, true)"
+        @click="onCheckboxClick($event, rowId, index)"
+      />
+      <span v-else />
+
+      <div
+        v-if="mobileHeaderColumns.length > 0"
+        class="flex items-center gap-1 min-w-0"
+      >
+        <template
+          v-for="(column, headerIndex) in mobileHeaderColumns"
+          :key="`header-${headerIndex}`"
+        >
+          <RuiExpandButton
+            v-if="column.key === 'expand'"
+            :expanded="isExpanded(rowId)"
+            @click="onToggleExpand(row)"
+          />
+          <slot
+            v-else-if="itemSlotKeys.has(column.key.toString())"
+            :name="`item.${column.key.toString()}`"
+            :column="column"
+            :row="row"
+            :index="index"
+          />
+          <template v-else>
+            {{ cellValue(row, column.key) }}
+          </template>
+        </template>
+      </div>
+    </td>
+
+    <!-- Desktop checkbox cell -->
+    <td
+      v-else-if="selectedData && !isMobile"
       :class="classes.checkbox"
       colspan="1"
       rowspan="1"
@@ -58,7 +153,7 @@ const rowClass = computed<string>(() => typeof itemClass === 'string' ? itemClas
     </td>
 
     <RuiDataTableCell
-      v-for="(column, subIndex) in columns"
+      v-for="(column, subIndex) in bodyColumns"
       :key="subIndex"
       :column="column"
       :row="row"

--- a/packages/ui-library/src/components/tables/data-table/context.spec.ts
+++ b/packages/ui-library/src/components/tables/data-table/context.spec.ts
@@ -51,9 +51,11 @@ function stubFullContext(): DataTableContext<TestItem, 'id'> {
     classes: computed<DataTableClasses>(() => stubClasses()),
     colspan: computed<number>(() => 0),
     dense: false,
+    isMobile: computed<boolean>(() => false),
     columns: computed<[]>(() => []),
     cellValue: (_row, _key) => 0,
     itemSlotKeys: new Set<string>(),
+    columnAttr: 'label',
     selectedData: ref<number[] | undefined>(undefined),
     isSelected: () => false,
     isDisabledRow: () => false,
@@ -180,6 +182,7 @@ describe('dataTableContext', () => {
         classes: computed<DataTableClasses>(() => stubClasses()),
         colspan: computed<number>(() => 5),
         dense: true,
+        isMobile: computed<boolean>(() => false),
       };
       const injected = roundTrip(provideDataTableStyling, useDataTableStyling, context);
       expect(injected).toBe(context);
@@ -191,6 +194,7 @@ describe('dataTableContext', () => {
         columns: computed<[]>(() => []),
         cellValue: (_row, _key) => 0,
         itemSlotKeys: new Set<string>(['name']),
+        columnAttr: 'label',
       };
       const injected = roundTrip(provideDataTableColumns<TestItem>, useDataTableColumns<TestItem>, context);
       expect(injected).toBe(context);

--- a/packages/ui-library/src/components/tables/data-table/context.ts
+++ b/packages/ui-library/src/components/tables/data-table/context.ts
@@ -22,12 +22,16 @@ export interface DataTableStylingContext {
   classes: ComputedRef<DataTableClasses>;
   colspan: ComputedRef<number>;
   dense: boolean;
+  /** whether the table is currently rendered in its stacked mobile layout */
+  isMobile: ComputedRef<boolean>;
 }
 
 export interface DataTableColumnsContext<T extends object = any> {
   columns: ComputedRef<TableColumn<T>[]>;
   cellValue: (row: T, key: TableColumn<T>['key']) => T[keyof T];
   itemSlotKeys: Set<string>;
+  /** the column definition attribute used as the visible label (e.g. `label`) */
+  columnAttr: keyof TableColumn<T>;
 }
 
 export interface DataTableSelectionContext<T extends object = any, IdType extends keyof T = keyof T> {
@@ -76,6 +80,7 @@ const DATA_TABLE_SELECTION = Symbol('data-table-selection');
 const DATA_TABLE_EXPANSION = Symbol('data-table-expansion');
 const DATA_TABLE_GROUPING = Symbol('data-table-grouping');
 const DATA_TABLE_ROW_IDENTITY = Symbol('data-table-row-identity');
+const DATA_TABLE_NESTED = Symbol('data-table-nested');
 
 // --- Per-concern provide/use pairs ---
 
@@ -135,11 +140,21 @@ export function useDataTableRowIdentity<T extends object = any, IdType extends k
   return injectOrThrow<DataTableRowIdentityContext<T, IdType>>(DATA_TABLE_ROW_IDENTITY, 'useDataTableRowIdentity');
 }
 
+/** Marks descendant data tables as nested (e.g. rendered inside an expanded row). */
+export function provideDataTableNested(): void {
+  provide(DATA_TABLE_NESTED, true);
+}
+
+/** True when this data table is rendered inside another data table. */
+export function useDataTableNested(): boolean {
+  return inject<boolean>(DATA_TABLE_NESTED, false);
+}
+
 // --- Backward-compatible facade ---
 
 export function provideDataTableContext<T extends object, IdType extends keyof T>(context: DataTableContext<T, IdType>): void {
-  provideDataTableStyling({ classes: context.classes, colspan: context.colspan, dense: context.dense });
-  provideDataTableColumns<T>({ columns: context.columns, cellValue: context.cellValue, itemSlotKeys: context.itemSlotKeys });
+  provideDataTableStyling({ classes: context.classes, colspan: context.colspan, dense: context.dense, isMobile: context.isMobile });
+  provideDataTableColumns<T>({ columns: context.columns, cellValue: context.cellValue, itemSlotKeys: context.itemSlotKeys, columnAttr: context.columnAttr });
   provideDataTableSelection<T, IdType>({ selectedData: context.selectedData, isSelected: context.isSelected, isDisabledRow: context.isDisabledRow, onSelect: context.onSelect, onCheckboxClick: context.onCheckboxClick });
   provideDataTableExpansion<T, IdType>({ expandable: context.expandable, isExpanded: context.isExpanded, onToggleExpand: context.onToggleExpand });
   provideDataTableGrouping<T>({ groupExpandButtonPosition: context.groupExpandButtonPosition, groupKey: context.groupKey, isExpandedGroup: context.isExpandedGroup, onToggleExpandGroup: context.onToggleExpandGroup, onUngroup: context.onUngroup, onCopyGroup: context.onCopyGroup });

--- a/packages/ui-library/src/composables/defaults/table.ts
+++ b/packages/ui-library/src/composables/defaults/table.ts
@@ -5,6 +5,18 @@ export interface TableOptions {
   globalItemsPerPage: MaybeRef<boolean>;
   limits: MaybeRef<number[]>;
   stickyOffset: MaybeRef<number>;
+  /**
+   * Global default width (px) below which every table switches to its stacked
+   * mobile card layout. A table's own `mobileBreakpoint` prop overrides this.
+   * Leave unset to keep the mobile layout opt-in per table.
+   */
+  mobileBreakpoint?: MaybeRef<number>;
+  /**
+   * Whether the mobile breakpoint is measured against the browser viewport
+   * (`viewport`, default) or each table's own container width (`container`).
+   * A table's own `mobileBreakpointBasis` prop overrides this.
+   */
+  mobileBreakpointBasis?: MaybeRef<'viewport' | 'container'>;
 }
 
 export const TableSymbol: InjectionKey<TableOptions> = Symbol.for('rui:table');

--- a/packages/ui-library/src/composables/tables/data-table/columns.ts
+++ b/packages/ui-library/src/composables/tables/data-table/columns.ts
@@ -24,6 +24,8 @@ export interface UseTableColumnsOptions<T extends object, IdType extends keyof T
   slots: Record<string, any>;
   /** Pre-computes td class per column to avoid per-cell tv() calls. */
   tdResolver?: (options: { class?: string }) => string;
+  /** Whether the table is currently rendered in its stacked mobile layout. */
+  isMobile?: MaybeRefOrGetter<boolean>;
 }
 
 export interface UseTableColumnsReturn<T extends object> {
@@ -36,7 +38,7 @@ export interface UseTableColumnsReturn<T extends object> {
 export function useTableColumns<T extends object, IdType extends keyof T>(
   options: UseTableColumnsOptions<T, IdType>,
 ): UseTableColumnsReturn<T> {
-  const { cols, columnAttr, expandable, groupKeys, rows, selectedData, slots, tdResolver } = options;
+  const { cols, columnAttr, expandable, groupKeys, isMobile, rows, selectedData, slots, tdResolver } = options;
 
   function attachTdClass(columnList: TableColumn<T>[]): TableColumn<T>[] {
     if (!tdResolver)
@@ -51,7 +53,7 @@ export function useTableColumns<T extends object, IdType extends keyof T>(
   const columns = computed<TableColumn<T>[]>(() => {
     const currentCols = toValue(cols);
     const currentRows = toValue(rows);
-    const data =
+    const allColumns =
       currentCols ??
       getObjectKeys(currentRows[0] ?? {}).map(
         key =>
@@ -60,6 +62,10 @@ export function useTableColumns<T extends object, IdType extends keyof T>(
             [columnAttr]: String(key),
           }) satisfies NoneSortableTableColumn<T>,
       );
+
+    const data = toValue(isMobile)
+      ? allColumns.filter(column => !column.mobileHidden)
+      : allColumns;
 
     const hasExpandColumn = data.some(row => row.key === 'expand');
 


### PR DESCRIPTION
## Summary

Adds an **opt-in, backward-compatible** mobile layout to `RuiDataTable`. Nothing changes for existing tables unless a new prop is set.

Research first (UX consensus: comparison-heavy tables want horizontal scroll, record-heavy tables want stacked cards). rotki tables are mostly record-heavy, so this implements the **card/stacked** transformation.

## What's included

- **`mobileBreakpoint?: number`** — auto-switch to stacked cards below this viewport width (px).
- **`mobile?: boolean`** — force the stacked layout on/off, overrides the breakpoint.
- **`TableColumn.mobileHidden?: boolean`** — drop a column from the card layout.
- Rows render as **label/value cards**, reusing the existing `item.*` slots (CSS-driven `mobile` style variant, no duplicated slot forwarding).
- Headers are hidden on mobile, so sorting moves into a new **`RuiDataTableMobileSort`** menu that emits to the same `onSort` handler (identical asc/desc/none cycle).
- **`RuiTablePagination`** gains a `mobile` prop: full-width, drops first/last jump buttons, keeps prev/next.

## Testing

- Unit: stacked layout, `mobileHidden`, mobile pagination (`RuiDataTable.spec.ts`); sort menu (`RuiDataTableMobileSort.spec.ts`).
- E2E: `apps/example/e2e/data-table-mobile.spec.ts` (route `/data-tables/mobile`).
- Storybook `Mobile` story + example view demonstrating forced and breakpoint-driven modes.
- `pnpm typecheck` + `pnpm lint` clean; all table unit tests and the 4 new e2e tests pass locally.

## Open decisions to confirm

- **Activation default**: currently opt-in (off unless `mobile`/`mobileBreakpoint` set). Considered auto-on-by-default but chose not to change every existing table silently.
- **Card design**: no "primary/title field" concept yet; all visible columns render as equal label/value rows.
- **Not included** (possible follow-ups): horizontal-scroll hardening (keyboard-focusable region, scroll shadows, pinned first column).

Draft: to review and finalize together.