### PR TITLE
fix(progress): draw a track behind the circular arc and size its label

### DIFF
--- a/apps/example/e2e/progress.spec.ts
+++ b/apps/example/e2e/progress.spec.ts
@@ -40,6 +40,8 @@ test.describe('progress indicators', () => {
     await expect(determinateProgress).toBeVisible();
     await expect(indeterminateProgress).toBeVisible();
     await expect(bufferProgress).toBeVisible();
-    await expect(circularProgress.locator('svg circle')).toBeVisible();
+    // A determinate circle renders a track plus the arc on top of it.
+    await expect(circularProgress.locator('svg circle')).toHaveCount(2);
+    await expect(circularProgress.locator('svg circle').last()).toBeVisible();
   });
 });

--- a/packages/ui-library/src/components/progress/RuiProgress.spec.ts
+++ b/packages/ui-library/src/components/progress/RuiProgress.spec.ts
@@ -86,6 +86,56 @@ describe('components/progress/RuiProgress.vue', () => {
     expect(wrapper.find('div[role=progressbar] svg circle').exists()).toBeTruthy();
   });
 
+  it('should render a track behind the arc for determinate circular progress', async () => {
+    wrapper = createWrapper({
+      props: {
+        circular: true,
+        value: 50,
+      },
+    });
+
+    expect(wrapper.findAll('div[role=progressbar] svg circle')).toHaveLength(2);
+
+    // the spinning variant has no track, a full ring would just sit there
+    await wrapper.setProps({ variant: 'indeterminate' });
+    expect(wrapper.findAll('div[role=progressbar] svg circle')).toHaveLength(1);
+  });
+
+  it('should scale the circular label with size and thickness', async () => {
+    function labelFontSize(): number {
+      const style = wrapper.find('div[role=progressbar] > div').attributes('style') ?? '';
+      return Number.parseFloat(/font-size:\s*([\d.]+)px/.exec(style)?.[1] ?? '0');
+    }
+
+    wrapper = createWrapper({
+      props: {
+        circular: true,
+        showLabel: true,
+        size: 30,
+        thickness: 2,
+        value: 94,
+      },
+    });
+
+    const label = wrapper.find('div[role=progressbar] > div');
+    expect(label.text()).toBe('94%');
+    // the value is already exposed through aria-valuenow
+    expect(label.attributes('aria-hidden')).toBe('true');
+    expect(labelFontSize()).toBeCloseTo(8.21, 2);
+
+    // the label is sized for `100%`, so it does not jump as the value climbs
+    await wrapper.setProps({ value: 100 });
+    expect(labelFontSize()).toBeCloseTo(8.21, 2);
+
+    // large rings are capped by the sublinear curve rather than the fit
+    await wrapper.setProps({ size: 100 });
+    expect(labelFontSize()).toBeCloseTo(21, 1);
+
+    // a fatter stroke leaves less room inside, and the fit takes over again
+    await wrapper.setProps({ size: 30, thickness: 10 });
+    expect(labelFontSize()).toBeCloseTo(3.16, 1);
+  });
+
   it('should show label when showLabel is true', () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/progress/RuiProgress.stories.ts
+++ b/packages/ui-library/src/components/progress/RuiProgress.stories.ts
@@ -142,6 +142,22 @@ export const CircularWithLabel = meta.story({
   },
 });
 
+export const CircularWithLabelSizes = meta.story({
+  render(args) {
+    return {
+      components: { Progress: RuiProgress },
+      setup: () => ({ args, sizes: [24, 30, 40, 64, 100] }),
+      template: `
+        <div class="flex flex-wrap items-center gap-6 p-4 text-black dark:text-white">
+          <div v-for="size in sizes" :key="size" class="flex flex-col items-center gap-2">
+            <Progress circular show-label color="primary" :value="100" :size="size" :thickness="2" />
+            <span class="text-xs">{{ size }}px</span>
+          </div>
+        </div>`,
+    };
+  },
+});
+
 export const Colors = meta.story({
   render(args) {
     return {

--- a/packages/ui-library/src/components/progress/RuiProgress.vue
+++ b/packages/ui-library/src/components/progress/RuiProgress.vue
@@ -47,6 +47,10 @@ defineSlots<Record<string, never>>();
 
 const CIRCLE_RADIUS = 20;
 const CIRCLE_CIRCUMFERENCE = 2 * Math.PI * CIRCLE_RADIUS; // ~125.66
+/** approximate width of `100%` in ems */
+const LABEL_WIDTH_EM = 2.5;
+/** keeps the label off the stroke rather than merely inside it */
+const LABEL_BREATHING_ROOM = 0.85;
 
 function clampPercent(val: number | undefined): number {
   return Math.max(0, Math.min(val ?? 100, 100));
@@ -64,7 +68,8 @@ const progressStyles = tv({
     circularContainer: 'inline-block relative',
     svg: 'block',
     circle: 'stroke-current',
-    label: 'dark:text-white',
+    circleTrack: 'stroke-current opacity-20',
+    label: 'text-rui-text',
   },
   variants: {
     color: {
@@ -95,8 +100,8 @@ const progressStyles = tv({
   compoundVariants: [
     // Linear label
     { circular: false, hasLabel: true, class: { label: 'block text-sm ml-4' } },
-    // Circular label (overlays the circle)
-    { circular: true, hasLabel: true, class: { label: 'absolute inset-0 flex items-center justify-center text-[0.6rem] leading-none' } },
+    // Circular label (overlays the circle, font size derived from `size`)
+    { circular: true, hasLabel: true, class: { label: 'absolute inset-0 flex items-center justify-center leading-none tabular-nums whitespace-nowrap' } },
   ],
   compoundSlots: [
     // Rail background (track behind the bar)
@@ -156,6 +161,18 @@ const circularGeometry = computed<{ scaledThickness: number; viewSize: number }>
   return { scaledThickness, viewSize: 40 + scaledThickness };
 });
 
+/**
+ * The circular label lives inside the ring, so it scales with both `size` and `thickness`.
+ * `fit` solves for the widest label (`100%`) fitting the chord it spans, always computed
+ * for that widest label so the text does not resize as the value climbs. It is capped by
+ * a sublinear curve so large rings do not end up with an oversized number in the middle.
+ */
+const circularLabelStyle = computed<Record<string, string>>(() => {
+  const innerRadius = Math.max((+size - 2 * +thickness) / 2, 0);
+  const fit = (LABEL_BREATHING_ROOM * 2 * innerRadius) / Math.sqrt(LABEL_WIDTH_EM ** 2 + 1);
+  return { fontSize: `${Math.min(fit, +size * 0.15 + 6)}px` };
+});
+
 const circularStrokeStyle = computed<Record<string, string>>(() => ({
   strokeDasharray: `${CIRCLE_CIRCUMFERENCE}`,
   strokeDashoffset: `${(get(progress) / 100) * -CIRCLE_CIRCUMFERENCE}`,
@@ -181,6 +198,16 @@ const circularStrokeStyle = computed<Record<string, string>>(() => ({
         :class="ui.svg()"
         :viewBox="`0 0 ${circularGeometry.viewSize} ${circularGeometry.viewSize}`"
       >
+        <!-- Track behind the arc, mirroring the linear rail. Indeterminate spins, so it gets no track. -->
+        <circle
+          v-if="variant === ProgressVariant.determinate"
+          cx="50%"
+          cy="50%"
+          fill="none"
+          :r="CIRCLE_RADIUS"
+          :class="ui.circleTrack()"
+          :stroke-width="circularGeometry.scaledThickness"
+        />
         <circle
           cx="50%"
           cy="50%"
@@ -194,6 +221,8 @@ const circularStrokeStyle = computed<Record<string, string>>(() => ({
       <div
         v-if="hasLabel"
         :class="ui.label()"
+        :style="circularLabelStyle"
+        aria-hidden="true"
       >
         {{ label }}
       </div>


### PR DESCRIPTION
Circular progress rendered only the arc, so a determinate ring showed a floating stroke with a bare gap where the linear variant draws a faded rail. The overlaid percentage was also pinned at `0.6rem` regardless of `size`, which crowded the stroke at the small sizes we use (`100%` measured 31px inside a 32px inner diameter) and shrank to nothing on large rings.

## Changes

- Draw the track circle for the determinate variant, at the same `/20` opacity as the linear rail. The indeterminate variant spins, so a full ring under it would only sit there; every existing spinner is unchanged.
- Derive the circular label's font size from the inner diameter (`size - 2 * thickness`) instead of a flat rem value. It is solved for the widest label (`100%`) so the text does not resize as the value climbs, capped by a sublinear curve so a large ring keeps a proportionate number, and set in `tabular-nums` so the digits do not jitter.
- Use the neutral text colour for the label in both themes. It previously inherited the progress colour in light mode and turned white in dark, which read as two different designs and left the `warning` and `success` labels low contrast at ~8px. It is also `aria-hidden` now, since `aria-valuenow` already carries the value.

## Notes

This lines up with what other libraries do: Material 3, Vuetify, Ant Design and Chakra all draw a track, Ant Design and MUI both use a neutral label colour rather than the stroke colour, and Ant Design scales the circle label from the width (`width * 0.15 + 6`) — the curve the cap here borrows. The deliberate divergence is the indeterminate track, which Vuetify and Ant Design draw and this does not, to keep the spinner look unchanged.

## Verification

Checked on `/progress` in the example app in both themes: 2 circles on determinate, 1 on indeterminate, and `100%` now measures 24.4px inside the same 32px inner diameter.

Unit 1357/1357, storybook 464/464, `progress.spec.ts` e2e 4/4, lint and typecheck clean. New coverage for the track, the label scaling and the `aria-hidden`; the e2e assertion that expected a single `circle` was updated.