### PR TITLE
fix(menu): keep a persistent menu open on escape

### DIFF
--- a/apps/example/e2e/overlays/menu.spec.ts
+++ b/apps/example/e2e/overlays/menu.spec.ts
@@ -1,6 +1,15 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 const menuContent = 'div[role=menu] [data-id=content]';
+
+/**
+ * A menu that stays open is an absence of change, and the leave transition runs
+ * for 150ms, so asserting straight after the key press sees the content still
+ * on the page mid-fade and passes for the wrong reason.
+ */
+async function settle(page: Page): Promise<void> {
+  await page.waitForTimeout(300);
+}
 
 test.describe('menu', () => {
   test.beforeEach(async ({ page }) => {
@@ -152,6 +161,34 @@ test.describe('menu', () => {
 
     // the second closes the outer one
     await page.keyboard.press('Escape');
+    await expect(page.locator(menuContent)).toHaveCount(0);
+  });
+
+  test('escape closes an inner menu without closing a persistent outer one', async ({ page }) => {
+    const outer = page.locator('div[data-id=menu-persistent-nested]');
+    const outerContent = page.locator('[data-id=persistent-close]');
+    const innerContent = page.locator('[data-id=persistent-inner-content]');
+
+    await outer.locator('[data-id=activator]').click();
+    await expect(outerContent).toBeVisible();
+
+    await page.locator('[data-id=persistent-inner-activator]').click();
+    await expect(innerContent).toBeVisible();
+
+    // the inner menu goes, the persistent outer one stays
+    await page.keyboard.press('Escape');
+    await expect(innerContent).toHaveCount(0);
+    await settle(page);
+    await expect(outerContent).toBeVisible();
+
+    // and a second press does not reach it either — this one lands on the inner
+    // activator, which sits inside the outer menu's own popover
+    await page.keyboard.press('Escape');
+    await settle(page);
+    await expect(outerContent).toBeVisible();
+
+    // only its own model closes it — also leaves the page clean for the next test
+    await outerContent.click();
     await expect(page.locator(menuContent)).toHaveCount(0);
   });
 

--- a/apps/example/src/views/MenuView.vue
+++ b/apps/example/src/views/MenuView.vue
@@ -122,6 +122,8 @@ const menus = ref<SimpleMenu[]>([
     persistent: true,
   },
 ]);
+
+const persistentNestedOpen = ref<boolean>(false);
 </script>
 
 <template>
@@ -198,6 +200,61 @@ const menus = ref<SimpleMenu[]>([
               This is the inner menu
             </div>
           </RuiMenu>
+        </div>
+      </RuiMenu>
+    </div>
+
+    <h6 class="text-h6 mt-8 mb-4">
+      Persistent nested menu
+    </h6>
+
+    <div class="py-4">
+      <RuiMenu
+        v-model="persistentNestedOpen"
+        data-id="menu-persistent-nested"
+        persistent
+        :open-delay="10"
+        :popper="{ placement: 'bottom' }"
+      >
+        <template #activator="{ attrs }">
+          <RuiButton
+            color="primary"
+            v-bind="{ ...attrs, 'data-id': 'activator' }"
+          >
+            Open persistent outer menu
+          </RuiButton>
+        </template>
+        <div class="px-3 py-2 flex flex-col items-start gap-2">
+          <span>Escape leaves this one open</span>
+          <RuiMenu
+            data-id="menu-persistent-nested-inner"
+            :open-delay="10"
+            :popper="{ placement: 'right' }"
+          >
+            <template #activator="{ attrs }">
+              <RuiButton
+                color="secondary"
+                size="sm"
+                v-bind="{ ...attrs, 'data-id': 'persistent-inner-activator' }"
+              >
+                Open inner menu
+              </RuiButton>
+            </template>
+            <div
+              class="px-3 py-2"
+              data-id="persistent-inner-content"
+            >
+              This is the inner menu
+            </div>
+          </RuiMenu>
+          <RuiButton
+            color="error"
+            size="sm"
+            data-id="persistent-close"
+            @click="persistentNestedOpen = false"
+          >
+            Close
+          </RuiButton>
         </div>
       </RuiMenu>
     </div>

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.spec.ts
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.spec.ts
@@ -329,20 +329,26 @@ describe('components/overlays/menu/RuiMenu.vue', () => {
   describe('escape propagation', () => {
     const Host = defineComponent({
       components: { RuiButton, RuiMenu },
+      props: {
+        persistent: { default: false, type: Boolean },
+      },
       emits: ['ancestor-keydown'],
       template: `
         <div @keydown="$emit('ancestor-keydown')">
-          <RuiMenu>
+          <RuiMenu v-model="open" :persistent="persistent">
             <template #activator="{ attrs }">
               <RuiButton id="trigger" v-bind="attrs">Click me!</RuiButton>
             </template>
             <div>${text}</div>
           </RuiMenu>
         </div>`,
+      setup() {
+        return { open: ref(false) };
+      },
     });
 
-    function createHost(): VueWrapper<InstanceType<typeof Host>> {
-      return mount(Host);
+    function createHost(persistent = false): VueWrapper<InstanceType<typeof Host>> {
+      return mount(Host, { props: { persistent } });
     }
 
     function ancestorKeydowns(host: VueWrapper<InstanceType<typeof Host>>): number {
@@ -371,6 +377,40 @@ describe('components/overlays/menu/RuiMenu.vue', () => {
       await vi.runAllTimersAsync();
 
       expect(ancestorKeydowns(host)).toBe(before);
+      expect(document.body.innerHTML).not.toMatch(new RegExp(text));
+
+      host.unmount();
+    });
+
+    it('should keep a persistent menu open on escape and let the key through', async () => {
+      const host = createHost(true);
+
+      await host.find('#trigger').trigger('click');
+      await vi.runAllTimersAsync();
+      expect(document.body.innerHTML).toMatch(new RegExp(text));
+
+      const before = ancestorKeydowns(host);
+      await host.find('#trigger').trigger('keydown', { key: 'Escape' });
+      await vi.runAllTimersAsync();
+
+      // An inner popover that closed on the same press leaves the menu
+      // standing, and nothing consumed the key, so the ancestor still sees it.
+      expect(document.body.innerHTML).toMatch(new RegExp(text));
+      expect(ancestorKeydowns(host)).toBe(before + 1);
+
+      host.unmount();
+    });
+
+    it('should still close a persistent menu through its model', async () => {
+      const host = createHost(true);
+
+      await host.find('#trigger').trigger('click');
+      await vi.runAllTimersAsync();
+      expect(document.body.innerHTML).toMatch(new RegExp(text));
+
+      host.vm.open = false;
+      await vi.runAllTimersAsync();
+
       expect(document.body.innerHTML).not.toMatch(new RegExp(text));
 
       host.unmount();

--- a/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
+++ b/packages/ui-library/src/components/overlays/menu/RuiMenu.vue
@@ -45,6 +45,11 @@ export interface MenuProps {
   successMessages?: string | string[];
   showDetails?: boolean;
   dense?: boolean;
+  /**
+   * Keeps the menu open through the interactions that would otherwise dismiss
+   * it: a click outside and an Escape press. A programmatic close (`v-model`
+   * set to `false`) still applies.
+   */
   persistent?: boolean;
   disableAutoFocus?: boolean;
   /**
@@ -234,6 +239,20 @@ function onLeave(event?: KeyboardEvent): void {
   nextTick(() => focusOnActivator());
 }
 
+// `persistent` blocks the outside interactions that would close the menu, and
+// Escape is one of them — `RuiDialog` and `RuiBottomSheet` already read it that
+// way. The guard sits here rather than in `onLeave` because `onLeave` also runs
+// for a programmatic close (`v-model` set to `false`), which must keep working.
+// A persistent menu leaves the key alone instead of swallowing it, so an inner
+// popover can close on Escape while the menu stays open, and an ancestor still
+// sees a key nothing consumed.
+function onEscape(event: KeyboardEvent): void {
+  if (persistent)
+    return;
+
+  onLeave(event);
+}
+
 function checkClick(): void {
   if (get(open) && get(click)) {
     if (!persistOnActivatorClick)
@@ -273,13 +292,14 @@ onClickOutside(menu, () => {
 
 <template>
   <!--
-    Escape is swallowed only while the menu is open (`onLeave` stops the event
-    itself); a closed menu must let it through, or a consumer that closes its
-    own editor on Escape never sees the key.
+    Escape is swallowed only while the menu is open and not persistent
+    (`onLeave` stops the event itself); a closed or persistent menu must let it
+    through, or a consumer that closes its own editor on Escape never sees the
+    key.
   -->
   <div
     :class="classNames?.root"
-    @keydown.esc="onLeave($event)"
+    @keydown.esc="onEscape($event)"
   >
     <div
       ref="activator"
@@ -304,7 +324,7 @@ onClickOutside(menu, () => {
         :role="role"
         :data-placement="currentPlacement"
         @click="closeOnContentClick ? onLeave() : undefined"
-        @keydown.esc="onLeave($event)"
+        @keydown.esc="onEscape($event)"
       >
         <TransitionGroup
           enter-active-class="transition ease-out duration-200"


### PR DESCRIPTION
Closes #567.

`persistent` was only read by the click-outside handler, so it meant "a click outside does not close me" rather than "an outside interaction does not close me". Escape ran straight through `onLeave` and closed the menu, unlike `RuiDialog` and `RuiBottomSheet`, which both treat `persistent` as blocking it.

## The change

A new `onEscape` handler is wired to both `@keydown.esc` sites and returns early when `persistent`.

The guard deliberately does **not** sit in `onLeave`: that function also runs for a programmatic close (`v-model` set to `false`), and guarding there would leave a persistent menu with no way to close at all.

A persistent menu now leaves the key alone instead of swallowing it, so an inner popover can close on Escape while the menu stays open, and an ancestor still sees a key nothing consumed. That is the case this comes from: rotki's pill filter bar renders a date editor with its own `RuiDateTimePicker` popover inside a `RuiMenu`, and one Escape press collapsed both layers.

The `persistent` prop now carries a doc comment stating that a programmatic close still applies.

## Tests

- `RuiMenu.spec.ts` — the escape-propagation host takes a `persistent` prop and a real `v-model`. Two new tests: a persistent menu survives Escape and the ancestor still receives the key, and a persistent menu still closes through its model (the control for the guard's placement).
- `apps/example` — a "Persistent nested menu" section plus an e2e that opens the inner menu, presses Escape twice, and then closes the outer through its own button.

Both were run as negative controls with the component change reverted: the unit test fails on "stays open", the e2e fails. With it in place, unit 21/21 in this file and e2e 10/10.

⚠️ Worth knowing for future menu tests: the first version of the e2e was vacuous and passed against the unfixed build. The leave transition runs for 150ms, so asserting `toBeVisible()` straight after the key press sees the content mid-fade. The test now settles before asserting, with a comment saying why.

## Gates

lint 0 errors / 73 warnings (unchanged baseline) · typecheck clean · unit 1353/1353 · storybook 463/463 · e2e menu 10/10 · typos clean.