### PR TITLE
fix(date-time-picker): write bound errors in the field's own format

### DIFF
--- a/apps/example/e2e/datetimepicker.spec.ts
+++ b/apps/example/e2e/datetimepicker.spec.ts
@@ -408,4 +408,22 @@ test.describe('datetimepicker footer actions against a bound', () => {
   test('the field is not spellchecked', async ({ page }) => {
     await expect(boundedInput(page)).toHaveAttribute('spellcheck', 'false');
   });
+
+  // the message used to come from toLocaleDateString(), which follows the
+  // browser locale rather than the field, and dropped the bound's time
+  test('the bound error is written in the field format, with its time', async ({ page }) => {
+    const input = boundedInput(page);
+    await expect(input).toHaveValue('02/01/2023 20:20:00');
+
+    // click the left edge so the day segment is selected, then type a day past the bound
+    const box = await input.boundingBox();
+    if (!box)
+      throw new Error('input bounding box unavailable');
+    await page.mouse.click(box.x + 12, box.y + box.height / 2);
+    await page.keyboard.press('2');
+    await page.keyboard.press('0');
+
+    await expect(input).toHaveValue('20/01/2023 20:20:00');
+    await expect(page.getByText('Date cannot be after 10/01/2023 12:00:00')).toBeVisible();
+  });
 });

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.spec.ts
@@ -37,6 +37,12 @@ function createWrapper(
   });
 }
 
+// bound errors are written in the field's own format; these pickers all use the
+// defaults, so DD/MM/YYYY HH:mm
+function boundLabel(date: Date): string {
+  return dayjs(date).format('DD/MM/YYYY HH:mm');
+}
+
 describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
   let wrapper: VueWrapper<InstanceType<typeof RuiDateTimePicker>>;
 
@@ -345,7 +351,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
     expect(menu.exists()).toBeTruthy();
 
     // Verify the constraint is enforced by checking the error message
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${minDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${boundLabel(minDate)}`);
   });
 
   it('should respect max date constraint', async () => {
@@ -366,7 +372,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
     expect(menu.exists()).toBeTruthy();
 
     // Verify the constraint is enforced by checking the error message
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${maxDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${boundLabel(maxDate)}`);
   });
 
   it('should show error message when date is below minAllowedDate', async () => {
@@ -382,7 +388,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
 
     await vi.runOnlyPendingTimersAsync();
 
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${minDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${boundLabel(minDate)}`);
   });
 
   it('should show error message when date is above maxAllowedDate', async () => {
@@ -397,7 +403,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
     });
 
     await vi.runOnlyPendingTimersAsync();
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${maxDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${boundLabel(maxDate)}`);
   });
 
   it('should show an error when now is used as mas an the date is in the future', async () => {
@@ -451,7 +457,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
     await vi.runOnlyPendingTimersAsync();
 
     // Verify the constraint works by checking the error message
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${testDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${boundLabel(testDate)}`);
   });
 
   it('should respect max date constraint with epoch type', async () => {
@@ -469,7 +475,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
     await vi.runOnlyPendingTimersAsync();
 
     // Verify the constraint works by checking the error message
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${testDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${boundLabel(testDate)}`);
   });
 
   it('should show error message when date is below minAllowedDate with epoch type', async () => {
@@ -487,7 +493,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
 
     await vi.runOnlyPendingTimersAsync();
 
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${testDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be before ${boundLabel(testDate)}`);
   });
 
   it('should show error message when date is above maxAllowedDate with epoch type', async () => {
@@ -505,7 +511,7 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
 
     await vi.runOnlyPendingTimersAsync();
 
-    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${testDate.toLocaleDateString()}`);
+    expect(wrapper.find('.details').text()).toContain(`Date cannot be after ${boundLabel(testDate)}`);
   });
 
   it('should clear the value when clear button is clicked', async () => {

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -133,6 +133,17 @@ const { focused: searchInputFocused } = useFocus(textInput);
 
 const anyFocused = computed<boolean>(() => get(activatorFocusedWithin) || get(menuWrapperFocusedWithin));
 
+const dateFormat = computed<string>(() => {
+  const fmt = baseFormats[format];
+  if (accuracy === 'second') {
+    return fmt.replace('HH:mm', 'HH:mm:ss');
+  }
+  else if (accuracy === 'millisecond') {
+    return fmt.replace('HH:mm', 'HH:mm:ss.SSS');
+  }
+  return fmt;
+});
+
 const {
   clear: clearSelection,
   getDateTime,
@@ -156,6 +167,7 @@ const {
 } = useDateTimeSelection({
   accuracy,
   allowEmpty,
+  dateFormat,
   maxDate,
   minDate,
   modelValue,
@@ -163,17 +175,6 @@ const {
 });
 
 const { setValue, getCurrent } = useInputHandler(segmentData, currentValue);
-
-const dateFormat = computed<string>(() => {
-  const fmt = baseFormats[format];
-  if (accuracy === 'second') {
-    return fmt.replace('HH:mm', 'HH:mm:ss');
-  }
-  else if (accuracy === 'millisecond') {
-    return fmt.replace('HH:mm', 'HH:mm:ss.SSS');
-  }
-  return fmt;
-});
 
 const {
   clear: clearSegment,

--- a/packages/ui-library/src/components/date-time-picker/segment-utils.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/segment-utils.spec.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { describe, expect, it, vi } from 'vitest';
 import { TimeAccuracy } from '@/consts/time-accuracy';
-import { buildDateTime, clampToBounds, getClickPosition, parseAndSetDateValues } from './segment-utils';
+import { buildDateTime, clampToBounds, getClickPosition, parseAndSetDateValues, resolveBound } from './segment-utils';
 
 dayjs.extend(customParseFormat);
 
@@ -216,6 +216,34 @@ describe('date-time-picker/segment-utils', () => {
 
     it('should apply the minimum even without a maximum', () => {
       expect(clampToBounds(dayjs('1999-01-01T00:00:00'), min).valueOf()).toBe(min.getTime());
+    });
+  });
+
+  describe('resolveBound', () => {
+    it('should return undefined when there is no bound', () => {
+      expect(resolveBound(undefined, false)).toBeUndefined();
+      expect(resolveBound(undefined, true)).toBeUndefined();
+    });
+
+    it('should pass a Date through', () => {
+      const date = new Date(2023, 5, 15, 10, 30);
+      expect(resolveBound(date, false)?.getTime()).toBe(date.getTime());
+    });
+
+    it('should treat a number as milliseconds by default', () => {
+      const ms = new Date(2023, 5, 15).getTime();
+      expect(resolveBound(ms, false)?.getTime()).toBe(ms);
+    });
+
+    // an `epoch` picker states its bounds in whole seconds
+    it('should widen a number to milliseconds for an epoch picker', () => {
+      const ms = new Date(2023, 5, 15).getTime();
+      expect(resolveBound(Math.floor(ms / 1000), true)?.getTime()).toBe(ms);
+    });
+
+    it('should not widen a Date even for an epoch picker', () => {
+      const date = new Date(2023, 5, 15);
+      expect(resolveBound(date, true)?.getTime()).toBe(date.getTime());
     });
   });
 });

--- a/packages/ui-library/src/components/date-time-picker/segment-utils.ts
+++ b/packages/ui-library/src/components/date-time-picker/segment-utils.ts
@@ -52,6 +52,24 @@ export function buildDateTime(segments: SegmentValues, accuracy: TimeAccuracy, b
   return dateTime;
 }
 
+const MILLISECONDS = 1000;
+
+/**
+ * Turns a `minDate` / `maxDate` prop into a Date. An `epoch` picker states its
+ * bounds in whole seconds, so those are widened to milliseconds first.
+ */
+export function resolveBound(bound: Date | number | undefined, epochSeconds: boolean): Date | undefined {
+  if (bound === undefined) {
+    return undefined;
+  }
+
+  if (epochSeconds && typeof bound === 'number') {
+    return new Date(bound * MILLISECONDS);
+  }
+
+  return new Date(bound);
+}
+
 /**
  * Pulls a date inside the allowed range. Used by the `now` and `today` actions,
  * which have no partial state: typed input is left to diverge and explain

--- a/packages/ui-library/src/components/date-time-picker/use-date-time-selection.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-date-time-selection.spec.ts
@@ -35,6 +35,8 @@ function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
 
 describe('use-date-time-selection', () => {
   const fixedDate = new Date(2023, 5, 15, 14, 30, 45, 500);
+  // the field's format, which the bound errors are written in
+  const dateFormat = ref('DD/MM/YYYY HH:mm');
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -52,6 +54,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -74,6 +77,7 @@ describe('use-date-time-selection', () => {
       const { unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -98,6 +102,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -123,6 +128,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -147,6 +153,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -171,6 +178,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'second',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -191,6 +199,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'millisecond',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -213,6 +222,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -234,6 +244,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -259,6 +270,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -287,6 +299,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -307,6 +320,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -332,6 +346,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -354,6 +369,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -379,6 +395,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -400,6 +417,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate,
         modelValue,
@@ -419,6 +437,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: minDateEpoch,
         modelValue,
@@ -441,6 +460,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -459,6 +479,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate,
         minDate: undefined,
         modelValue,
@@ -476,6 +497,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: 'now',
         minDate: undefined,
         modelValue,
@@ -499,6 +521,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: maxDateEpoch,
         minDate: undefined,
         modelValue,
@@ -521,6 +544,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: new Date(2025, 11, 31),
         minDate: new Date(2020, 0, 1),
         modelValue,
@@ -541,6 +565,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate,
         modelValue,
@@ -550,7 +575,7 @@ describe('use-date-time-selection', () => {
       const testDate = dayjs('2019-12-31');
       expect(result.isDateValid(testDate)).toBe(false);
       expect(get(result.internalErrorMessages).length).toBeGreaterThan(0);
-      expect(get(result.internalErrorMessages)[0]).toContain('Date cannot be before');
+      expect(get(result.internalErrorMessages)[0]).toBe('Date cannot be before 10/01/2020 00:00');
 
       unmount();
     });
@@ -562,6 +587,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate,
         minDate: undefined,
         modelValue,
@@ -571,7 +597,7 @@ describe('use-date-time-selection', () => {
       const testDate = dayjs('2023-06-15');
       expect(result.isDateValid(testDate)).toBe(false);
       expect(get(result.internalErrorMessages).length).toBeGreaterThan(0);
-      expect(get(result.internalErrorMessages)[0]).toContain('Date cannot be after');
+      expect(get(result.internalErrorMessages)[0]).toBe('Date cannot be after 01/06/2023 00:00');
 
       unmount();
     });
@@ -582,6 +608,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: 'now',
         minDate: undefined,
         modelValue,
@@ -604,6 +631,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'millisecond',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -638,6 +666,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate,
         modelValue,
@@ -665,6 +694,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -689,6 +719,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'second',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -709,6 +740,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'millisecond',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -730,6 +762,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -751,6 +784,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -772,6 +806,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -798,6 +833,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'millisecond',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -830,6 +866,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -855,6 +892,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -879,6 +917,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -905,6 +944,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -937,6 +977,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -966,6 +1007,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: false,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -995,6 +1037,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate: undefined,
         modelValue,
@@ -1007,6 +1050,52 @@ describe('use-date-time-selection', () => {
     });
   });
 
+  describe('bound errors follow the field format', () => {
+    // 06/07 is the giveaway pair: it reads as 6 July day-first and 7 June
+    // month-first, so a message built from the browser locale cannot pass these
+    const bound = new Date(2023, 6, 6, 9, 5);
+
+    function errorFor(format: string, min: boolean): string {
+      const modelValue = ref<number | undefined>(undefined);
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'minute',
+        allowEmpty: true,
+        dateFormat: ref(format),
+        maxDate: min ? undefined : bound,
+        minDate: min ? bound : undefined,
+        modelValue,
+        type: 'epoch-ms',
+      }));
+
+      result.isDateValid(dayjs(min ? '2020-01-01' : '2030-01-01'));
+      const message = get(result.internalErrorMessages)[0] ?? '';
+      unmount();
+      return message;
+    }
+
+    it('should write a maximum day-first when the field is day-first', () => {
+      expect(errorFor('DD/MM/YYYY HH:mm', false)).toBe('Date cannot be after 06/07/2023 09:05');
+    });
+
+    it('should write a maximum month-first when the field is month-first', () => {
+      expect(errorFor('MM/DD/YYYY HH:mm', false)).toBe('Date cannot be after 07/06/2023 09:05');
+    });
+
+    it('should write a maximum year-first when the field is year-first', () => {
+      expect(errorFor('YYYY/MM/DD HH:mm', false)).toBe('Date cannot be after 2023/07/06 09:05');
+    });
+
+    it('should write a minimum in the field format too', () => {
+      expect(errorFor('MM/DD/YYYY HH:mm', true)).toBe('Date cannot be before 07/06/2023 09:05');
+    });
+
+    // toLocaleDateString() dropped the clock, so a mid-day bound could not
+    // explain why a time later that same day was refused
+    it('should keep the time of the bound', () => {
+      expect(errorFor('DD/MM/YYYY HH:mm:ss', false)).toBe('Date cannot be after 06/07/2023 09:05:00');
+    });
+  });
+
   describe('footer actions against a bound', () => {
     it('should clamp now to maxDate instead of emitting nothing', async () => {
       const maxDate = new Date(2023, 5, 10, 9, 0);
@@ -1015,6 +1104,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate,
         minDate: undefined,
         modelValue,
@@ -1041,6 +1131,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: undefined,
         minDate,
         modelValue,
@@ -1066,6 +1157,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate,
         minDate: undefined,
         modelValue,
@@ -1094,6 +1186,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate: new Date(2023, 11, 31),
         minDate: undefined,
         modelValue,
@@ -1121,6 +1214,7 @@ describe('use-date-time-selection', () => {
       const { result, unmount } = withSetup(() => useDateTimeSelection({
         accuracy: 'minute',
         allowEmpty: true,
+        dateFormat,
         maxDate,
         minDate: undefined,
         modelValue,

--- a/packages/ui-library/src/components/date-time-picker/use-date-time-selection.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-date-time-selection.ts
@@ -2,7 +2,7 @@ import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
 import type { SegmentData } from '@/components/date-time-picker/types';
 import type { TimeAccuracy } from '@/consts/time-accuracy';
 import dayjs, { type Dayjs } from 'dayjs';
-import { buildDateTime, clampToBounds } from '@/components/date-time-picker/segment-utils';
+import { buildDateTime, clampToBounds, resolveBound } from '@/components/date-time-picker/segment-utils';
 import { formatWallClock, guessTimezone, includeMilliseconds, includeSeconds } from '@/components/date-time-picker/utils';
 import { useRuiI8n } from '@/composables/use-rui-i18n';
 import { RUI_I18N_KEYS } from '@/i18n/keys';
@@ -23,6 +23,11 @@ interface DateTimeSelectionOptions<T extends DateTimeModelType> {
   minDate: Date | number | undefined;
   maxDate: Date | number | 'now' | undefined;
   allowEmpty: boolean;
+  /**
+   * The field's own format, so a bound named in an error message is written the
+   * same way round as the value the user is looking at.
+   */
+  dateFormat: Ref<string>;
 }
 
 interface DateTimeSelectionReturn {
@@ -57,6 +62,7 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
   const {
     accuracy,
     allowEmpty,
+    dateFormat,
     maxDate,
     minDate,
     modelValue,
@@ -78,30 +84,15 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
   const internalErrorMessages = ref<string[]>([]);
   const now = ref<Dayjs>(dayjs.tz(undefined, guessTimezone()));
 
-  const minAllowedDate = computed<Date>(() => {
-    if (minDate === undefined) {
-      return new Date(1970, 0, 1);
-    }
+  const epochSeconds = type === 'epoch';
 
-    if (type === 'epoch' && typeof minDate === 'number') {
-      return new Date(minDate * MILLISECONDS);
-    }
+  const minAllowedDate = computed<Date>(
+    () => resolveBound(minDate, epochSeconds) ?? new Date(1970, 0, 1),
+  );
 
-    return new Date(minDate);
-  });
-
-  const maxAllowedDate = computed<Date | undefined>(() => {
-    if (maxDate === undefined) {
-      return undefined;
-    }
-    if (maxDate === 'now') {
-      return get(now).toDate();
-    }
-    if (type === 'epoch' && typeof maxDate === 'number') {
-      return new Date(maxDate * MILLISECONDS);
-    }
-    return new Date(maxDate);
-  });
+  const maxAllowedDate = computed<Date | undefined>(
+    () => (maxDate === 'now' ? get(now).toDate() : resolveBound(maxDate, epochSeconds)),
+  );
 
   const segmentData: SegmentData = {
     DD: selectedDay,
@@ -170,6 +161,16 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
     }, accuracy);
   }
 
+  /**
+   * Writes a bound the way the field writes its value. `toLocaleDateString()`
+   * followed the browser locale and ignored the picker's own format, so a
+   * day-first field could report its limit month-first, and it dropped the time
+   * entirely, which left a mid-day bound unable to explain itself.
+   */
+  function formatBound(bound: Date): string {
+    return dayjs(bound).format(get(dateFormat));
+  }
+
   function isDateValid(date: Dayjs): boolean {
     const min = get(minAllowedDate);
     const max = get(maxAllowedDate);
@@ -177,16 +178,18 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
     set(internalErrorMessages, []);
 
     if (min && date.isBefore(min)) {
+      const formatted = formatBound(min);
       const errorMessage = t(RUI_I18N_KEYS.dateTimePicker.dateBeforeMin, {
-        date: min.toLocaleDateString(),
-      }, `Date cannot be before ${min.toLocaleDateString()}`);
+        date: formatted,
+      }, `Date cannot be before ${formatted}`);
       set(internalErrorMessages, [...get(internalErrorMessages), errorMessage]);
       return false;
     }
 
     if (max && date.isAfter(max)) {
+      const formatted = formatBound(max);
       const nowError = t(RUI_I18N_KEYS.dateTimePicker.dateInFuture, 'The selected date cannot be in the future');
-      const maxError = t(RUI_I18N_KEYS.dateTimePicker.dateAfterMax, { date: max.toLocaleDateString() }, `Date cannot be after ${max.toLocaleDateString()}`);
+      const maxError = t(RUI_I18N_KEYS.dateTimePicker.dateAfterMax, { date: formatted }, `Date cannot be after ${formatted}`);
       const errorMessage = maxDate === 'now' ? nowError : maxError;
       set(internalErrorMessages, [...get(internalErrorMessages), errorMessage]);
       return false;


### PR DESCRIPTION
Follow-up to #561, which left this one open on purpose.

## The problem

The `minDate` / `maxDate` error messages rendered the bound with `toLocaleDateString()`:

```ts
t(RUI_I18N_KEYS.dateTimePicker.dateAfterMax, { date: max.toLocaleDateString() }, …)
```

That follows the **browser locale** and ignores the picker's own `format` prop, so the component could contradict itself. On an en-US browser a `day-first` field shows `15/06/2024` while the error underneath reads `Date cannot be after 6/20/2023`: the same date, written two ways, a few pixels apart. `year-first` disagrees as well.

It also dropped the time. A bound of 10 Jan at 12:00 produced `Date cannot be after 10/01/2023`, yet 10 Jan at 14:00 was still refused, so the message could not explain its own limit.

## The fix

Both messages now format through the field's `dateFormat`, the same string the value is rendered with, so the limit reads exactly like the value above it and carries the bound's time.

`useDateTimeSelection` gains a `dateFormat` option; `RuiDateTimePicker` already computed it, so the computed simply moves above the call.

## Also here

`resolveBound` moves into `segment-utils` as a pure function, because the composable was back at the 400-line lint cap. It replaces the two near-identical `minDate` / `maxDate` normalisations, including the duplicated "an epoch picker states its bounds in seconds" branch.

## Tests

- Five composable specs pin the message against a `day-first`, `month-first` and `year-first` field, plus the minimum, plus one that keeps the bound's time. The bound is 6 July, which reads as 6 July day-first and 7 June month-first, so a message built from the browser locale cannot pass them.
- Five specs for `resolveBound` covering the epoch-seconds widening.
- The eight existing assertions that built their expectation from `toLocaleDateString()` now go through the field format.
- An e2e types a day past the bound on the bounded example picker added in #561 and asserts the rendered message, including the seconds.

Gates: unit 1352, storybook 463, e2e 362, typecheck clean, lint 0 errors.
