### PR TITLE
fix(category-picker): viewport-aware menu, opaque footer, scroll-safe focus

### DIFF
--- a/apps/example/src/views/CategoryPickerView.vue
+++ b/apps/example/src/views/CategoryPickerView.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { RuiCategoryPicker } from '@rotki/ui-library';
+import { RuiButton, RuiCategoryPicker } from '@rotki/ui-library';
 import ComponentView from '@/components/ComponentView.vue';
 
 interface CountryOption { id: number; label: string; continent: string }
@@ -90,7 +90,20 @@ const noSearchValue = ref<number>();
           label="Action"
           clearable
           data-id="cp-actions"
-        />
+        >
+          <template #footer="{ close }">
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-caption text-rui-text-secondary">{{ actions.length }} actions</span>
+              <RuiButton
+                size="sm"
+                variant="text"
+                @click="close()"
+              >
+                Close
+              </RuiButton>
+            </div>
+          </template>
+        </RuiCategoryPicker>
       </div>
 
       <div>

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
@@ -201,6 +201,25 @@ describe('components/forms/category-picker/RuiCategoryPicker.vue', () => {
     expect(optionLabels).toEqual(['Germany']);
   });
 
+  it('focuses the detail pane without scrolling the page when a category is picked', async () => {
+    wrapper = mountPicker();
+    const dialog = await openPicker(wrapper);
+
+    const detail = queryByDataId<HTMLElement>('detail', dialog);
+    assertExists(detail);
+    const focusSpy = vi.spyOn(detail, 'focus');
+
+    const europe = Array.from(dialog.querySelectorAll<HTMLElement>('[data-category]'))
+      .find(el => el.dataset.category === 'Europe');
+    assertExists(europe);
+    europe.click();
+    await vi.runAllTimersAsync();
+
+    // Focusing a teleported pane must pass preventScroll, or the browser scrolls
+    // the page behind the popover to bring the pane into view.
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
   it('renders the field label, required marker and error messages', async () => {
     wrapper = mountPicker({ errorMessages: 'This field is required', required: true });
 

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
@@ -220,6 +220,23 @@ describe('components/forms/category-picker/RuiCategoryPicker.vue', () => {
     expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
   });
 
+  it('caps the panel to the floating size middleware height and lets the body shrink', async () => {
+    wrapper = mountPicker();
+    const panel = await openPicker(wrapper);
+
+    // The size middleware writes the available viewport space into
+    // --rui-floating-max-height; the panel caps to it so the popover never
+    // overflows the window bottom, falling back to 60vh before it is measured.
+    expect(panel.className).toContain('max-h-[var(--rui-floating-max-height,60vh)]');
+
+    // The body flex-shrinks inside that cap (flex-1, not a fixed max-h) so the
+    // footer stays anchored and each pane scrolls internally instead.
+    const body = panel.querySelector<HTMLElement>('.grid');
+    assertExists(body);
+    expect(body.className).toContain('flex-1');
+    expect(body.className).not.toContain('max-h-[60vh]');
+  });
+
   it('renders the field label, required marker and error messages', async () => {
     wrapper = mountPicker({ errorMessages: 'This field is required', required: true });
 

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.spec.ts
@@ -237,6 +237,21 @@ describe('components/forms/category-picker/RuiCategoryPicker.vue', () => {
     expect(body.className).not.toContain('max-h-[60vh]');
   });
 
+  it('gives the footer an opaque panel surface so a scrolled pane cannot bleed through', async () => {
+    wrapper = createWrapper<string, GroupedSelectOption>({
+      props: baseProps,
+      slots: { footer: '<button data-id="footer-action">Apply</button>' },
+    });
+    const panel = await openPicker(wrapper);
+
+    const footer = panel.querySelector<HTMLElement>('[data-id=footer-action]')?.parentElement;
+    assertExists(footer);
+    expect(footer.className).toContain('bg-white');
+    expect(footer.className).toContain('dark:bg-rui-grey-900');
+    // shrink-0 keeps the footer at its natural height inside the flex column.
+    expect(footer.className).toContain('shrink-0');
+  });
+
   it('renders the field label, required marker and error messages', async () => {
     wrapper = mountPicker({ errorMessages: 'This field is required', required: true });
 

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
@@ -203,11 +203,14 @@ const shellProps = computed<Record<string, unknown>>(() => {
     // Anchor to the field box, not the wrapper, so the popover sits directly
     // under the input instead of below the reserved details row.
     anchorEl: get(fieldRef) ?? undefined,
-    classNames: { menu: 'z-[9999]' },
+    // Drop the menu's default vertical padding so the popover box equals our
+    // panel: the size middleware caps the panel to the available height, and
+    // any extra chrome padding would push the popover past the viewport edge.
+    classNames: { content: 'py-0', menu: 'z-[9999]' },
     closeOnContentClick: false,
     disableAutoFocus: true,
     fullWidth: true,
-    options: { placement: Placement.bottomStart },
+    options: { placement: Placement.bottomStart, size: true },
     persistent: dialogOptions?.persistent,
     persistOnActivatorClick: true,
   };

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
@@ -315,7 +315,9 @@ function onCategoryClick(category: string | null): void {
 function focusPane(pane: 'rail' | 'detail'): void {
   set(focusedPane, pane);
   nextTick(() => {
-    (pane === 'rail' ? get(railRef) : get(detailRef))?.focus();
+    // preventScroll: focus moves between panes inside a teleported popover;
+    // without it the browser scrolls the page behind to reveal the pane.
+    (pane === 'rail' ? get(railRef) : get(detailRef))?.focus({ preventScroll: true });
   });
 }
 
@@ -403,13 +405,13 @@ watch(isOpen, (value) => {
     // Desktop is a combobox: keep focus in the field so the user can type
     // straight away (ArrowDown moves into the panes). The mobile sheet has no
     // typing field, so focus the rail instead.
-    nextTick(() => (get(canType) ? get(activatorRef) : get(railRef))?.focus());
+    nextTick(() => (get(canType) ? get(activatorRef) : get(railRef))?.focus({ preventScroll: true }));
   }
   else {
     // Reset the query so the field shows the selection again next time, and
     // return focus to the trigger (APG dialog contract).
     set(searchInput, '');
-    nextTick(() => get(activatorRef)?.focus());
+    nextTick(() => get(activatorRef)?.focus({ preventScroll: true }));
   }
 });
 </script>

--- a/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
+++ b/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
@@ -38,7 +38,8 @@ export const categoryPickerStyles = tv({
     highlighted: '!bg-rui-grey-100 dark:!bg-rui-grey-800',
     subheader: 'px-3 pt-3 pb-1 text-overline text-rui-text-secondary uppercase',
     empty: 'flex flex-1 items-center justify-center p-8 text-body-2 text-rui-text-secondary text-center',
-    footer: 'p-3 border-t border-rui-grey-200 dark:border-rui-grey-800',
+    // Opaque panel surface so a scrolled pane never bleeds through the footer.
+    footer: 'shrink-0 p-3 border-t border-rui-grey-200 dark:border-rui-grey-800 bg-white dark:bg-rui-grey-900',
     backButton: 'flex items-center gap-2',
   },
   variants: {

--- a/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
+++ b/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
@@ -23,10 +23,13 @@ export const categoryPickerActivatorStyles = tv({
  */
 export const categoryPickerStyles = tv({
   slots: {
-    root: 'flex flex-col min-w-0 bg-white dark:bg-rui-grey-900 rounded-md overflow-hidden',
+    // Cap to the space the floating layer measured toward the viewport edge
+    // (set as --rui-floating-max-height by the menu's size middleware), falling
+    // back to 60vh. The body flex-shrinks within this so the footer stays put.
+    root: 'flex flex-col min-w-0 max-h-[var(--rui-floating-max-height,60vh)] bg-white dark:bg-rui-grey-900 rounded-md overflow-hidden',
     header: 'flex flex-col gap-3 p-4 border-b border-rui-grey-200 dark:border-rui-grey-800',
     title: 'text-h6 text-rui-text',
-    body: 'grid min-h-0 max-h-[60vh]',
+    body: 'grid min-h-0 flex-1',
     rail: 'flex flex-col gap-0.5 p-2 overflow-y-auto outline-none border-rui-grey-200 dark:border-rui-grey-800',
     railCount: 'ml-auto pl-2 text-caption tabular-nums text-rui-text-secondary',
     detail: 'flex flex-col gap-0.5 p-2 overflow-y-auto outline-none min-w-0',

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
@@ -14,6 +14,8 @@ export interface RuiMenuClassNames {
   root?: VueClassValue;
   wrapper?: VueClassValue;
   menu?: VueClassValue;
+  /** Overrides applied to the popover content box (e.g. to drop its default padding). */
+  content?: VueClassValue;
 }
 
 export interface MenuProps {
@@ -297,7 +299,7 @@ onClickOutside(menu, () => {
             ref="menuContent"
             key="menu"
             data-id="content"
-            :class="ui.content()"
+            :class="ui.content({ class: cn(classNames?.content) })"
             tabindex="-1"
             v-bind="baseMenuAttrs"
           >

--- a/packages/ui-library/src/composables/floating.ts
+++ b/packages/ui-library/src/composables/floating.ts
@@ -8,6 +8,7 @@ import {
   type Middleware,
   offset,
   shift,
+  size,
 } from '@floating-ui/dom';
 import { type MaybeElement, unrefElement } from '@vueuse/core';
 import { type MaybeRefOrGetter, onMounted, type Ref, ref, watchEffect } from 'vue';
@@ -52,7 +53,19 @@ export interface FloatingOptions {
   shiftPadding?: number;
   /** Whether to auto-update position on scroll/resize. @default true */
   autoUpdate?: boolean | { scroll?: boolean; resize?: boolean };
+  /**
+   * Cap the floating element to the space available toward the viewport edge so
+   * it never overflows the window. Exposes the measured space as the
+   * `--rui-floating-max-height` custom property on the floating element; the
+   * content is responsible for consuming it by capping its own max-height to
+   * that variable and scrolling internally.
+   * @default false
+   */
+  size?: boolean;
 }
+
+/** Custom property carrying the space-aware max height set by the size middleware. */
+export const FLOATING_MAX_HEIGHT_VAR = '--rui-floating-max-height';
 
 export const DEFAULT_FLOATING_OPTIONS: Required<FloatingOptions> = {
   autoUpdate: true,
@@ -60,6 +73,7 @@ export const DEFAULT_FLOATING_OPTIONS: Required<FloatingOptions> = {
   offset: 2,
   placement: Placement.bottom,
   shiftPadding: 8,
+  size: false,
   strategy: Strategy.absolute,
 };
 
@@ -75,6 +89,22 @@ export interface UseFloatingReturn {
   reference: Ref<HTMLElement | undefined>;
   updatePosition: () => Promise<void>;
   visible: Ref<boolean>;
+}
+
+/**
+ * Cap the floating element to the space available toward the viewport edge and
+ * expose it as {@link FLOATING_MAX_HEIGHT_VAR}. The content decides how to use
+ * it (cap its own height and scroll internally); writing a custom property
+ * instead of a hard max-height keeps this non-invasive for elements that opt in
+ * but size themselves differently.
+ */
+function buildSizeMiddleware(padding: number): Middleware {
+  return size({
+    padding,
+    apply({ availableHeight, elements }) {
+      elements.floating.style.setProperty(FLOATING_MAX_HEIGHT_VAR, `${Math.max(0, Math.floor(availableHeight))}px`);
+    },
+  });
 }
 
 function buildMiddleware(opts: FloatingOptions, arrowEl: HTMLElement | null): Middleware[] {
@@ -96,6 +126,9 @@ function buildMiddleware(opts: FloatingOptions, arrowEl: HTMLElement | null): Mi
 
   if (arrowEl)
     mw.push(arrow({ element: arrowEl, padding: 4 }));
+
+  if (opts.size === true)
+    mw.push(buildSizeMiddleware(opts.shiftPadding ?? DEFAULT_FLOATING_OPTIONS.shiftPadding));
 
   return mw;
 }


### PR DESCRIPTION
## What

Three UX fixes for `RuiCategoryPicker`, each in its own commit with a regression test.

### 1. Focus panes without scrolling the page (`cc236924`)
Picking a category focused the detail pane, and because the pane is teleported, the browser scrolled the page behind the popover to bring it into view. The three `.focus()` calls now pass `{ preventScroll: true }`.

### 2. Cap the menu to the viewport so it never overflows (`edb644d`)
The two-pane popover used a fixed `max-h` of `60vh` on its body, so a tall catalogue could run past the bottom of the window with the footer clipped off-screen.

- The desktop menu now opts into a floating-ui `size` middleware that measures the space toward the viewport edge and writes it into a `--rui-floating-max-height` custom property (opt-in `size?: boolean` on `FloatingOptions`, exported `FLOATING_MAX_HEIGHT_VAR`).
- The panel root caps to that var (falling back to `60vh` before it is measured) and the body flex-shrinks within it, so the footer stays anchored and each pane scrolls internally.
- A new `classNames.content` hook on `RuiMenu` lets the picker drop the popover's default vertical padding, so the box equals the panel instead of being pushed past the edge.

### 3. Give the menu footer an opaque surface (`be6ccff`)
The footer slot only had a top border, so its background was transparent and a scrolled rail/detail pane could bleed through behind it. It now paints the panel surface (`bg-white dark:bg-rui-grey-900`) and is marked `shrink-0`. The example's large-catalogue picker gains a footer slot to exercise it.

## Testing
- `RuiCategoryPicker.spec.ts` 16/16 (added style-contract tests for the viewport cap and the opaque footer, plus the existing preventScroll assertion).
- `RuiMenu.spec.ts` passing, typecheck clean, lint green.
- Manually verified in the example app: the two-pane menu caps to the viewport with both panes scrolling internally and the footer anchored; the footer is opaque; and the rail stays populated when selecting "All".