### PR TITLE
fix(renovate): move minimumReleaseAge note into a description field

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,8 +6,7 @@
     ":dependencyDashboardApproval",
     "helpers:pinGitHubActionDigests"
   ],
-  // Mirror the pnpm-workspace.yaml `minimumReleaseAge: 10080` (7 days) cooldown so
-  // the dashboard does not surface updates that a local install would reject.
+  "description": "Mirror the pnpm-workspace.yaml minimumReleaseAge: 10080 (7 days) cooldown so the dashboard does not surface updates that a local install would reject.",
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {


### PR DESCRIPTION
## Problem

`main`'s **Lint & typecheck** job has been red since `c4a89006` with:

```
.github/renovate.json5
  9:3  error  Parsing error: Unexpected comment
```

The `//` comment added next to `minimumReleaseAge` is valid JSON5, but the repo lints `.github/renovate.json5` as strict JSON (no comments), so eslint rejects it and the job fails on every branch.

## Fix

Move the same note into Renovate's own top-level `description` field, which is valid strict JSON and lints clean (`eslint .github/renovate.json5` → exit 0). No behaviour change to the Renovate config.

## Note on how this slipped through

The `pre-commit` hook runs `lint-staged`, whose glob is `*.{js,cjs,ts,vue,yml,json,md}` — it does not include `json5`, so `renovate.json5` is never linted on commit (lint-staged reports "could not find any staged files matching configured tasks"). Worth widening that glob to `json5` in a follow-up so config files are covered locally.