### PR TITLE
feat(auto-complete): match group labels in search

### DIFF
--- a/apps/example/e2e/forms/autocomplete.spec.ts
+++ b/apps/example/e2e/forms/autocomplete.spec.ts
@@ -780,6 +780,24 @@ test.describe('auto-complete - grouping', () => {
     await menu.locator('button', { hasText: 'Indonesia' }).click();
     await expect(ac.locator('input')).toHaveValue('Indonesia');
   });
+
+  test('should surface every item in a group when searching the group label', async ({ page }) => {
+    const ac = page.locator('[data-id=ac-grouping-search-label]');
+    await ac.locator('[data-id=activator]').click();
+
+    const menu = page.locator('div[role=menu]');
+    await expect(menu).toBeVisible();
+
+    // "Europe" is only a group label; no item text contains it.
+    await ac.locator('input').fill('Europe');
+
+    // Only the Europe group survives, with all three of its items.
+    await expect(menu.locator('[data-id=group-header]')).toHaveCount(1);
+    await expect(menu.locator('[data-id=group-header]')).toContainText('Europe');
+    await expect(menu.locator('button', { hasText: 'Germany' })).toBeVisible();
+    await expect(menu.locator('button', { hasText: 'France' })).toBeVisible();
+    await expect(menu.locator('button', { hasText: 'Spain' })).toBeVisible();
+  });
 });
 
 test.describe('auto-complete - slots (placeholder & footer)', () => {

--- a/apps/example/src/views/auto-completes/AutoCompleteGroupingView.vue
+++ b/apps/example/src/views/auto-completes/AutoCompleteGroupingView.vue
@@ -34,6 +34,7 @@ function groupByContinentUpper(item: CountryOption): string {
 const customHeaderValue = ref<number>();
 const disabledValue = ref<number>();
 const groupedDisabledValue = ref<number>();
+const groupLabelSearchValue = ref<number>();
 </script>
 
 <template>
@@ -118,6 +119,20 @@ const groupedDisabledValue = ref<number>();
           text-attr="label"
           label="Grouped with disabled items"
           data-id="ac-grouping-grouped-disabled"
+        />
+      </div>
+
+      <div class="py-4">
+        <RuiAutoComplete
+          v-model="groupLabelSearchValue"
+          clearable
+          :options="countries"
+          group-by="continent"
+          search-includes-group-label
+          key-attr="id"
+          text-attr="label"
+          label="Search matches group label"
+          data-id="ac-grouping-search-label"
         />
       </div>
     </div>

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -1388,6 +1388,234 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     });
   });
 
+  describe('searchIncludesGroupLabel', () => {
+    it('should not match the group label by default', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      // "Europe" is only a group label, no item text contains it.
+      await wrapper.find('input').setValue('Europe');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const menuButtons = queryAllMenuButtons();
+      const relevant = menuButtons.filter(btn =>
+        ['Germany', 'France', 'Spain'].some(label => btn.innerHTML.includes(label)),
+      );
+      expect(relevant).toHaveLength(0);
+    });
+
+    it('should show every item in a group whose label matches when enabled', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          searchIncludesGroupLabel: true,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('Europe');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const menuButtons = queryAllMenuButtons();
+      const relevant = menuButtons.filter(btn =>
+        ['Germany', 'France', 'Spain'].some(label => btn.innerHTML.includes(label)),
+      );
+      expect(relevant).toHaveLength(3);
+
+      // Group header for the matched group is still rendered.
+      const headers = Array.from(document.body.querySelectorAll('[data-id="group-header"]'));
+      expect(headers.map(h => h.textContent?.trim())).toEqual(['Europe']);
+    });
+
+    it('should still match item text when enabled and not duplicate items', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          searchIncludesGroupLabel: true,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      // Matches item text only.
+      await wrapper.find('input').setValue('Germany');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const menuButtons = queryAllMenuButtons();
+      const relevant = menuButtons.filter(btn => btn.innerHTML.includes('Germany'));
+      expect(relevant).toHaveLength(1);
+    });
+
+    it('should have no effect without groupBy', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          searchIncludesGroupLabel: true,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('Europe');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(queryAllMenuButtons()).toHaveLength(0);
+    });
+
+    it('should pass the resolved group label to a custom filter', async () => {
+      const customFilter = vi.fn(
+        (item: GroupedSelectOption, query: string, group?: string): boolean =>
+          item.label.toLowerCase().includes(query.toLowerCase())
+          || (group?.toLowerCase().includes(query.toLowerCase()) ?? false),
+      );
+
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          filter: customFilter,
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('Asia');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(customFilter).toHaveBeenCalledWith(
+        expect.objectContaining({ category: 'Asia' }),
+        'Asia',
+        'Asia',
+      );
+
+      const menuButtons = queryAllMenuButtons();
+      const relevant = menuButtons.filter(btn =>
+        ['India', 'Indonesia'].some(label => btn.innerHTML.includes(label)),
+      );
+      expect(relevant).toHaveLength(2);
+    });
+
+    it('should not duplicate an item that matches both its text and group label', async () => {
+      // "Asia" matches both the group label and the item's own text.
+      const overlappingOptions: GroupedSelectOption[] = [
+        { category: 'Asia', id: '1', label: 'Asia Pacific' },
+        { category: 'Asia', id: '2', label: 'India' },
+        { category: 'Europe', id: '3', label: 'Germany' },
+      ];
+
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: overlappingOptions,
+          searchIncludesGroupLabel: true,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('Asia');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const menuButtons = queryAllMenuButtons();
+      // Both Asia items show (one via group, one via group; the first also via
+      // text) but neither is rendered twice.
+      expect(menuButtons.filter(btn => btn.innerHTML.includes('Asia Pacific'))).toHaveLength(1);
+      expect(menuButtons.filter(btn => btn.innerHTML.includes('India'))).toHaveLength(1);
+      expect(menuButtons.filter(btn => btn.innerHTML.includes('Germany'))).toHaveLength(0);
+    });
+
+    it('should return nothing when the query matches neither item nor group', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: 'category',
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          searchIncludesGroupLabel: true,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('zzzznomatch');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(queryAllMenuButtons()).toHaveLength(0);
+      expect(queryByDataId('group-header')).toBeFalsy();
+    });
+
+    it('should match against a group label resolved by a function', async () => {
+      wrapper = createWrapper<string | undefined, GroupedSelectOption>({
+        attachTo: document.body,
+        props: {
+          groupBy: (item: GroupedSelectOption): string => item.category.toUpperCase(),
+          keyAttr: 'id',
+          modelValue: undefined,
+          options: groupedOptions,
+          searchIncludesGroupLabel: true,
+          textAttr: 'label',
+        },
+      });
+
+      await wrapper.find('[data-id=activator]').trigger('click');
+      await vi.advanceTimersToNextTimerAsync();
+
+      await wrapper.find('input').setValue('europe');
+      await vi.advanceTimersToNextTimerAsync();
+
+      const menuButtons = queryAllMenuButtons();
+      const relevant = menuButtons.filter(btn =>
+        ['Germany', 'France', 'Spain'].some(label => btn.innerHTML.includes(label)),
+      );
+      expect(relevant).toHaveLength(3);
+
+      const headers = Array.from(document.body.querySelectorAll('[data-id="group-header"]'));
+      expect(headers.map(h => h.textContent?.trim())).toEqual(['EUROPE']);
+    });
+  });
+
   describe('itemDisabled', () => {
     it('should not emit update:modelValue when clicking a disabled item', async () => {
       const flatOptions: GroupedSelectOption[] = [

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.stories.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.stories.ts
@@ -447,6 +447,36 @@ export const Grouped = meta.story({
   },
 });
 
+// @ts-expect-error GroupedSearchLabel uses GroupedSelectOption[] options
+export const GroupedSearchLabel = meta.story({
+  args: {
+    groupBy: 'category',
+    keyAttr: 'id',
+    modelValue: undefined,
+    options: groupedOptions,
+    searchIncludesGroupLabel: true,
+    textAttr: 'label',
+    variant: 'outlined',
+  },
+  async play({ canvas, userEvent }) {
+    const body = within(document.body);
+    const combobox = canvas.getByRole('combobox');
+    await userEvent.click(combobox);
+    await waitFor(() => expect(body.getByRole('menu')).toBeVisible());
+
+    // Typing a group label surfaces every item in that group, even though
+    // none of the item labels contain the query.
+    await userEvent.keyboard('Europe');
+    const menu = body.getByRole('menu');
+    await waitFor(() => expect(within(menu).getByText('Germany')).toBeVisible());
+    expect(within(menu).getByText('France')).toBeVisible();
+    expect(within(menu).getByText('Spain')).toBeVisible();
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(body.queryByRole('menu')).toBeNull());
+  },
+});
+
 // @ts-expect-error GroupedCustomHeader uses GroupedSelectOption[] options
 export const GroupedCustomHeader = meta.story({
   args: {

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -63,7 +63,12 @@ export interface AutoCompleteProps<TValue, TItem> {
   noFilter?: boolean;
   hideNoData?: boolean;
   noDataText?: string;
-  filter?: (item: TItem, queryText: string) => boolean;
+  /**
+   * Custom search predicate. Receives the resolved group label as a third
+   * argument when `groupBy` is set, so callers don't have to re-run the
+   * `groupBy` resolver themselves.
+   */
+  filter?: (item: TItem, queryText: string, group?: string) => boolean;
   hideSelected?: boolean;
   placeholder?: string;
   returnObject?: boolean;
@@ -74,6 +79,14 @@ export interface AutoCompleteProps<TValue, TItem> {
   hideSelectionWrapper?: boolean;
   groupBy?: GroupBy<TItem>;
   itemDisabled?: ItemDisabled<TItem>;
+  /**
+   * When true and `groupBy` is set, the default search predicate also matches
+   * against the resolved group label. Items belonging to a group whose label
+   * matches the query stay visible (group header included), even when the
+   * items themselves don't match. No effect when a custom `filter` is supplied
+   * or when `groupBy` is undefined.
+   */
+  searchIncludesGroupLabel?: boolean;
 }
 
 defineOptions({
@@ -121,6 +134,7 @@ const {
   hideSelectionWrapper = false,
   groupBy,
   itemDisabled,
+  searchIncludesGroupLabel = false,
 } = defineProps<AutoCompleteProps<TValue, TItem>>();
 
 const slots = defineSlots<{
@@ -178,6 +192,8 @@ const {
     customValue: () => customValue,
     hideCustomValue: () => hideCustomValue,
     returnObject: () => returnObject,
+    groupBy: () => groupBy,
+    searchIncludesGroupLabel: () => searchIncludesGroupLabel,
   },
 );
 

--- a/packages/ui-library/src/composables/forms/auto-complete/search.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/search.ts
@@ -1,4 +1,5 @@
 import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { GroupBy } from '@/composables/dropdown-menu';
 import { get, set } from '@vueuse/shared';
 import { getTextToken } from '@/utils/helpers';
 
@@ -10,13 +11,17 @@ export interface UseAutoCompleteSearchOptions<TItem> {
   /** Whether to disable client-side filtering of options. */
   noFilter?: MaybeRefOrGetter<boolean>;
   /** Custom filter function to match items against the search query. */
-  filter?: MaybeRefOrGetter<((item: TItem, queryText: string) => boolean) | undefined>;
+  filter?: MaybeRefOrGetter<((item: TItem, queryText: string, group?: string) => boolean) | undefined>;
   /** Whether custom (free-text) values are allowed. */
   customValue?: MaybeRefOrGetter<boolean>;
   /** Whether to hide the custom value option from the dropdown. */
   hideCustomValue?: MaybeRefOrGetter<boolean>;
   /** Whether to return the full item object instead of just the key. */
   returnObject?: MaybeRefOrGetter<boolean>;
+  /** How items are grouped, used to resolve group labels for filtering. */
+  groupBy?: MaybeRefOrGetter<GroupBy<TItem> | undefined>;
+  /** When true and `groupBy` is set, the default filter also matches the resolved group label. */
+  searchIncludesGroupLabel?: MaybeRefOrGetter<boolean>;
 }
 
 export interface UseAutoCompleteSearchReturn<TItem> {
@@ -58,6 +63,19 @@ export function useAutoCompleteSearch<TItem>(
     return token;
   };
 
+  // Resolve the group label for an item. Mirrors `getGroupKey` in
+  // dropdown-menu.ts so the filter can match against the same labels the
+  // rendered group headers show.
+  const resolveGroup = (item: TItem, groupBy: GroupBy<TItem> | undefined): string | undefined => {
+    if (!groupBy)
+      return undefined;
+
+    if (typeof groupBy === 'function')
+      return groupBy(item);
+
+    return String((item as any)?.[groupBy] ?? '');
+  };
+
   const filteredOptions = computed<TItem[]>(() => {
     const search = get(debouncedInternalSearch);
     const optionsValue = toValue(options);
@@ -69,12 +87,14 @@ export function useAutoCompleteSearch<TItem>(
     const keyAttr = toValue(opts.keyAttr);
     const textAttr = toValue(opts.textAttr);
     const filter = toValue(opts.filter);
+    const groupBy = toValue(opts.groupBy);
+    const searchIncludesGroupLabel = toValue(opts.searchIncludesGroupLabel);
 
     // Cache the search token once
     const searchToken = getCachedTextToken(search);
 
     const filtered = filter
-      ? optionsValue.filter(item => filter(item, search))
+      ? optionsValue.filter(item => filter(item, search, resolveGroup(item, groupBy)))
       : optionsValue.filter((item) => {
           if (!item)
             return false;
@@ -83,6 +103,15 @@ export function useAutoCompleteSearch<TItem>(
 
           if (textAttr && typeof item === 'object')
             keywords.push(getCachedTextToken(String((item as any)[textAttr])));
+
+          // Widen the match to the group label so a query like "trade" surfaces
+          // every item under a "Trade" section, even when the items themselves
+          // (e.g. "Swap") don't contain the query.
+          if (searchIncludesGroupLabel && groupBy) {
+            const group = resolveGroup(item, groupBy);
+            if (group)
+              keywords.push(getCachedTextToken(group));
+          }
 
           return keywords.some(keyword => keyword.includes(searchToken));
         });


### PR DESCRIPTION
## Summary

When `RuiAutoComplete` uses `groupBy`, the search filter only matched item text (via `keyAttr`/`textAttr` or a custom `filter`). The group label itself was invisible to the filter, so typing a section's name (e.g. **Trade**) returned nothing even though a group with that exact label was on screen and the underlying item was **Swap**.

This adds an opt-in prop that widens the default filter to also match the resolved group label.

Closes #543.

## Changes

- **`searchIncludesGroupLabel?: boolean`** (default `false`) on `RuiAutoComplete`. When on and `groupBy` is set, the default filter also matches the resolved group label. Existing consumers are untouched.
- The group label is pushed into each item's keyword set, so a group-label match keeps **every item in that group** visible with its header, with **no duplication** when both the item text and the group label match.
- Group labels reuse the existing `getCachedTextToken` cache (no extra GC pressure).
- The custom `filter` callback now receives the resolved group as a third argument: `filter(item, query, group?)`. Backwards-compatible: existing two-arg filters ignore it, so consumers that supply their own filter no longer have to re-run the `groupBy` resolver themselves.

## Behaviour

- No effect when `groupBy` is undefined.
- Off by default (opt-in), matching the issue's proposed default. The "default to `true` when `groupBy` is set" question is left for a follow-up if desired.
- Works with both string-key and function forms of `groupBy`.

## Tests

- **Unit (8):** default off, group-only match (header renders), item-only match (no dup), both item+group match (no dup), genuine no-match, no-op without `groupBy`, function-form `groupBy`, custom-filter receives the group arg.
- **E2E:** typing a group label surfaces all items in that group under a single header.
- **Storybook:** `GroupedSearchLabel` story with a play function.