### PR TITLE
fix(menu-select): keep the clear button clear of the chevron

### DIFF
--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.spec.ts
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.spec.ts
@@ -195,6 +195,27 @@ describe('components/forms/select/RuiMenuSelect.vue', () => {
     expect(wrapper.emitted('update:modelValue')).toEqual([[undefined]]);
   });
 
+  it('should keep the clear button clear of the chevron unless dense', async () => {
+    const option0 = options[0];
+    assert(option0);
+    wrapper = createWrapper({
+      props: {
+        clearable: true,
+        keyAttr: 'id',
+        modelValue: option0.id,
+        options,
+        textAttr: 'label',
+      },
+    });
+
+    // the 24px chevron sits at `right-3`, so the clear icon needs the gap
+    expect(wrapper.find('[data-id=clear]').classes()).toContain('mr-2');
+
+    // the dense chevron is 16px and leaves room on its own
+    await wrapper.setProps({ dense: true });
+    expect(wrapper.find('[data-id=clear]').classes()).not.toContain('mr-2');
+  });
+
   it('should not open menu when readOnly', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
+++ b/packages/ui-library/src/components/forms/select/RuiMenuSelect.vue
@@ -277,7 +277,7 @@ const menuFloatingOptions = computed<FloatingOptions>(() => ({
           <span
             v-if="clearable && value && !disabled"
             data-id="clear"
-            :class="[ui.clear(), focused && '!visible']"
+            :class="[ui.clear(), focused && '!visible', { 'mr-2': !dense }]"
             @click.stop.prevent="clear()"
           >
             <RuiIcon


### PR DESCRIPTION
`RuiMenuSelect`'s clear icon sits in normal flow and ends at the activator's `pr-8` edge, while the chevron is absolutely placed at `right-3` with a 24px icon. The two boxes overlap, and only the chevron's internal SVG padding kept that from being obvious.

Measured on `/menu-selects/selection` in the example app: **4px of overlap**, `margin-right: 0px`. After the change: a 4px gap, with the clear icon's right edge 40px from the activator's edge, still inside the `right-16` reservation.

This is the same `mr-2` that `RuiAutoComplete` and `RuiCategoryPicker` already carry, so this was the last activator without it. The dense chevron is 16px and leaves room on its own, so `dense` stays exempt.

## Verification

Unit 26/26 for the component (new case asserts the class is present when not dense and absent when dense), typecheck and lint clean.