### PR TITLE
feat(category-picker): add RuiCategoryPicker two-pane taxonomy selector

### DIFF
--- a/apps/example/e2e/forms/category-picker.spec.ts
+++ b/apps/example/e2e/forms/category-picker.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('category-picker', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/category-pickers');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  test('opens an anchored popover with a category rail and a detail pane', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=activator]').click();
+
+    await expect(page.getByTestId('panel')).toBeVisible();
+    await expect(page.getByTestId('rail')).toBeVisible();
+    await expect(page.getByTestId('detail')).toBeVisible();
+    await expect(page.getByRole('tab', { name: /All/ })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /Europe/ })).toBeVisible();
+  });
+
+  test('shows only a category items after picking it', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=activator]').click();
+    await page.getByRole('tab', { name: /Europe/ }).click();
+
+    const options = page.getByTestId('detail').getByRole('option');
+    await expect(options).toHaveText(['Germany', 'France', 'Spain', 'Italy']);
+  });
+
+  test('selects an item and reflects it on the trigger', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=activator]').click();
+    await page.getByRole('tab', { name: /Europe/ }).click();
+    await page.getByRole('option', { name: 'France' }).click();
+
+    await expect(page.getByTestId('panel')).toBeHidden();
+    await expect(page.locator('[data-id=cp-default] [data-id=search-input]')).toHaveValue('France');
+  });
+
+  test('filters both panes by typing in the field (no separate search box)', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=search-input]').fill('germany');
+
+    // The field is the only search input on desktop.
+    await expect(page.getByTestId('panel').getByTestId('search')).toHaveCount(0);
+    await expect(page.getByRole('tab')).toHaveText([/All/, /Europe/]);
+    await expect(page.getByTestId('detail').getByRole('option')).toHaveText(['Germany']);
+  });
+
+  test('surfaces every item of a category when its label matches', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=search-input]').fill('asia');
+
+    await expect(page.getByTestId('detail').getByRole('option')).toHaveText(['India', 'Indonesia', 'Japan']);
+  });
+
+  test('type-to-pick: Enter in the field commits the top match', async ({ page }) => {
+    const field = page.locator('[data-id=cp-default] [data-id=search-input]');
+    await field.fill('india');
+    await field.press('Enter');
+
+    await expect(page.getByTestId('panel')).toBeHidden();
+    await expect(field).toHaveValue('India');
+  });
+
+  test('renders the large catalogue at 16 categories', async ({ page }) => {
+    await page.locator('[data-id=cp-actions] [data-id=activator]').click();
+
+    // All + 16 categories
+    await expect(page.getByRole('tab')).toHaveCount(17);
+    await expect(page.getByRole('tab', { name: /Staking/ })).toBeVisible();
+  });
+});
+
+test.describe('category-picker - narrow (drill-in)', () => {
+  test.use({ viewport: { width: 480, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/category-pickers');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  test('collapses to a single pane with its own search and drills in and out', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=activator]').click();
+
+    // The sheet carries its own search box on narrow screens.
+    await expect(page.getByTestId('search')).toBeVisible();
+
+    // Only the category rail is visible at first; the detail pane is hidden.
+    await expect(page.getByTestId('rail')).toBeVisible();
+    await expect(page.getByTestId('detail')).toBeHidden();
+
+    // Drill into a category → detail replaces the rail, back button appears.
+    await page.getByRole('tab', { name: /Europe/ }).click();
+    await expect(page.getByTestId('detail')).toBeVisible();
+    await expect(page.getByTestId('rail')).toBeHidden();
+    await expect(page.getByTestId('back')).toBeVisible();
+
+    // Back returns to the category rail.
+    await page.getByTestId('back').click();
+    await expect(page.getByTestId('rail')).toBeVisible();
+    await expect(page.getByTestId('detail')).toBeHidden();
+  });
+
+  test('selects an item from the drilled-in pane', async ({ page }) => {
+    await page.locator('[data-id=cp-default] [data-id=activator]').click();
+    await page.getByRole('tab', { name: /Europe/ }).click();
+    await page.getByRole('option', { name: 'France' }).click();
+
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(page.locator('[data-id=cp-default] [data-id=search-input]')).toHaveValue('France');
+  });
+});

--- a/apps/example/src/App.vue
+++ b/apps/example/src/App.vue
@@ -19,6 +19,7 @@ const navigation = ref([
       { to: '/text-areas', title: 'Text Areas' },
       { to: '/sliders', title: 'Sliders' },
       { to: '/auto-completes', title: 'Auto Complete' },
+      { to: '/category-pickers', title: 'Category Picker' },
       { to: '/file-uploads', title: 'File Upload' },
       { to: '/steppers', title: 'Steppers' },
       { to: '/progress', title: 'Progress' },

--- a/apps/example/src/pages/category-pickers.vue
+++ b/apps/example/src/pages/category-pickers.vue
@@ -1,0 +1,7 @@
+<script lang="ts" setup>
+import CategoryPickerView from '@/views/CategoryPickerView.vue';
+</script>
+
+<template>
+  <CategoryPickerView />
+</template>

--- a/apps/example/src/route-map.d.ts
+++ b/apps/example/src/route-map.d.ts
@@ -164,6 +164,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/category-pickers': RouteRecordInfo<
+      '/category-pickers',
+      '/category-pickers',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/checkboxes': RouteRecordInfo<
       '/checkboxes',
       '/checkboxes',
@@ -618,6 +625,14 @@ declare module 'vue-router/auto-routes' {
     'src/pages/cards.vue': {
       routes:
         | '/cards'
+      views:
+        | never
+      pathParamNames:
+        | never
+    }
+    'src/pages/category-pickers.vue': {
+      routes:
+        | '/category-pickers'
       views:
         | never
       pathParamNames:

--- a/apps/example/src/views/CategoryPickerView.vue
+++ b/apps/example/src/views/CategoryPickerView.vue
@@ -1,0 +1,129 @@
+<script lang="ts" setup>
+import { RuiCategoryPicker } from '@rotki/ui-library';
+import ComponentView from '@/components/ComponentView.vue';
+
+interface CountryOption { id: number; label: string; continent: string }
+
+interface ActionOption { id: string; label: string; category: string }
+
+const countries: CountryOption[] = [
+  { continent: 'Europe', id: 1, label: 'Germany' },
+  { continent: 'Europe', id: 2, label: 'France' },
+  { continent: 'Europe', id: 3, label: 'Spain' },
+  { continent: 'Europe', id: 4, label: 'Italy' },
+  { continent: 'Asia', id: 5, label: 'India' },
+  { continent: 'Asia', id: 6, label: 'Indonesia' },
+  { continent: 'Asia', id: 7, label: 'Japan' },
+  { continent: 'Africa', id: 8, label: 'Nigeria' },
+  { continent: 'Africa', id: 9, label: 'Kenya' },
+  { continent: 'Americas', id: 10, label: 'Brazil' },
+  { continent: 'Americas', id: 11, label: 'Canada' },
+];
+
+// A catalogue at rotki's real scale: 16 categories of history-event verbs.
+const actionCatalogue: Record<string, string[]> = {
+  Airdrop: ['Claim airdrop', 'Receive airdrop'],
+  Approval: ['Approve spender', 'Revoke approval'],
+  Bridge: ['Bridge deposit', 'Bridge withdraw', 'Bridge refund'],
+  Deposit: ['Deposit asset', 'Deposit collateral', 'Bridge in', 'Fund account'],
+  Fee: ['Gas fee', 'Protocol fee', 'Exchange fee'],
+  Governance: ['Propose', 'Vote', 'Delegate', 'Execute'],
+  Liquidity: ['Add liquidity', 'Remove liquidity', 'Collect fees', 'Migrate position'],
+  Loan: ['Borrow', 'Repay', 'Liquidate', 'Roll over'],
+  Migration: ['Migrate balance', 'Upgrade contract', 'Move position'],
+  NFT: ['Mint', 'Buy NFT', 'Sell NFT', 'Transfer NFT'],
+  Reward: ['Claim reward', 'Compound', 'Distribute'],
+  Staking: ['Stake', 'Unstake', 'Restake rewards', 'Claim reward', 'Withdraw stake'],
+  Swap: ['Swap', 'Wrap', 'Unwrap'],
+  Trade: ['Buy', 'Sell', 'Limit order'],
+  Transfer: ['Send', 'Receive', 'Internal transfer', 'Gift'],
+  Withdrawal: ['Withdraw asset', 'Withdraw collateral', 'Bridge out', 'Redeem'],
+};
+
+const actions: ActionOption[] = Object.entries(actionCatalogue).flatMap(
+  ([category, labels], groupIndex) => labels.map((label, itemIndex) => ({
+    category,
+    id: `${groupIndex}-${itemIndex}`,
+    label,
+  })),
+);
+
+const countryValue = ref<number>();
+const actionValue = ref<string>();
+const denseValue = ref<number>();
+const noSearchValue = ref<number>();
+</script>
+
+<template>
+  <ComponentView data-id="category-pickers">
+    <template #title>
+      Category Pickers
+    </template>
+
+    <div class="grid gap-6 grid-cols-2">
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Default
+        </h3>
+        <RuiCategoryPicker
+          v-model="countryValue"
+          :items="countries"
+          category-attr="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Country"
+          clearable
+          data-id="cp-default"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Large catalogue (16 × ~4)
+        </h3>
+        <RuiCategoryPicker
+          v-model="actionValue"
+          :items="actions"
+          category-attr="category"
+          key-attr="id"
+          text-attr="label"
+          label="Action"
+          clearable
+          data-id="cp-actions"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Dense
+        </h3>
+        <RuiCategoryPicker
+          v-model="denseValue"
+          :items="countries"
+          category-attr="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Country"
+          dense
+          data-id="cp-dense"
+        />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Without search
+        </h3>
+        <RuiCategoryPicker
+          v-model="noSearchValue"
+          :items="countries"
+          category-attr="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Country"
+          :searchable="false"
+          data-id="cp-no-search"
+        />
+      </div>
+    </div>
+  </ComponentView>
+</template>

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
@@ -1,0 +1,234 @@
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { groupedOptions, type GroupedSelectOption } from '@/__test__/options';
+import RuiCategoryPicker from '@/components/forms/category-picker/RuiCategoryPicker.vue';
+import { assertExists, cleanupElements, queryByDataId } from '~/tests/helpers/dom-helpers';
+
+// RuiMenu positions via requestAnimationFrame; run it synchronously in tests.
+vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+  cb(Date.now());
+  return 0;
+});
+
+type PickerProps = NonNullable<ComponentMountingOptions<typeof RuiCategoryPicker<string, GroupedSelectOption>>['props']>;
+
+const baseProps: PickerProps = {
+  categoryAttr: 'category',
+  items: groupedOptions,
+  keyAttr: 'id',
+  label: 'Country',
+  textAttr: 'label',
+};
+
+function createWrapper<TValue, TItem>(
+  options?: ComponentMountingOptions<typeof RuiCategoryPicker<TValue, TItem>>,
+) {
+  const opts: ComponentMountingOptions<typeof RuiCategoryPicker<TValue, TItem>> = { ...options };
+  return mount(RuiCategoryPicker, opts);
+}
+
+function mountPicker(extra?: Partial<PickerProps>) {
+  return createWrapper<string, GroupedSelectOption>({ props: { ...baseProps, ...extra } });
+}
+
+async function openPicker(wrapper: VueWrapper<any>): Promise<HTMLElement> {
+  await wrapper.find('[data-id=activator]').trigger('click');
+  await vi.runAllTimersAsync();
+  const panel = queryByDataId<HTMLElement>('panel', document.body);
+  assertExists(panel);
+  return panel;
+}
+
+describe('components/forms/category-picker/RuiCategoryPicker.vue', () => {
+  let wrapper: ReturnType<typeof mountPicker>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    cleanupElements('*', document.body);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('opens the dialog from the trigger', async () => {
+    wrapper = mountPicker();
+    expect(queryByDataId('panel', document.body)).toBeFalsy();
+
+    const dialog = await openPicker(wrapper);
+    expect(queryByDataId('rail', dialog)).toBeTruthy();
+    expect(queryByDataId('detail', dialog)).toBeTruthy();
+  });
+
+  it('renders the rail with an "All" entry plus every category', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    const rail = queryByDataId<HTMLElement>('rail', dialog);
+    assertExists(rail);
+    const tabs = rail.querySelectorAll('[role=tab]');
+    // All + Europe + Asia + Africa
+    expect(tabs).toHaveLength(4);
+    expect(tabs[0]?.textContent).toContain('All');
+  });
+
+  it('shows only the active category items when a category is picked', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    const rail = queryByDataId<HTMLElement>('rail', dialog);
+    assertExists(rail);
+    const europe = Array.from(rail.querySelectorAll<HTMLElement>('[data-category]'))
+      .find(el => el.dataset.category === 'Europe');
+    assertExists(europe);
+    europe.click();
+    await vi.runAllTimersAsync();
+
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    const optionLabels = Array.from(detail.querySelectorAll('[role=option]')).map(el => el.textContent?.trim());
+    expect(optionLabels).toEqual(['Germany', 'France', 'Spain']);
+  });
+
+  it('selects an item, emits the key and closes', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    const germany = Array.from(detail.querySelectorAll<HTMLElement>('[role=option]'))
+      .find(el => el.textContent?.includes('Germany'));
+    assertExists(germany);
+    germany.click();
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['1']);
+    expect(wrapper.emitted('select')).toBeTruthy();
+    expect(queryByDataId('panel', document.body)).toBeFalsy();
+  });
+
+  it('filters both panes on search and hides empty categories', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    await wrapper.find('[data-id=search-input]').setValue('germany');
+    await vi.runAllTimersAsync();
+
+    const rail = queryByDataId<HTMLElement>('rail', dialog);
+    assertExists(rail);
+    const categoryLabels = Array.from(rail.querySelectorAll<HTMLElement>('[data-category]'))
+      .map(el => el.dataset.category);
+    // Only "All" and Europe survive (Germany lives in Europe)
+    expect(categoryLabels).toEqual(['__all__', 'Europe']);
+  });
+
+  it('surfaces a whole category when its label matches the search', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    await wrapper.find('[data-id=search-input]').setValue('asia');
+    await vi.runAllTimersAsync();
+
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    const optionLabels = Array.from(detail.querySelectorAll('[role=option]')).map(el => el.textContent?.trim());
+    expect(optionLabels).toEqual(['India', 'Indonesia']);
+  });
+
+  it('shows the empty state when nothing matches', async () => {
+    wrapper = mountPicker({ emptyText: 'Nothing here' });
+    const dialog = await openPicker(wrapper);
+
+    await wrapper.find('[data-id=search-input]').setValue('zzzznope');
+    await vi.runAllTimersAsync();
+
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    expect(detail.textContent).toContain('Nothing here');
+  });
+
+  it('navigates rail and detail with the keyboard and selects with Enter', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    const rail = queryByDataId<HTMLElement>('rail', dialog);
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(rail);
+    assertExists(detail);
+
+    // Down from "All" to the first real category (Europe), then into the detail.
+    rail.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }));
+    await vi.runAllTimersAsync();
+    rail.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+    await vi.runAllTimersAsync();
+
+    // Down to the second item (France) and select it.
+    detail.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }));
+    await vi.runAllTimersAsync();
+    detail.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['2']);
+  });
+
+  it('picks the top match when pressing Enter in the field', async () => {
+    wrapper = mountPicker();
+    await openPicker(wrapper);
+
+    const field = wrapper.find('[data-id=search-input]');
+    await field.setValue('india');
+    await vi.runAllTimersAsync();
+    await field.trigger('keydown', { key: 'Enter' });
+    await vi.runAllTimersAsync();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['4']); // India
+  });
+
+  it('surfaces matches globally when searching with a category selected', async () => {
+    wrapper = mountPicker({ modelValue: '4' }); // India → opens on Asia
+    const dialog = await openPicker(wrapper);
+
+    await wrapper.find('[data-id=search-input]').setValue('germany');
+    await vi.runAllTimersAsync();
+
+    // Even though Asia was the active category, the query jumps to "All" so the
+    // Europe match shows instead of an empty Asia pane.
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    const optionLabels = Array.from(detail.querySelectorAll('[role=option]')).map(el => el.textContent?.trim());
+    expect(optionLabels).toEqual(['Germany']);
+  });
+
+  it('renders the field label, required marker and error messages', async () => {
+    wrapper = mountPicker({ errorMessages: 'This field is required', required: true });
+
+    expect(wrapper.text()).toContain('Country');
+    expect(wrapper.text()).toContain('﹡');
+    expect(wrapper.text()).toContain('This field is required');
+    expect(wrapper.find('[data-id=activator]').attributes('aria-required')).toBe('true');
+    expect(wrapper.find('[data-id=activator]').attributes('aria-invalid')).toBe('true');
+  });
+
+  it('renders the selected value through the #selection slot', () => {
+    wrapper = createWrapper<string, GroupedSelectOption>({
+      props: { ...baseProps, modelValue: '1' },
+      slots: { selection: '<span class="custom-selection">picked: {{ params.item.label }}</span>' },
+    });
+
+    const selection = wrapper.find('.custom-selection');
+    expect(selection.exists()).toBe(true);
+    expect(selection.text()).toBe('picked: Germany');
+  });
+
+  it('opens with the rail pointed at the selected value', async () => {
+    wrapper = mountPicker({ modelValue: '4' }); // India → Asia
+    const dialog = await openPicker(wrapper);
+
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    const optionLabels = Array.from(detail.querySelectorAll('[role=option]')).map(el => el.textContent?.trim());
+    expect(optionLabels).toEqual(['India', 'Indonesia']);
+  });
+});

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.stories.ts
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.stories.ts
@@ -1,0 +1,210 @@
+import type { ComponentPropsAndSlots, Decorator } from '@storybook/vue3-vite';
+import { expect, waitFor, within } from 'storybook/test';
+import { groupedOptions, type GroupedSelectOption } from '@/__test__/options';
+import RuiCategoryPicker from '@/components/forms/category-picker/RuiCategoryPicker.vue';
+import preview from '~/.storybook/preview';
+
+interface ActionOption { id: string; label: string; category: string }
+
+// A catalogue at the scale that motivated the component: 16 categories of
+// history-event verbs (~4 each ≈ 64 options), from rotki/ui-library#544.
+const actionCategories: Record<string, string[]> = {
+  Deposit: ['Deposit asset', 'Deposit collateral', 'Bridge in', 'Fund account'],
+  Withdrawal: ['Withdraw asset', 'Withdraw collateral', 'Bridge out', 'Redeem'],
+  Trade: ['Buy', 'Sell', 'Limit order'],
+  Staking: ['Stake', 'Unstake', 'Restake rewards', 'Claim reward', 'Withdraw stake'],
+  Transfer: ['Send', 'Receive', 'Internal transfer', 'Gift'],
+  Swap: ['Swap', 'Wrap', 'Unwrap'],
+  Fee: ['Gas fee', 'Protocol fee', 'Exchange fee'],
+  Airdrop: ['Claim airdrop', 'Receive airdrop'],
+  Approval: ['Approve spender', 'Revoke approval'],
+  Governance: ['Propose', 'Vote', 'Delegate', 'Execute'],
+  Liquidity: ['Add liquidity', 'Remove liquidity', 'Collect fees', 'Migrate position'],
+  Bridge: ['Bridge deposit', 'Bridge withdraw', 'Bridge refund'],
+  NFT: ['Mint', 'Buy NFT', 'Sell NFT', 'Transfer NFT'],
+  Loan: ['Borrow', 'Repay', 'Liquidate', 'Roll over'],
+  Reward: ['Claim reward', 'Compound', 'Distribute'],
+  Migration: ['Migrate balance', 'Upgrade contract', 'Move position'],
+};
+
+const actionOptions: ActionOption[] = Object.entries(actionCategories).flatMap(
+  ([category, labels], groupIndex) => labels.map((label, itemIndex) => ({
+    category,
+    id: `${groupIndex}-${itemIndex}`,
+    label,
+  })),
+);
+
+type CategoryPickerProps = ComponentPropsAndSlots<typeof RuiCategoryPicker<string, GroupedSelectOption>>;
+
+function render(args: CategoryPickerProps) {
+  return {
+    components: { RuiCategoryPicker: RuiCategoryPicker<string, GroupedSelectOption> },
+    setup() {
+      const modelValue = computed({
+        get() {
+          return args.modelValue;
+        },
+        set(val) {
+          // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+          args.modelValue = val;
+        },
+      });
+      return { args, modelValue };
+    },
+    template: `<RuiCategoryPicker v-bind="args" v-model="modelValue" />`,
+  };
+}
+
+const meta = preview.meta<
+  typeof RuiCategoryPicker<string, GroupedSelectOption>,
+  Decorator,
+  Required<Pick<CategoryPickerProps, 'items'>>
+>({
+  args: {
+    categoryAttr: 'category',
+    items: groupedOptions,
+    keyAttr: 'id',
+    textAttr: 'label',
+  },
+  argTypes: {
+    dense: { control: 'boolean' },
+    searchable: { control: 'boolean' },
+    showAll: { control: 'boolean' },
+  },
+  component: RuiCategoryPicker<string, GroupedSelectOption>,
+  parameters: {
+    docs: { controls: { exclude: ['update:model-value', 'update:search', 'select'] } },
+  },
+  render,
+  tags: ['autodocs'],
+  title: 'Components/Forms/CategoryPicker',
+});
+
+export const Default = meta.story({
+  args: {
+    label: 'Country',
+    modelValue: undefined,
+  },
+  async play({ canvas, userEvent }) {
+    const body = within(document.body);
+    await userEvent.click(canvas.getByRole('combobox'));
+    await waitFor(() => expect(body.getByRole('tablist')).toBeVisible());
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(body.queryByRole('dialog')).toBeNull());
+  },
+});
+
+// Density spike at rotki's real scale (16 categories × ~4 verbs).
+export const LargeCatalogue = meta.story({
+  args: {
+    // @ts-expect-error the spike uses the ActionOption shape
+    items: actionOptions,
+    label: 'Action',
+    modelValue: undefined,
+  },
+});
+
+export const Dense = meta.story({
+  args: {
+    dense: true,
+    label: 'Country',
+    modelValue: undefined,
+  },
+});
+
+export const NoSearch = meta.story({
+  args: {
+    label: 'Country',
+    modelValue: undefined,
+    searchable: false,
+  },
+});
+
+export const WithoutAll = meta.story({
+  args: {
+    label: 'Country',
+    modelValue: undefined,
+    showAll: false,
+  },
+});
+
+export const Validation = meta.story({
+  args: {
+    hint: 'Pick from the grouped list',
+    label: 'Country',
+    modelValue: undefined,
+    required: true,
+  },
+  render(args: CategoryPickerProps) {
+    return {
+      components: { RuiCategoryPicker: RuiCategoryPicker<string, GroupedSelectOption> },
+      setup() {
+        const modelValue = computed({
+          get() {
+            return args.modelValue;
+          },
+          set(val) {
+            // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+            args.modelValue = val;
+          },
+        });
+        const errorMessages = computed<string[]>(() =>
+          get(modelValue) ? [] : ['Please choose a country'],
+        );
+        return { args, errorMessages, modelValue };
+      },
+      template: `<RuiCategoryPicker v-bind="args" v-model="modelValue" :error-messages="errorMessages" />`,
+    };
+  },
+});
+
+// Force the mobile bottom-sheet + single-pane drill-in on a desktop canvas by
+// treating everything below 2xl as "mobile".
+export const DrillIn = meta.story({
+  args: {
+    label: 'Country',
+    mobileBreakpoint: '2xl',
+    modelValue: undefined,
+  },
+});
+
+export const CustomSlots = meta.story({
+  args: {
+    label: 'Country',
+    modelValue: undefined,
+  },
+  render(args: CategoryPickerProps) {
+    return {
+      components: { RuiCategoryPicker: RuiCategoryPicker<string, GroupedSelectOption> },
+      setup() {
+        const modelValue = computed({
+          get() {
+            return args.modelValue;
+          },
+          set(val) {
+            // @ts-expect-error Storybook args are mutable but Vue extracts readonly props
+            args.modelValue = val;
+          },
+        });
+        return { args, modelValue };
+      },
+      template: `
+        <RuiCategoryPicker v-bind="args" v-model="modelValue">
+          <template #category="{ label, count }">
+            <span class="font-medium truncate">{{ label }}</span>
+            <span class="ml-auto pl-2 text-xs opacity-60">{{ count }}</span>
+          </template>
+          <template #item="{ item, selected }">
+            <span :class="{ 'font-bold': selected }">{{ item.label }}</span>
+            <span class="ml-2 text-xs opacity-50">{{ item.category }}</span>
+          </template>
+          <template #selection="{ item }">
+            <span class="font-medium">{{ item.label }}</span>
+            <span class="ml-2 text-xs opacity-60">({{ item.category }})</span>
+          </template>
+        </RuiCategoryPicker>
+      `,
+    };
+  },
+});

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
@@ -1,0 +1,720 @@
+<script lang="ts" setup generic="TValue, TItem">
+import type { KeyOfType } from '@/composables/dropdown-menu';
+import type { VueClassValue } from '@/types/class-value';
+import { breakpointsTailwind, useBreakpoints } from '@vueuse/core';
+import RuiButton from '@/components/buttons/button/RuiButton.vue';
+import { categoryPickerActivatorStyles, categoryPickerStyles, type CategoryPickerVariant } from '@/components/forms/category-picker/category-picker-styles';
+import RuiTextField from '@/components/forms/text-field/RuiTextField.vue';
+import RuiFormTextDetail from '@/components/helpers/RuiFormTextDetail.vue';
+import RuiIcon from '@/components/icons/RuiIcon.vue';
+import RuiDialog, { type DialogProps } from '@/components/overlays/dialog/RuiDialog.vue';
+import RuiMenu from '@/components/overlays/menu/RuiMenu.vue';
+import RuiProgress from '@/components/progress/RuiProgress.vue';
+import { Placement } from '@/composables/floating';
+import { useCategoryPicker } from '@/composables/forms/category-picker/use-category-picker';
+import { useFormTextDetail } from '@/utils/form-text-detail';
+import { cn } from '@/utils/tv';
+
+export interface RuiCategoryPickerClassNames {
+  root?: VueClassValue;
+  rail?: VueClassValue;
+  detail?: VueClassValue;
+  search?: VueClassValue;
+}
+
+export type CategoryPickerBreakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+export interface RuiCategoryPickerProps<TValue, TItem> {
+  /** The full catalogue of selectable items. */
+  items: TItem[];
+  /** Resolve an item's category label. Takes precedence over `categoryAttr`. */
+  categoryOf?: (item: TItem) => string;
+  /** Resolve an item's category from one of its own properties. */
+  categoryAttr?: keyof TItem;
+  /** Property whose value becomes the model value. Omit to use the item itself. */
+  keyAttr?: KeyOfType<TItem, TValue extends (infer U)[] ? U : TValue>;
+  /** Property that produces an item's display text. */
+  textAttr?: keyof TItem;
+  /** Field label, and the title of the mobile sheet. */
+  label?: string;
+  /** Placeholder shown in the field while it is empty or being searched. */
+  placeholder?: string;
+  /** Allow filtering: type in the field (desktop) or the sheet's search box (mobile). */
+  searchable?: boolean;
+  /**
+   * Custom predicate. Receives the resolved category label as the third
+   * argument, matching the `RuiAutoComplete` filter signature.
+   */
+  filter?: (item: TItem, query: string, category: string) => boolean;
+  /** Show the synthetic "All" pseudo-category as the first rail entry. */
+  showAll?: boolean;
+  /** Label for the "All" pseudo-category. */
+  allLabel?: string;
+  /** Text shown when no item matches the current search. */
+  emptyText?: string;
+  disabled?: boolean;
+  readOnly?: boolean;
+  dense?: boolean;
+  clearable?: boolean;
+  loading?: boolean;
+  /** Trigger field style: underline (`default`), `outlined`, or `filled`. */
+  variant?: CategoryPickerVariant;
+  /** Marks the trigger field as required (renders the asterisk). */
+  required?: boolean;
+  /** Validation errors rendered under the trigger field. */
+  errorMessages?: string | string[];
+  /** Success messages rendered under the trigger field. */
+  successMessages?: string | string[];
+  /** Hint rendered under the trigger field. */
+  hint?: string;
+  /** Hide the details row (errors/success/hint) under the trigger field. */
+  hideDetails?: boolean;
+  /** Below this breakpoint the picker collapses to a single-pane drill-in. */
+  mobileBreakpoint?: CategoryPickerBreakpoint;
+  /** Forwarded to the mobile bottom-sheet (`RuiDialog`). */
+  dialogOptions?: DialogProps;
+  classNames?: RuiCategoryPickerClassNames;
+}
+
+defineOptions({
+  name: 'RuiCategoryPicker',
+  inheritAttrs: false,
+});
+
+const modelValue = defineModel<TValue>();
+const searchInput = defineModel<string>('search', { default: '' });
+
+const {
+  items,
+  categoryOf = undefined,
+  categoryAttr = undefined,
+  keyAttr = undefined,
+  textAttr = undefined,
+  label = 'Select',
+  placeholder = 'Search',
+  searchable = true,
+  filter = undefined,
+  showAll = true,
+  allLabel = 'All',
+  emptyText = 'No results',
+  disabled = false,
+  readOnly = false,
+  dense = false,
+  clearable = false,
+  loading = false,
+  variant = 'outlined',
+  required = false,
+  errorMessages = [],
+  successMessages = [],
+  hint = '',
+  hideDetails = false,
+  mobileBreakpoint = 'md',
+  dialogOptions = undefined,
+  classNames = undefined,
+} = defineProps<RuiCategoryPickerProps<TValue, TItem>>();
+
+const emit = defineEmits<{
+  select: [item: TItem];
+}>();
+
+defineSlots<{
+  'activator'?: (props: { attrs: { onClick?: () => void; onMouseover?: () => void; onMouseleave?: () => void }; isOpen: boolean; open: () => void; item: TItem | undefined; text: string | undefined }) => any;
+  'activator.label'?: (props: { item: TItem | undefined }) => any;
+  'selection'?: (props: { item: TItem }) => any;
+  'selection.prepend'?: (props: { item: TItem }) => any;
+  'category'?: (props: { category: string | null; label: string; active: boolean; count: number }) => any;
+  'item'?: (props: { item: TItem; active: boolean; selected: boolean }) => any;
+  'item.prepend'?: (props: { item: TItem; active: boolean; selected: boolean }) => any;
+  'item.append'?: (props: { item: TItem; active: boolean; selected: boolean }) => any;
+  'empty'?: () => any;
+  'header'?: () => any;
+  'footer'?: (props: { close: () => void }) => any;
+}>();
+
+const isOpen = ref<boolean>(false);
+const focusedPane = ref<'rail' | 'detail'>('rail');
+const highlightedItemIndex = ref<number>(0);
+const drillStep = ref<'category' | 'detail'>('category');
+
+const railRef = useTemplateRef<HTMLDivElement>('railRef');
+const detailRef = useTemplateRef<HTMLDivElement>('detailRef');
+const activatorRef = useTemplateRef<HTMLInputElement>('activatorRef');
+const fieldRef = useTemplateRef<HTMLElement>('fieldRef');
+const isHovered = ref<boolean>(false);
+
+const { focused } = useFocus(activatorRef);
+const { hasError, hasSuccess } = useFormTextDetail(() => errorMessages, () => successMessages);
+
+const baseId = useId();
+const breakpoints = useBreakpoints(breakpointsTailwind);
+
+function resolveCategory(item: TItem): string {
+  if (categoryOf)
+    return categoryOf(item);
+  if (categoryAttr !== undefined)
+    return String(item[categoryAttr] ?? '');
+  return '';
+}
+
+const {
+  activeCategory,
+  detailItems,
+  detailRows,
+  getIdentifier,
+  getText,
+  isEmpty,
+  isSelected,
+  railEntries,
+  setActiveCategory,
+  syncActiveToSelection,
+} = useCategoryPicker<TValue, TItem>({
+  allLabel: () => allLabel,
+  categoryOf: resolveCategory,
+  filter: () => filter,
+  items: () => items,
+  keyAttr,
+  modelValue,
+  search: searchInput,
+  searchable: () => searchable,
+  showAll: () => showAll,
+  textAttr,
+});
+
+const isMobile = computed<boolean>(() => get(breakpoints.smaller(mobileBreakpoint)));
+
+const mode = computed<'twoPane' | 'drill'>(() => (get(isMobile) ? 'drill' : 'twoPane'));
+
+// Desktop anchors an outside-click popover under the field (RuiMenu); narrow
+// width shows a full-width bottom sheet (RuiDialog). Each branch returns only
+// its own shell's props so the other component's props never leak as attrs.
+const shell = computed<typeof RuiMenu | typeof RuiDialog>(() => (get(isMobile) ? RuiDialog : RuiMenu));
+
+const shellProps = computed<Record<string, unknown>>(() => {
+  if (get(isMobile)) {
+    return {
+      ariaLabel: dialogOptions?.ariaLabel ?? label,
+      bottomSheet: dialogOptions?.bottomSheet ?? true,
+      maxWidth: dialogOptions?.maxWidth,
+      persistent: dialogOptions?.persistent,
+      width: dialogOptions?.width ?? '100%',
+    };
+  }
+  return {
+    // Anchor to the field box, not the wrapper, so the popover sits directly
+    // under the input instead of below the reserved details row.
+    anchorEl: get(fieldRef) ?? undefined,
+    classNames: { menu: 'z-[9999]' },
+    closeOnContentClick: false,
+    disableAutoFocus: true,
+    fullWidth: true,
+    options: { placement: Placement.bottomStart },
+    persistent: dialogOptions?.persistent,
+    persistOnActivatorClick: true,
+  };
+});
+
+const ui = computed<ReturnType<typeof categoryPickerStyles>>(() => categoryPickerStyles({
+  dense,
+  mode: get(mode),
+}));
+
+const selectedItem = computed<TItem | undefined>(() => {
+  const value = get(modelValue);
+  if (value === undefined)
+    return undefined;
+  return items.find(item => getIdentifier(item) === value);
+});
+
+const selectedText = computed<string | undefined>(() => {
+  const selected = get(selectedItem);
+  return selected ? getText(selected) : undefined;
+});
+
+const outlined = computed<boolean>(() => variant === 'outlined');
+
+// Desktop lets the user type in the field itself (no separate search box);
+// narrow width keeps a read-only trigger that opens the sheet's own search.
+const canType = computed<boolean>(() => searchable && !get(isMobile) && !readOnly && !disabled);
+
+const isTyping = computed<boolean>(() => get(isOpen) && get(canType));
+
+const float = computed<boolean>(() => (get(isOpen) || get(selectedItem) !== undefined || get(focused)) && get(outlined));
+
+const legendText = computed<string>(() => {
+  if (!get(float) || !label)
+    return '';
+  return required ? `${label} ﹡` : label;
+});
+
+const activatorUi = computed<ReturnType<typeof categoryPickerActivatorStyles>>(() => categoryPickerActivatorStyles({
+  dense,
+  disabled,
+  filled: variant === 'filled',
+  float: get(float),
+  hasError: get(hasError),
+  hasSuccess: get(hasSuccess) && !get(hasError),
+  hovered: get(isHovered),
+  opened: get(isOpen),
+  outlined: get(outlined),
+  readonly: readOnly,
+}));
+
+const activeRailIndex = computed<number>(() =>
+  get(railEntries).findIndex(entry => entry.category === get(activeCategory)));
+
+const showRail = computed<boolean>(() => get(mode) === 'twoPane' || get(drillStep) === 'category');
+const showDetail = computed<boolean>(() => get(mode) === 'twoPane' || get(drillStep) === 'detail');
+
+function clamp(value: number, max: number): number {
+  if (value < 0)
+    return 0;
+  if (value > max)
+    return max;
+  return value;
+}
+
+function open(): void {
+  if (disabled)
+    return;
+  set(isOpen, true);
+}
+
+function close(): void {
+  set(isOpen, false);
+}
+
+function onInput(event: Event): void {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement))
+    return;
+  set(searchInput, target.value);
+  if (!get(isOpen))
+    open();
+}
+
+function selectItem(item: TItem): void {
+  if (readOnly)
+    return;
+  set(modelValue, getIdentifier(item));
+  emit('select', item);
+  close();
+}
+
+function clearSelection(): void {
+  set(modelValue, undefined);
+}
+
+function onCategoryClick(category: string | null): void {
+  setActiveCategory(category);
+  if (get(mode) === 'drill')
+    set(drillStep, 'detail');
+  else
+    focusPane('detail');
+}
+
+function focusPane(pane: 'rail' | 'detail'): void {
+  set(focusedPane, pane);
+  nextTick(() => {
+    (pane === 'rail' ? get(railRef) : get(detailRef))?.focus();
+  });
+}
+
+function moveRail(direction: 1 | -1): void {
+  const entries = get(railEntries);
+  if (entries.length === 0)
+    return;
+  const next = clamp(get(activeRailIndex) + direction, entries.length - 1);
+  setActiveCategory(entries[next]?.category ?? null);
+}
+
+function moveItem(direction: 1 | -1): void {
+  const total = get(detailItems).length;
+  if (total === 0)
+    return;
+  set(highlightedItemIndex, clamp(get(highlightedItemIndex) + direction, total - 1));
+}
+
+function enterDetail(): void {
+  if (get(detailItems).length === 0)
+    return;
+  resetHighlightToSelection();
+  if (get(mode) === 'drill')
+    set(drillStep, 'detail');
+  focusPane('detail');
+}
+
+function selectHighlighted(): void {
+  const item = get(detailItems)[get(highlightedItemIndex)];
+  if (item !== undefined)
+    selectItem(item);
+}
+
+// Enter from the field commits the best match for the current query, so a
+// type-to-pick flow (type a few letters, press Enter) works without leaving the
+// input. Does nothing when the field is empty.
+function selectTopResult(): void {
+  if (!get(searchInput).trim())
+    return;
+  const item = get(detailItems)[0];
+  if (item !== undefined)
+    selectItem(item);
+}
+
+function resetHighlightToSelection(): void {
+  const index = get(detailItems).findIndex(item => isSelected(item));
+  set(highlightedItemIndex, index >= 0 ? index : 0);
+}
+
+function backToRail(): void {
+  if (get(mode) === 'drill')
+    set(drillStep, 'category');
+  else
+    focusPane('rail');
+}
+
+function scrollActiveDescendantIntoView(container: HTMLElement | null, id: string): void {
+  if (!container)
+    return;
+  nextTick(() => {
+    container.querySelector(`#${id}`)?.scrollIntoView({ block: 'nearest' });
+  });
+}
+
+// Reset the item highlight whenever the active category changes.
+watch(activeCategory, () => {
+  resetHighlightToSelection();
+});
+
+watch(highlightedItemIndex, (index) => {
+  scrollActiveDescendantIntoView(get(detailRef), `${baseId}-opt-${index}`);
+});
+
+watch(activeRailIndex, (index) => {
+  if (index >= 0)
+    scrollActiveDescendantIntoView(get(railRef), `${baseId}-cat-${index}`);
+});
+
+watch(isOpen, (value) => {
+  if (value) {
+    syncActiveToSelection();
+    set(focusedPane, 'rail');
+    set(drillStep, 'category');
+    resetHighlightToSelection();
+    // Desktop is a combobox: keep focus in the field so the user can type
+    // straight away (ArrowDown moves into the panes). The mobile sheet has no
+    // typing field, so focus the rail instead.
+    nextTick(() => (get(canType) ? get(activatorRef) : get(railRef))?.focus());
+  }
+  else {
+    // Reset the query so the field shows the selection again next time, and
+    // return focus to the trigger (APG dialog contract).
+    set(searchInput, '');
+    nextTick(() => get(activatorRef)?.focus());
+  }
+});
+</script>
+
+<template>
+  <component
+    :is="shell"
+    v-model="isOpen"
+    v-bind="{ ...$attrs, ...shellProps }"
+  >
+    <template #activator="{ attrs }">
+      <slot
+        name="activator"
+        v-bind="{ attrs, isOpen, item: selectedItem, open, text: selectedText }"
+      >
+        <div :class="activatorUi.wrapper()">
+          <div
+            ref="fieldRef"
+            role="combobox"
+            data-id="activator"
+            :class="activatorUi.activator()"
+            aria-haspopup="dialog"
+            :aria-controls="isOpen ? `${baseId}-panel` : undefined"
+            :aria-expanded="isOpen"
+            :aria-disabled="disabled || undefined"
+            :aria-readonly="(readOnly || !canType) || undefined"
+            :aria-required="required || undefined"
+            :aria-invalid="hasError || undefined"
+            :aria-busy="loading || undefined"
+            v-bind="readOnly ? {} : attrs"
+            @mouseenter="isHovered = true"
+            @mouseleave="isHovered = false"
+          >
+            <span
+              v-if="outlined || (!selectedItem && !isTyping)"
+              :class="activatorUi.label()"
+            >
+              <slot
+                name="activator.label"
+                v-bind="{ item: selectedItem }"
+              >
+                {{ label }}
+              </slot>
+              <span
+                v-if="required"
+                :class="activatorUi.required()"
+              >
+                ﹡
+              </span>
+            </span>
+            <span
+              v-if="selectedItem && !isTyping && $slots.selection"
+              class="absolute inset-y-0 left-4 right-8 flex items-center gap-2 pointer-events-none"
+              :class="[activatorUi.value()]"
+            >
+              <slot
+                name="selection.prepend"
+                v-bind="{ item: selectedItem }"
+              />
+              <slot
+                name="selection"
+                v-bind="{ item: selectedItem }"
+              />
+            </span>
+            <input
+              ref="activatorRef"
+              data-id="search-input"
+              :value="isTyping ? searchInput : (($slots.selection && selectedItem) ? '' : (selectedText ?? ''))"
+              :placeholder="isTyping ? placeholder : ''"
+              :readonly="!canType"
+              :disabled="disabled"
+              :aria-invalid="hasError || undefined"
+              class="bg-transparent outline-none"
+              :class="[activatorUi.value(), !canType && 'cursor-pointer']"
+              @input="onInput($event)"
+              @keydown.down.prevent="focusPane('rail')"
+              @keydown.enter.prevent="selectTopResult()"
+              @keydown.esc="close()"
+            />
+            <span
+              v-if="clearable && selectedItem && !disabled && !readOnly"
+              data-id="clear"
+              :class="[activatorUi.clear(), focused && '!visible']"
+              @click.stop.prevent="clearSelection()"
+            >
+              <RuiIcon
+                color="error"
+                name="lu-x"
+                size="18"
+              />
+            </span>
+            <span :class="activatorUi.iconWrapper()">
+              <RuiIcon
+                :class="activatorUi.icon()"
+                :size="dense ? 16 : 24"
+                name="lu-chevron-down"
+              />
+            </span>
+            <RuiProgress
+              v-if="loading"
+              :class="activatorUi.progress()"
+              color="primary"
+              thickness="3"
+              variant="indeterminate"
+            />
+            <fieldset
+              v-if="outlined"
+              :class="activatorUi.fieldset()"
+            >
+              <legend :class="activatorUi.legend()">
+                {{ legendText }}
+              </legend>
+            </fieldset>
+          </div>
+          <RuiFormTextDetail
+            v-if="!hideDetails"
+            class="px-3 pt-1"
+            :error-messages="errorMessages"
+            :success-messages="successMessages"
+            :hint="hint"
+          />
+        </div>
+      </slot>
+    </template>
+
+    <div
+      :id="`${baseId}-panel`"
+      :class="ui.root({ class: cn(classNames?.root) })"
+      data-id="panel"
+    >
+      <!-- On desktop the field itself is the search input, so the panel only
+           needs its own search box in the mobile sheet. -->
+      <div
+        v-if="isMobile || $slots.header"
+        :class="ui.header()"
+      >
+        <slot name="header">
+          <div :class="ui.title()">
+            {{ label }}
+          </div>
+        </slot>
+        <RuiTextField
+          v-if="searchable && isMobile"
+          v-model="searchInput"
+          :class="cn(classNames?.search)"
+          :placeholder="placeholder"
+          :dense="dense"
+          variant="outlined"
+          prepend-icon="lu-search"
+          hide-details
+          clearable
+          data-id="search"
+        />
+      </div>
+
+      <div :class="ui.body()">
+        <!-- Category rail (master) -->
+        <div
+          v-show="showRail"
+          ref="railRef"
+          :class="ui.rail({ class: cn(classNames?.rail) })"
+          role="tablist"
+          aria-orientation="vertical"
+          :aria-label="label"
+          :aria-activedescendant="focusedPane === 'rail' && activeRailIndex >= 0 ? `${baseId}-cat-${activeRailIndex}` : undefined"
+          tabindex="0"
+          data-id="rail"
+          @focus="focusedPane = 'rail'"
+          @keydown.down.prevent="moveRail(1)"
+          @keydown.up.prevent="moveRail(-1)"
+          @keydown.right.prevent="enterDetail()"
+          @keydown.enter.prevent="enterDetail()"
+          @keydown.home.prevent="setActiveCategory(railEntries[0]?.category ?? null)"
+          @keydown.end.prevent="setActiveCategory(railEntries[railEntries.length - 1]?.category ?? null)"
+        >
+          <RuiButton
+            v-for="(entry, index) in railEntries"
+            :id="`${baseId}-cat-${index}`"
+            :key="entry.category ?? '__all__'"
+            role="tab"
+            variant="list"
+            :size="dense ? 'sm' : undefined"
+            :active="entry.category === activeCategory"
+            :aria-selected="entry.category === activeCategory"
+            tabindex="-1"
+            :data-highlighted="focusedPane === 'rail' && index === activeRailIndex"
+            :data-category="entry.category ?? '__all__'"
+            @click="onCategoryClick(entry.category)"
+          >
+            <slot
+              name="category"
+              v-bind="{ active: entry.category === activeCategory, category: entry.category, count: entry.count, label: entry.label }"
+            >
+              <span class="truncate">{{ entry.label }}</span>
+              <span :class="ui.railCount()">{{ entry.count }}</span>
+            </slot>
+          </RuiButton>
+        </div>
+
+        <!-- Detail pane -->
+        <div
+          v-show="showDetail"
+          ref="detailRef"
+          :class="ui.detail({ class: cn(classNames?.detail) })"
+          role="listbox"
+          :aria-label="activeCategory ?? allLabel"
+          :aria-activedescendant="focusedPane === 'detail' && !isEmpty ? `${baseId}-opt-${highlightedItemIndex}` : undefined"
+          tabindex="0"
+          data-id="detail"
+          @focus="focusedPane = 'detail'"
+          @keydown.down.prevent="moveItem(1)"
+          @keydown.up.prevent="moveItem(-1)"
+          @keydown.left.prevent="backToRail()"
+          @keydown.home.prevent="highlightedItemIndex = 0"
+          @keydown.end.prevent="highlightedItemIndex = detailItems.length - 1"
+          @keydown.enter.prevent="selectHighlighted()"
+          @keydown.space.prevent="selectHighlighted()"
+        >
+          <template v-if="mode === 'drill' && showDetail">
+            <button
+              type="button"
+              :class="ui.backButton()"
+              data-id="back"
+              @click="backToRail()"
+            >
+              <RuiIcon
+                name="lu-chevron-left"
+                size="18"
+              />
+              <span>{{ activeCategory ?? allLabel }}</span>
+            </button>
+          </template>
+
+          <slot
+            v-if="isEmpty"
+            name="empty"
+          >
+            <div :class="ui.empty()">
+              {{ emptyText }}
+            </div>
+          </slot>
+
+          <template
+            v-for="row in detailRows"
+            v-else
+            :key="row.type === 'header' ? `h-${row.category}` : `i-${row.index}`"
+          >
+            <div
+              v-if="row.type === 'header'"
+              :class="ui.subheader()"
+              role="presentation"
+            >
+              {{ row.category }}
+            </div>
+            <RuiButton
+              v-else
+              :id="`${baseId}-opt-${row.index}`"
+              role="option"
+              variant="list"
+              :size="dense ? 'sm' : undefined"
+              :active="isSelected(row.item)"
+              :aria-selected="isSelected(row.item)"
+              tabindex="-1"
+              :data-highlighted="focusedPane === 'detail' && row.index === highlightedItemIndex"
+              :class="{ [ui.highlighted()]: focusedPane === 'detail' && row.index === highlightedItemIndex && !isSelected(row.item) }"
+              @click="selectItem(row.item)"
+            >
+              <template
+                v-if="$slots['item.prepend']"
+                #prepend
+              >
+                <slot
+                  name="item.prepend"
+                  v-bind="{ active: row.index === highlightedItemIndex, item: row.item, selected: isSelected(row.item) }"
+                />
+              </template>
+              <slot
+                name="item"
+                v-bind="{ active: row.index === highlightedItemIndex, item: row.item, selected: isSelected(row.item) }"
+              >
+                {{ getText(row.item) }}
+              </slot>
+              <template
+                v-if="$slots['item.append']"
+                #append
+              >
+                <slot
+                  name="item.append"
+                  v-bind="{ active: row.index === highlightedItemIndex, item: row.item, selected: isSelected(row.item) }"
+                />
+              </template>
+            </RuiButton>
+          </template>
+        </div>
+      </div>
+
+      <div
+        v-if="$slots.footer"
+        :class="ui.footer()"
+      >
+        <slot
+          name="footer"
+          v-bind="{ close }"
+        />
+      </div>
+    </div>
+  </component>
+</template>

--- a/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
+++ b/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
@@ -1,0 +1,70 @@
+import { activatorStyles, type TextInputVariant } from '@/components/forms/text-input-styles';
+import { tv } from '@/utils/tv';
+
+export type CategoryPickerVariant = TextInputVariant;
+
+/**
+ * Form-field trigger, shared with `RuiAutoComplete` / `RuiMenuSelect` via
+ * `activatorStyles`: floating label, outlined/filled/underline variants,
+ * error + hint details, required marker.
+ */
+export const categoryPickerActivatorStyles = tv({
+  extend: activatorStyles,
+  variants: {
+    // Re-declare for type inference — actual styles live in activatorStyles.
+    filled: { true: {} },
+  },
+});
+
+/**
+ * Layout styles for `RuiCategoryPicker`. Item and category rows lean on
+ * `RuiButton variant="list"` for their interactive/active visuals; these slots
+ * cover only the surrounding two-pane (and mobile drill-in) scaffold.
+ */
+export const categoryPickerStyles = tv({
+  slots: {
+    root: 'flex flex-col min-w-0 bg-white dark:bg-rui-grey-900 rounded-md overflow-hidden',
+    header: 'flex flex-col gap-3 p-4 border-b border-rui-grey-200 dark:border-rui-grey-800',
+    title: 'text-h6 text-rui-text',
+    body: 'grid min-h-0 max-h-[60vh]',
+    rail: 'flex flex-col gap-0.5 p-2 overflow-y-auto outline-none border-rui-grey-200 dark:border-rui-grey-800',
+    railCount: 'ml-auto pl-2 text-caption tabular-nums text-rui-text-secondary',
+    detail: 'flex flex-col gap-0.5 p-2 overflow-y-auto outline-none min-w-0',
+    // Keyboard highlight for the active-descendant item (focus lives on the
+    // pane container, so the highlight is the only per-item focus cue).
+    highlighted: '!bg-rui-grey-100 dark:!bg-rui-grey-800',
+    subheader: 'px-3 pt-3 pb-1 text-overline text-rui-text-secondary uppercase',
+    empty: 'flex flex-1 items-center justify-center p-8 text-body-2 text-rui-text-secondary text-center',
+    footer: 'p-3 border-t border-rui-grey-200 dark:border-rui-grey-800',
+    backButton: 'flex items-center gap-2',
+  },
+  variants: {
+    mode: {
+      // Desktop: category rail beside the detail pane, inside an anchored
+      // popover. The explicit width lets the `1fr` detail column resolve
+      // (a `w-max` popover would otherwise collapse it to its content).
+      twoPane: {
+        root: 'w-[40rem] max-w-[calc(100vw-2rem)]',
+        body: 'grid-cols-[minmax(9.5rem,13rem)_1fr]',
+        rail: 'border-r',
+      },
+      // Narrow width: one column at a time, drill in and back out, inside a
+      // full-width bottom sheet.
+      drill: {
+        root: 'w-full',
+        body: 'grid-cols-1',
+        rail: 'border-r-0',
+      },
+    },
+    dense: {
+      true: {
+        header: 'p-3',
+        title: 'text-subtitle-1',
+      },
+    },
+  },
+  defaultVariants: {
+    mode: 'twoPane',
+    dense: false,
+  },
+});

--- a/packages/ui-library/src/components/index.ts
+++ b/packages/ui-library/src/components/index.ts
@@ -22,6 +22,7 @@ import RuiDateTimePicker, { type RuiDateTimePickerProps } from '@/components/dat
 import RuiTimezoneSelect, { type RuiTimezoneSelectProps } from '@/components/date-time-picker/RuiTimezoneSelect.vue';
 import RuiDivider, { type Props as DividerProps } from '@/components/divider/RuiDivider.vue';
 import RuiAutoComplete, { type AutoCompleteProps, type RuiAutoCompleteClassNames } from '@/components/forms/auto-complete/RuiAutoComplete.vue';
+import RuiCategoryPicker, { type RuiCategoryPickerClassNames, type RuiCategoryPickerProps } from '@/components/forms/category-picker/RuiCategoryPicker.vue';
 import RuiCheckboxGroup, { type Props as CheckboxGroupProps } from '@/components/forms/checkbox/checkbox-group/RuiCheckboxGroup.vue';
 import RuiCheckbox, { type Props as CheckboxProps } from '@/components/forms/checkbox/RuiCheckbox.vue';
 import RuiFileUpload, { type FileUploadProps } from '@/components/forms/file-upload/RuiFileUpload.vue';
@@ -98,6 +99,8 @@ export type {
   RuiAccordionClassNames,
   RuiAutoCompleteClassNames,
   RuiCardClassNames,
+  RuiCategoryPickerClassNames,
+  RuiCategoryPickerProps,
   RuiChipClassNames,
   RuiDateTimePickerProps,
   RuiDialogClassNames,
@@ -139,6 +142,7 @@ export {
   RuiCalendar,
   RuiCard,
   RuiCardHeader,
+  RuiCategoryPicker,
   RuiCheckbox,
   RuiCheckboxGroup,
   RuiChip,

--- a/packages/ui-library/src/composables/forms/category-picker/use-category-picker.ts
+++ b/packages/ui-library/src/composables/forms/category-picker/use-category-picker.ts
@@ -1,0 +1,230 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { type KeyOfType, useDropdownOptionProperty } from '@/composables/dropdown-menu';
+
+/**
+ * A resolved category and the items that belong to it.
+ */
+export interface CategoryGroup<TItem> {
+  category: string;
+  items: TItem[];
+}
+
+/**
+ * A single entry in the category rail. `category` is `null` for the synthetic
+ * "All" pseudo-category, which aggregates every currently visible item.
+ */
+export interface CategoryRailEntry {
+  category: string | null;
+  label: string;
+  count: number;
+}
+
+/**
+ * A row rendered in the detail pane. Item rows carry a running `index` used for
+ * `aria-activedescendant`; header rows are visual separators shown in the
+ * flattened "All" view and never receive focus.
+ */
+export type DetailRow<TItem>
+  = | { type: 'header'; category: string }
+    | { type: 'item'; item: TItem; index: number };
+
+export interface UseCategoryPickerOptions<TValue, TItem> {
+  /** The full catalogue of selectable items. */
+  items: MaybeRefOrGetter<TItem[]>;
+  /** Resolve an item's category label. */
+  categoryOf: (item: TItem) => string;
+  /** Property whose value becomes the model value. */
+  keyAttr?: KeyOfType<TItem, TValue extends (infer U)[] ? U : TValue>;
+  /** Property (or getter) that produces an item's display text. */
+  textAttr?: keyof TItem | ((item: TItem) => string);
+  /** The current search query. */
+  search: Ref<string>;
+  /** Whether the search query is applied. */
+  searchable: MaybeRefOrGetter<boolean>;
+  /** Custom predicate receiving the resolved category as the third argument. */
+  filter?: MaybeRefOrGetter<((item: TItem, query: string, category: string) => boolean) | undefined>;
+  /** Whether the synthetic "All" pseudo-category is offered. */
+  showAll: MaybeRefOrGetter<boolean>;
+  /** Label used for the "All" pseudo-category. */
+  allLabel: MaybeRefOrGetter<string>;
+  /** The picker's current selection. */
+  modelValue: Ref<TValue | undefined>;
+}
+
+export interface UseCategoryPickerReturn<TItem> {
+  getText: (item: TItem) => string | undefined;
+  getIdentifier: (item: TItem) => any;
+  filteredGroups: Ref<CategoryGroup<TItem>[]>;
+  railEntries: Ref<CategoryRailEntry[]>;
+  activeCategory: Readonly<Ref<string | null>>;
+  detailGroups: Ref<CategoryGroup<TItem>[]>;
+  detailRows: Ref<DetailRow<TItem>[]>;
+  detailItems: Ref<TItem[]>;
+  isEmpty: Ref<boolean>;
+  setActiveCategory: (category: string | null) => void;
+  syncActiveToSelection: () => void;
+  isSelected: (item: TItem) => boolean;
+  categoryOf: (item: TItem) => string;
+}
+
+/**
+ * Owns the grouping, filtering and selection state for `RuiCategoryPicker`.
+ *
+ * The component keeps DOM concerns (focus, keyboard, scrolling); this composable
+ * keeps the data: which categories exist, which survive the current search, and
+ * which items belong in the detail pane for the active category.
+ */
+export function useCategoryPicker<TValue, TItem>(
+  options: UseCategoryPickerOptions<TValue, TItem>,
+): UseCategoryPickerReturn<TItem> {
+  const { allLabel, categoryOf, filter, items, keyAttr, modelValue, search, searchable, showAll, textAttr } = options;
+
+  const { getIdentifier, getText } = useDropdownOptionProperty<TValue, TItem>({
+    keyAttr,
+    textAttr,
+  });
+
+  function defaultFilter(item: TItem, query: string, category: string): boolean {
+    const needle = query.toLowerCase();
+    const text = (getText(item) ?? '').toLowerCase();
+    return text.includes(needle) || category.toLowerCase().includes(needle);
+  }
+
+  // All items grouped by category, preserving first-seen category order.
+  const allGroups = computed<CategoryGroup<TItem>[]>(() => {
+    const map = new Map<string, TItem[]>();
+    for (const item of toValue(items)) {
+      const category = categoryOf(item);
+      const bucket = map.get(category);
+      if (bucket)
+        bucket.push(item);
+      else
+        map.set(category, [item]);
+    }
+    return Array.from(map, ([category, groupItems]) => ({ category, items: groupItems }));
+  });
+
+  const query = computed<string>(() => get(search).trim());
+
+  const filteredGroups = computed<CategoryGroup<TItem>[]>(() => {
+    const currentQuery = get(query);
+    if (!toValue(searchable) || !currentQuery)
+      return get(allGroups);
+
+    const filterFn = toValue(filter) ?? defaultFilter;
+    return get(allGroups)
+      .map(group => ({
+        category: group.category,
+        items: group.items.filter(item => filterFn(item, currentQuery, group.category)),
+      }))
+      .filter(group => group.items.length > 0);
+  });
+
+  const railEntries = computed<CategoryRailEntry[]>(() => {
+    const groups = get(filteredGroups);
+    const entries: CategoryRailEntry[] = [];
+
+    if (toValue(showAll)) {
+      const total = groups.reduce((sum, group) => sum + group.items.length, 0);
+      entries.push({ category: null, count: total, label: toValue(allLabel) });
+    }
+
+    for (const group of groups)
+      entries.push({ category: group.category, count: group.items.length, label: group.category });
+
+    return entries;
+  });
+
+  const activeCategory = shallowRef<string | null>(null);
+
+  function firstCategory(): string | null {
+    return get(filteredGroups)[0]?.category ?? null;
+  }
+
+  function fallbackCategory(): string | null {
+    return toValue(showAll) ? null : firstCategory();
+  }
+
+  function setActiveCategory(category: string | null): void {
+    set(activeCategory, category);
+  }
+
+  // Keep the active category valid as the search narrows the rail. If the
+  // active category disappears, fall back to "All" (when shown) or the first
+  // remaining category.
+  watch(filteredGroups, (groups) => {
+    const active = get(activeCategory);
+    if (active === null)
+      return;
+    if (!groups.some(group => group.category === active))
+      set(activeCategory, fallbackCategory());
+  });
+
+  // When the user starts typing, surface matches across every category so the
+  // top hit is global rather than scoped to whatever category was active.
+  watch(query, (current, previous) => {
+    if (current && !previous && toValue(showAll))
+      set(activeCategory, null);
+  });
+
+  const detailGroups = computed<CategoryGroup<TItem>[]>(() => {
+    const groups = get(filteredGroups);
+    const active = get(activeCategory);
+    if (active === null)
+      return groups;
+    const match = groups.find(group => group.category === active);
+    return match ? [match] : [];
+  });
+
+  const detailItems = computed<TItem[]>(() => get(detailGroups).flatMap(group => group.items));
+
+  const detailRows = computed<DetailRow<TItem>[]>(() => {
+    const groups = get(detailGroups);
+    const flattened = get(activeCategory) === null && groups.length > 1;
+    const rows: DetailRow<TItem>[] = [];
+    let index = 0;
+    for (const group of groups) {
+      if (flattened)
+        rows.push({ type: 'header', category: group.category });
+      for (const item of group.items)
+        rows.push({ index: index++, item, type: 'item' });
+    }
+    return rows;
+  });
+
+  const isEmpty = computed<boolean>(() => get(detailItems).length === 0);
+
+  function isSelected(item: TItem): boolean {
+    const value = get(modelValue);
+    if (value === undefined)
+      return false;
+    return getIdentifier(item) === value;
+  }
+
+  // Point the rail at the selected item's category so it is visible on open.
+  function syncActiveToSelection(): void {
+    const value = get(modelValue);
+    if (value === undefined) {
+      set(activeCategory, fallbackCategory());
+      return;
+    }
+    const selected = toValue(items).find(item => getIdentifier(item) === value);
+    set(activeCategory, selected ? categoryOf(selected) : fallbackCategory());
+  }
+
+  return {
+    activeCategory: readonly(activeCategory),
+    categoryOf,
+    detailGroups,
+    detailItems,
+    detailRows,
+    filteredGroups,
+    getIdentifier,
+    getText,
+    isEmpty,
+    isSelected,
+    railEntries,
+    setActiveCategory,
+    syncActiveToSelection,
+  };
+}


### PR DESCRIPTION
## What

Adds `RuiCategoryPicker`, a master/detail selector for taxonomies too large to scan in a flat grouped popover. The rotki action picker sits at 16 categories x ~4 verbs (~64 options), which is where a flat `RuiAutoComplete` + `groupBy` starts to lose. Closes #544.

## Shape

- **Trigger** is a form field (floating label, `outlined`/`filled`/underline variants, error/success/hint, `required`), reusing the same `activatorStyles` as `RuiAutoComplete`/`RuiMenuSelect`.
- **Desktop**: the field *is* the search input; it opens an anchored popover (`RuiMenu` + `useFloating`, anchored to the field box) with a category **rail** (vertical `tablist`) beside a **detail** `listbox`. Type to filter both panes.
- **Narrow width**: collapses to a full-width bottom sheet (`RuiDialog`) with a single-pane drill-in and its own search box.

## Behaviour

- Search filters both panes; empty categories drop from the rail; a typed query surfaces matches globally via the synthetic "All" pseudo-category.
- Type-to-pick: Enter in the field commits the top match.
- Keyboard: arrows within a pane, left/right between panes, Enter selects, Esc closes and returns focus to the field; `aria-activedescendant` per pane, `aria-controls`/`aria-haspopup` on the field.
- Selection resolves via `keyAttr`/`textAttr`; grouping via `categoryOf` or `categoryAttr`; a custom `filter` receives the resolved category as a third argument (matching the #543 signature).

## API

Slots: `activator`, `activator.label`, `selection(.prepend)`, `category`, `item(.prepend/.append)`, `empty`, `header`, `footer`. Props cover `items`, `categoryOf`/`categoryAttr`, `keyAttr`, `textAttr`, `searchable`, `filter`, `showAll`/`allLabel`, `clearable`, `dense`, `disabled`/`readOnly`/`loading`, `variant`, `required`, `errorMessages`/`successMessages`/`hint`/`hideDetails`, `mobileBreakpoint`, `dialogOptions`, `emptyText`, `classNames`.

## When to reach for it (vs `RuiAutoComplete` + `groupBy`)

Two-pane when groups are numerous (~8+), total items are large (~50+), or the flat list needs more than ~1.5 viewport-heights of scroll. Below that, keep the autocomplete.

## Testing

- Unit: 13 tests (open, rail/detail, category switch, select, search both panes, group-label surfacing, empty, keyboard nav, type-to-pick, global search, sync-to-selection, field validation, `#selection` slot).
- E2e: 9 tests (desktop anchored popover, mobile drill-in with in-sheet search, type-to-pick).
- Storybook: `Default`, `LargeCatalogue` (16x~4 density), `Dense`, `NoSearch`, `WithoutAll`, `Validation`, `DrillIn`, `CustomSlots`.
- Example app: `/category-pickers` view + nav entry.

## Notes

- Single-select only for now; **multi-select is deferred** until a consumer needs it.
- Follow-up: migrate `HistoryEventActionPicker` in the rotki app off `RuiAutoComplete` (drop-in; the only deltas are three slot renames and dropping the implicit-clear guard).
- The new Storybook stories will create fresh visual-regression baselines.
