### PR TITLE
fix(button): soften the colourless outlined edge

### DIFF
--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.spec.ts
@@ -59,12 +59,13 @@ describe('components/buttons/button-group/RuiButtonGroup.vue', () => {
 
   it('should pass variant props', async () => {
     wrapper = createWrapper();
-    expectNotToHaveClass(wrapper.element, /outline-rui-text/);
+    expectNotToHaveClass(wrapper.element, /outline-black/);
     await wrapper.setProps({ variant: 'outlined' });
-    expectToHaveClass(wrapper.element, /outline-rui-text/);
-    expectWrapperToHaveClass(wrapper, 'button', /outline-rui-text/);
+    expectToHaveClass(wrapper.element, /outline-black\/\[0\.23\]/);
+    expectToHaveClass(wrapper.element, /divide-black\/\[0\.23\]/);
+    expectWrapperToHaveClass(wrapper, 'button', /outline-black\/\[0\.23\]/);
     await wrapper.setProps({ variant: 'text' });
-    expectNotToHaveClass(wrapper.element, /outline-rui-text/);
+    expectNotToHaveClass(wrapper.element, /outline-black/);
     expectWrapperToHaveClass(wrapper, 'button', /bg-transparent/);
   });
 

--- a/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.vue
+++ b/packages/ui-library/src/components/buttons/button-group/RuiButtonGroup.vue
@@ -68,7 +68,9 @@ const buttonGroupStyles = tv({
     variant: {
       default: {},
       outlined: {
-        root: 'outline-rui-text divide-rui-text',
+        // Matches RuiButton's colourless outlined treatment: a neutral edge at Material's
+        // 23%, rather than an outline and dividers as dark as the labels themselves.
+        root: 'outline-black/[0.23] divide-black/[0.23] dark:outline-white/[0.23] dark:divide-white/[0.23]',
       },
       text: {},
     },

--- a/packages/ui-library/src/components/buttons/button/button-styles.ts
+++ b/packages/ui-library/src/components/buttons/button/button-styles.ts
@@ -107,7 +107,11 @@ export const buttonStyles = tv({
     { color: 'grey', active: true, class: { root: 'bg-rui-grey-50' } },
     { color: 'grey', variant: ['outlined', 'text', 'list'], class: { root: 'bg-transparent hover:bg-black/[.04] active:bg-black/10 dark:bg-transparent dark:active:bg-white/10 dark:hover:bg-white/[.04] dark:text-rui-text' } },
     { color: 'grey', variant: ['outlined', 'text', 'list'], active: true, class: { root: 'bg-black/10 dark:bg-white/30' } },
-    { color: 'grey', variant: 'outlined', class: { root: 'outline-rui-text' } },
+    // Material draws the colourless outlined button at 23% of the text colour, not at
+    // full strength: an outline as dark as the label reads as an error state and shouts
+    // next to the context colours, which are already at 50% (see below). The rest of the
+    // library uses the same restraint for neutral edges (cards and tables sit at 12%).
+    { color: 'grey', variant: 'outlined', class: { root: 'outline-black/[0.23] dark:outline-white/[0.23]' } },
     { color: 'grey', variant: 'text', class: { root: 'text-rui-text-secondary' } },
 
     // === Context colors — outlined/text variants ===


### PR DESCRIPTION
## Problem

The outlined variant draws its colourless case at the full text colour:

```ts
// button-styles.ts
{ color: 'grey', variant: 'outlined', class: { root: 'outline-rui-text' } },
```

So a plain `<RuiButton variant="outlined" />` gets an edge as dark as its own label. It reads as an error/danger state rather than a neutral affordance, and it looks especially out of place beside context-coloured outlined buttons, which are already drawn at 50%:

```ts
{ color: 'primary', variant: 'outlined', class: { root: 'outline-rui-primary/[0.5]' } },
// ...error, warning, info, success — all /[0.5]
```

In dark mode `outline-rui-text` inverts to near-white, which has the same problem from the other side.

It also disagrees with how the rest of the library draws neutral edges: tables and cards use `border-black/[0.12] dark:border-white/[0.12]`, and file upload, time picker and category picker use `border-rui-grey-200|300 dark:border-rui-grey-800`.

`RuiButtonGroup` repeated the same value for both its wrapper outline and the dividers between its buttons (`outline-rui-text divide-rui-text`), so a grouped set inherits the same heavy edge regardless of the children's colours.

## Change

Draw the colourless outlined case at 23% of black/white, which is what Material specifies for the inherit-coloured outlined button, and apply the same to the button group's outline and dividers.

```diff
-{ color: 'grey', variant: 'outlined', class: { root: 'outline-rui-text' } },
+{ color: 'grey', variant: 'outlined', class: { root: 'outline-black/[0.23] dark:outline-white/[0.23]' } },
```

Untouched on purpose: `disabled:outline-rui-text-disabled` (already the disabled token) and the context colours at 50%, which were never the issue.

## Testing

`RuiButtonGroup.spec.ts` asserted on `/outline-rui-text/`, so it moves to the new value and additionally asserts the divider colour, which it was not checking before.

`pnpm run test:run` 1244 passing, `pnpm run typecheck` clean, `pnpm run lint` 0 errors.