### PR TITLE
fix(icon): stop warning for app-registered icons

### DIFF
--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -1,6 +1,8 @@
+import type { GeneratedIcon } from '@/types/icons';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import RuiIcon from '@/components/icons/RuiIcon.vue';
+import { createIconDefaults, IconsSymbol } from '@/composables/icons';
 
 function createWrapper(options?: ComponentMountingOptions<typeof RuiIcon>): VueWrapper<InstanceType<typeof RuiIcon>> {
   return mount(RuiIcon, options);
@@ -143,6 +145,51 @@ describe('components/icons/RuiIcon.vue', () => {
     });
 
     expect(wrapper.classes()).toContain('rui-icon');
+  });
+
+  describe('app-registered icons', () => {
+    // A brand logo of the shape an app registers itself: a name the generated
+    // `RuiIcons` list can never contain.
+    const customIcon: GeneratedIcon = {
+      components: [['path', { d: 'M4 4h16v16H4z' }]],
+      name: 'lu-not-a-library-icon',
+    };
+
+    function createWithCustomIcon(
+      name: string,
+    ): VueWrapper<InstanceType<typeof RuiIcon>> {
+      return mount(RuiIcon, {
+        global: {
+          provide: {
+            [IconsSymbol]: createIconDefaults({ registeredIcons: [customIcon] }),
+          },
+        },
+        props: { name },
+      });
+    }
+
+    it('should render a registered icon without complaining about it', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      wrapper = createWithCustomIcon(customIcon.name);
+
+      // It is registered and it renders, so nothing is wrong with it — the
+      // regression guard for rotki/ui-library#568, where the name-list check
+      // warned on every render, in production builds too.
+      expect(wrapper.find('path').attributes('d')).toBe('M4 4h16v16H4z');
+      expect(warn).not.toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
+    });
+
+    it('should still report a name that is registered nowhere', () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      wrapper = createWithCustomIcon('lu-registered-nowhere');
+
+      expect(error).toHaveBeenCalledOnce();
+      expect(wrapper.find('path').exists()).toBe(false);
+    });
   });
 
   it('should render svg element', () => {

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { ContextColorsType } from '@/consts/colors';
+import type { RuiIcons } from '@/icons';
 import { useIcons } from '@/composables/icons';
-import { isRuiIcon, type RuiIcons } from '@/icons';
 import { tv } from '@/utils/tv';
 
 export interface Props {
@@ -62,10 +62,13 @@ const sizeStyle = computed<Record<string, string> | undefined>(() => {
 
 const isFill = computed<boolean>(() => name.endsWith('-fill'));
 
+// What is registered is the only thing that matters here. An app may register
+// its own icons through `createRui({ theme: { icons } })` — brand logos, since
+// the library carries none — and those names can never appear in the generated
+// `RuiIcons` list, so validating against that list warned for precisely the
+// icons the registration API exists to support. A genuinely unknown name is
+// still caught below, by the check that decides whether anything renders.
 const components = computed<SvgComponent[] | undefined>(() => {
-  if (!isRuiIcon(name)) {
-    console.warn(`icon ${name} must be a valid RuiIcon`);
-  }
   const found = registeredIcons[name];
 
   if (!found) {


### PR DESCRIPTION
Closes #568.

`RuiIcon` ran two independent checks:

```js
if (!isRuiIcon(name)) console.warn(`icon ${name} must be a valid RuiIcon`);
const found = registeredIcons[name];
if (!found) console.error(`Icons "${name}" not found. ...`);
```

The second is the real one, and it is already correct for icons an app registers through `createRui({ theme: { icons } })`. The first compares the name against the generated `RuiIcons` array, which by construction can never hold an app-provided name — so it warned for exactly the icons the registration API exists to support: every brand logo, on every render, in production builds too.

## The name check is not lost

It already runs at build time, in the vite plugin, which is the only place it can be done correctly:

| check | where | catches |
| --- | --- | --- |
| unknown name | `validateIcons` in the plugin's scanner, once per build | typos in a literal `name="lu-…"`, aware of the consumer's `customIcons` allow-list, throws under `strict` |
| registered nowhere | `RuiIcon` at runtime | dynamic `:name` bindings, and names allow-listed at build time but never registered at runtime |

The runtime check has to stay: `extractIconsFromSource` is a regex over source, so it never sees `:name="item.icon"`, and `customIcons` (build-time) and the registered icons (runtime) are separate lists, so an icon can clear the plugin and still render nothing.

`isRuiIcon` remains exported and covered by `icons-generated.spec.ts`; it is simply no longer used as a render-time gate.

## Tests

Two new tests in `RuiIcon.spec.ts`, mounting with an icon set that holds only an app-shaped custom icon:

- a registered custom icon renders its path and logs neither `warn` nor `error` (the regression guard),
- a name registered nowhere still logs `error` once and renders nothing (the control that the surviving check is intact).

Run as a negative control with the component change reverted, the first fails with `expected "warn" to not be called at all, but actually been called 1 times`.

## Gates

lint 0 errors / 73 warnings (unchanged baseline) · typecheck clean · unit 1355/1355 · storybook 463/463.