### PR TITLE
feat(auto-complete): restore a chip to editable text on Alt+Delete

### DIFF
--- a/apps/example/e2e/forms/autocomplete.spec.ts
+++ b/apps/example/e2e/forms/autocomplete.spec.ts
@@ -856,3 +856,29 @@ test.describe('auto-complete - slots (placeholder & footer)', () => {
     await expect(footer).toContainText('Tip: start typing');
   });
 });
+
+test.describe('auto-complete - advanced', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/auto-completes/advanced');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  test('should convert a chip back to editable text on Alt+Delete with custom-value', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-adv-chip-to-text]');
+    const chips = ac.locator('[data-id=activator] [data-value]');
+    await expect(chips).toHaveCount(2);
+
+    // Focus the first chip (Lorem) and convert it back to editable text.
+    await chips.first().focus();
+    await page.keyboard.press('Alt+Backspace');
+
+    // Only that chip is removed, its text is restored into the input, and the
+    // other selection (Ipsum) is untouched.
+    await expect(ac.locator('[data-id=activator] input')).toHaveValue('Lorem');
+    await expect(ac.locator('[data-id=activator] [data-value]')).toHaveCount(1);
+    await expect(page.locator('[data-id=ac-adv-chip-to-text-model]')).toHaveText('Model: Ipsum');
+  });
+});

--- a/apps/example/src/views/auto-completes/AutoCompleteAdvancedView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteAdvancedView.vue
@@ -23,6 +23,7 @@ const searchInputText = ref<string>('');
 
 const multiClearValue = ref<string[]>(['Lorem', 'Ipsum', 'Dolor']);
 const customBlurValue = ref<string>();
+const chipToTextValue = ref<string[]>(['Lorem', 'Ipsum']);
 </script>
 
 <template>
@@ -128,6 +129,23 @@ const customBlurValue = ref<string>();
           label="Custom Value on Blur"
           data-id="ac-adv-custom-blur"
         />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="chipToTextValue"
+          chips
+          custom-value
+          :options="primitiveOptions"
+          label="Chip to text (Alt+Delete)"
+          data-id="ac-adv-chip-to-text"
+        />
+        <div
+          data-id="ac-adv-chip-to-text-model"
+          class="mt-2 text-sm"
+        >
+          Model: {{ chipToTextValue.join(', ') }}
+        </div>
       </div>
     </div>
   </div>

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -291,6 +291,58 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     expect(wrapper.emitted('update:modelValue')?.[2]).toEqual([newValue]);
   });
 
+  it('should convert a chip back to editable text on Alt+Delete when customValue is set', async () => {
+    wrapper = createWrapper<string[], SelectOption>({
+      attachTo: document.body,
+      props: {
+        chips: true,
+        customValue: true,
+        keyAttr: 'id',
+        modelValue: ['7', '8'],
+        options,
+        textAttr: 'label',
+      },
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    const chips = wrapper.find('div[data-id=activator]').findAllComponents(RuiChip);
+    expect(chips).toHaveLength(2);
+    expect(chips[0].text()).toBe('France');
+    expect(chips[1].text()).toBe('England');
+
+    // Alt + Backspace on France restores its text into the input and removes
+    // only that chip, leaving the other selections untouched.
+    await chips[0].trigger('keydown', { altKey: true, key: 'Backspace' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([['8']]);
+    const input = wrapper.find<HTMLInputElement>('div[data-id=activator] input').element;
+    expect(input.value).toBe('France');
+  });
+
+  it('should just remove the chip on Alt+Delete when customValue is not set', async () => {
+    wrapper = createWrapper<string[], SelectOption>({
+      attachTo: document.body,
+      props: {
+        chips: true,
+        keyAttr: 'id',
+        modelValue: ['7'],
+        options,
+        textAttr: 'label',
+      },
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    const chips = wrapper.find('div[data-id=activator]').findAllComponents(RuiChip);
+    await chips[0].trigger('keydown', { altKey: true, key: 'Backspace' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // No custom values allowed → the modifier has no special effect, chip is removed.
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([[]]);
+    const input = wrapper.find<HTMLInputElement>('div[data-id=activator] input').element;
+    expect(input.value).toBe('');
+  });
+
   it('should custom value', async () => {
     wrapper = createWrapper<string[], SelectOption>({
       attachTo: document.body,

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -422,7 +422,17 @@ function chipAttrs(item: TItem, index: number): Record<string, unknown> {
       if (['Backspace', 'Delete'].includes(key)) {
         event.stopPropagation();
         event.preventDefault();
-        setValue(item);
+        // Alt/Option + delete converts the chip back into editable search text
+        // instead of removing it outright. Only meaningful when custom values
+        // are accepted, since the restored text has to be re-selectable.
+        if (event.altKey && customValue) {
+          const text = getText(item) ?? '';
+          setValue(item);
+          updateInternalSearch(text);
+        }
+        else {
+          setValue(item);
+        }
       }
     },
     'onClick': (e: MouseEvent): void => {


### PR DESCRIPTION
Closes #265.

## What

When custom values are allowed (`custom-value`), pressing **Alt/Option + Backspace/Delete** on a focused chip converts it back into editable search text instead of deleting it: the chip's text is placed into the input and only that chip is removed, leaving the other selections untouched.

Without `custom-value` the modifier has no special effect (the chip is simply removed, as before).

## Why

Requested in #265 — when you've typed a free-text value into a chip and want to tweak it, today you have to delete the chip and retype it from scratch. This lets you pull it back into the input for editing.

## Scope / decisions

- Implemented in the existing focused-chip keydown handler (`chipAttrs.onKeydown`) — no new props, no cross-composable plumbing.
- **Keyboard only** (the issue asks for a keyboard modifier); the mouse close button is unchanged.
- Gated on `custom-value`, since a restored raw text value only makes sense when custom values are re-selectable.
- **Modifier choice:** `Alt`/`Option`. The issue didn't specify one; Alt is unused on a focused chip element so there's no conflict. Trivial to switch to Shift if preferred.

## Tests

- **Unit** (`RuiAutoComplete.spec.ts`): Alt+Delete with `custom-value` on a two-chip selection restores the chip's text to the input and removes only that chip (the other remains); Alt+Delete without `custom-value` just removes the chip.
- **E2E** (`forms/autocomplete.spec.ts`): drives a real chips + `custom-value` field on the Advanced example page — focuses the first chip, presses Alt+Backspace, and asserts the input shows the restored text, the chip count drops by one, and the model retains the other value. Backed by a new `ac-adv-chip-to-text` fixture.
