### PR TITLE
fix(category-picker): keep the selection overlay inside the field

### DIFF
--- a/apps/example/e2e/forms/category-picker.spec.ts
+++ b/apps/example/e2e/forms/category-picker.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 test.describe('category-picker', () => {
   test.beforeEach(async ({ page }) => {
@@ -109,5 +109,51 @@ test.describe('category-picker - narrow (drill-in)', () => {
 
     await expect(page.getByRole('dialog')).toBeHidden();
     await expect(page.locator('[data-id=cp-default] [data-id=search-input]')).toHaveValue('France');
+  });
+});
+
+test.describe('category-picker - selection slot geometry', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/category-pickers');
+  });
+
+  // jsdom has no layout, so the only honest check for rotki/ui-library#559 is
+  // a measured one: the overlay must stay inside the field and leave the
+  // trailing controls alone.
+  async function box(page: Page, selector: string): Promise<{ left: number; right: number }> {
+    const rect = await page.locator(selector).boundingBox();
+    if (!rect)
+      throw new Error(`no box for ${selector}`);
+    return { left: rect.x, right: rect.x + rect.width };
+  }
+
+  test('keeps the overlay inside the field and clear of the chevron', async ({ page }) => {
+    const picker = '[data-id=cp-selection-badge]';
+
+    const field = await box(page, `${picker} [data-id=activator]`);
+    const selection = await box(page, `${picker} [data-id=selection]`);
+    const badge = await box(page, `${picker} [data-id=selection-badge]`);
+    const chevron = await box(page, `${picker} [data-id=chevron]`);
+
+    // Before the fix the layer was full field-width shifted right by `left-4`,
+    // so its right edge sat ~16px past the field's.
+    expect(selection.right).toBeLessThanOrEqual(field.right);
+    // And the right-aligned badge rode on top of the chevron.
+    expect(badge.right).toBeLessThanOrEqual(chevron.left);
+  });
+
+  test('leaves room for the clear button too', async ({ page }) => {
+    const picker = '[data-id=cp-selection-badge-clearable]';
+
+    // The clear button only shows on hover or focus.
+    await page.locator(`${picker} [data-id=activator]`).hover();
+
+    const field = await box(page, `${picker} [data-id=activator]`);
+    const selection = await box(page, `${picker} [data-id=selection]`);
+    const badge = await box(page, `${picker} [data-id=selection-badge]`);
+    const clear = await box(page, `${picker} [data-id=clear]`);
+
+    expect(selection.right).toBeLessThanOrEqual(field.right);
+    expect(badge.right).toBeLessThanOrEqual(clear.left);
   });
 });

--- a/apps/example/src/views/CategoryPickerView.vue
+++ b/apps/example/src/views/CategoryPickerView.vue
@@ -52,6 +52,8 @@ const countryValue = ref<number>();
 const actionValue = ref<string>();
 const denseValue = ref<number>();
 const noSearchValue = ref<number>();
+const badgeValue = ref<number>(1);
+const badgeClearableValue = ref<number>(1);
 </script>
 
 <template>
@@ -120,6 +122,63 @@ const noSearchValue = ref<number>();
           dense
           data-id="cp-dense"
         />
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Selection slot, right-aligned badge
+        </h3>
+        <RuiCategoryPicker
+          v-model="badgeValue"
+          :items="countries"
+          category-attr="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Country"
+          data-id="cp-selection-badge"
+        >
+          <template #selection="{ item }">
+            <span class="font-medium truncate">{{ item.label }}</span>
+            <!--
+              `ml-auto` content is the shape that exposed rotki/ui-library#559:
+              the selection layer used to take `w-full` on top of its own left
+              and right offsets, so it overflowed the field and this badge
+              landed on the chevron.
+            -->
+            <span
+              data-id="selection-badge"
+              class="ml-auto shrink-0 px-2 py-0.5 rounded text-caption bg-rui-primary/10 text-rui-primary"
+            >
+              {{ item.continent }}
+            </span>
+          </template>
+        </RuiCategoryPicker>
+      </div>
+
+      <div>
+        <h3 class="text-subtitle-1 mb-2">
+          Selection slot, right-aligned badge + clearable
+        </h3>
+        <RuiCategoryPicker
+          v-model="badgeClearableValue"
+          :items="countries"
+          category-attr="continent"
+          key-attr="id"
+          text-attr="label"
+          label="Country"
+          clearable
+          data-id="cp-selection-badge-clearable"
+        >
+          <template #selection="{ item }">
+            <span class="font-medium truncate">{{ item.label }}</span>
+            <span
+              data-id="selection-badge"
+              class="ml-auto shrink-0 px-2 py-0.5 rounded text-caption bg-rui-primary/10 text-rui-primary"
+            >
+              {{ item.continent }}
+            </span>
+          </template>
+        </RuiCategoryPicker>
       </div>
 
       <div>

--- a/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
+++ b/packages/ui-library/src/components/forms/category-picker/RuiCategoryPicker.vue
@@ -249,6 +249,11 @@ const legendText = computed<string>(() => {
   return required ? `${label} ﹡` : label;
 });
 
+// Drives both the clear button itself and the room the selection overlay has
+// to leave for it, so the two can never disagree.
+const showClear = computed<boolean>(() =>
+  clearable && get(selectedItem) !== undefined && !disabled && !readOnly);
+
 const activatorUi = computed<ReturnType<typeof categoryPickerActivatorStyles>>(() => categoryPickerActivatorStyles({
   dense,
   disabled,
@@ -260,6 +265,7 @@ const activatorUi = computed<ReturnType<typeof categoryPickerActivatorStyles>>((
   opened: get(isOpen),
   outlined: get(outlined),
   readonly: readOnly,
+  withClear: get(showClear),
 }));
 
 const activeRailIndex = computed<number>(() =>
@@ -467,8 +473,8 @@ watch(isOpen, (value) => {
             </span>
             <span
               v-if="selectedItem && !isTyping && $slots.selection"
-              class="absolute inset-y-0 left-4 right-8 flex items-center gap-2 pointer-events-none"
-              :class="[activatorUi.value()]"
+              data-id="selection"
+              :class="activatorUi.selection()"
             >
               <slot
                 name="selection.prepend"
@@ -495,9 +501,9 @@ watch(isOpen, (value) => {
               @keydown.esc="close()"
             />
             <span
-              v-if="clearable && selectedItem && !disabled && !readOnly"
+              v-if="showClear"
               data-id="clear"
-              :class="[activatorUi.clear(), focused && '!visible']"
+              :class="[activatorUi.clear(), focused && '!visible', { 'mr-2': !dense }]"
               @click.stop.prevent="clearSelection()"
             >
               <RuiIcon
@@ -506,7 +512,10 @@ watch(isOpen, (value) => {
                 size="18"
               />
             </span>
-            <span :class="activatorUi.iconWrapper()">
+            <span
+              data-id="chevron"
+              :class="activatorUi.iconWrapper()"
+            >
               <RuiIcon
                 :class="activatorUi.icon()"
                 :size="dense ? 16 : 24"

--- a/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
+++ b/packages/ui-library/src/components/forms/category-picker/category-picker-styles.ts
@@ -10,9 +10,31 @@ export type CategoryPickerVariant = TextInputVariant;
  */
 export const categoryPickerActivatorStyles = tv({
   extend: activatorStyles,
+  slots: {
+    // The `#selection` slot draws over the emptied input, so it is positioned
+    // rather than laid out: `inset-y-0 left-4` lines it up with the field's own
+    // `pl-4` text box, and the right offset reserves the trailing controls.
+    // It must NOT take the `value` slot's `w-full` — a width of 100% beats the
+    // right offset, so the layer would end up full field-width shifted right by
+    // `left-4`, overflowing the field and covering the chevron it meant to
+    // clear (rotki/ui-library#559).
+    selection: 'absolute inset-y-0 left-4 flex items-center gap-2 pointer-events-none truncate transition-all duration-75',
+  },
   variants: {
     // Re-declare for type inference — actual styles live in activatorStyles.
     filled: { true: {} },
+    // The chevron sits at `right-3` and is 24px wide, so it reaches 36px in;
+    // `right-10` clears it. The clear button ends at the activator's `pr-8`
+    // padding edge plus its own `mr-2`, so its 18px icon reaches 58px in and
+    // `right-16` clears that. Right-aligned selection content (`ml-auto`) then
+    // lands just left of whichever control is showing.
+    withClear: {
+      false: { selection: 'right-10' },
+      true: { selection: 'right-16' },
+    },
+  },
+  defaultVariants: {
+    withClear: false,
   },
 });
 


### PR DESCRIPTION
Closes #559.

The `#selection` layer is positioned, not laid out — `inset-y-0 left-4 right-8` lines it up with the field's own `pl-4 pr-8` padding box. It also received `activatorUi.value()`, whose classes carry `w-full`, and a width of 100% beats the right offset. The layer therefore ended up full field-width shifted right by `left-4`: it overflowed **16px past the field's right border** (measured, not estimated) and lost the gap it was supposed to leave, so right-aligned selection content landed on the chevron.

## The change

The layer gets its own slot in `categoryPickerActivatorStyles` instead of borrowing the input's, so it no longer inherits `w-full` (or the `block` that was fighting its own `flex`). The right offset now reserves the trailing controls: `right-10` clears the chevron (24px wide at `right-3`, so it reaches 36px in), and `right-16` when the clear button is showing as well. A new `showClear` computed drives both the button's `v-if` and that offset, so the two cannot drift apart.

## Verification

jsdom has no layout, so this is checked by measurement in a real browser. Two new tests in `apps/example/e2e/forms/category-picker.spec.ts` assert the invariants directly — the overlay's right edge stays inside the field, and the right-aligned badge stays left of the chevron (and of the clear button in the clearable case).

Run as a negative control against the old classes, both fail by exactly the overflow the issue describes:

```
expect(selection.right).toBeLessThanOrEqual(field.right)
  Expected: <= 1248     Received: 1264      // plain
  Expected: <=  747     Received:  763      // clearable
```

The example app grows two `RuiCategoryPicker` sections using a right-aligned `ml-auto` badge — the shape that exposed the bug — which is what those tests drive.

Note for reviewers: the "Visual regression" job does **not** cover this. `RuiTextField` is the only component in the visual lane, so the geometry assertions above are the real guard.

## Gates

lint 0 errors / 73 warnings (unchanged baseline) · typecheck clean · unit 1355/1355 · storybook 463/463 · e2e 366/366 · typos clean.