### PR TITLE
fix(navigation-drawer): let a consumer class override the variant class

### DIFF
--- a/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.spec.ts
+++ b/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.spec.ts
@@ -234,6 +234,41 @@ describe('components/overlays/navigation-drawer/RuiNavigationDrawer.vue', () => 
     assertExists(drawer);
   });
 
+  it('should let a consumer class replace the conflicting variant class', async () => {
+    wrapper = createWrapper({
+      attrs: {
+        class: 'z-[6]',
+      },
+    });
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const drawer = queryBody<HTMLElement>('aside[data-visible]');
+    assertExists(drawer);
+    expect(drawer.classList.contains('z-[6]')).toBe(true);
+    // the variant's own z-index must be gone, not merely outranked
+    expect(drawer.classList.contains('z-[7]')).toBe(false);
+  });
+
+  it('should still apply the variant class when the consumer passes none', async () => {
+    wrapper = createWrapper({
+      attrs: {
+        class: 'custom-drawer',
+      },
+    });
+    await vi.runAllTimersAsync();
+
+    await wrapper.find('#trigger').trigger('click');
+    await vi.runAllTimersAsync();
+
+    const drawer = queryBody<HTMLElement>('aside[data-visible]');
+    assertExists(drawer);
+    expect(drawer.classList.contains('custom-drawer')).toBe(true);
+    expect(drawer.classList.contains('z-[7]')).toBe(true);
+  });
+
   it('should keep DOM element when miniVariant is true and modelValue is false', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.vue
+++ b/packages/ui-library/src/components/overlays/navigation-drawer/RuiNavigationDrawer.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { MaybeElement } from '@vueuse/core';
+import type { ClassValue } from 'vue';
 import type { VueClassValue } from '@/types/class-value';
 import { useTimeoutManager } from '@/composables/timeout-manager';
 import { getRootAttrs, transformPropsUnit } from '@/utils/helpers';
-import { tv } from '@/utils/tv';
+import { cn, tv } from '@/utils/tv';
 
 export interface RuiNavigationDrawerClassNames {
   root?: VueClassValue;
@@ -94,7 +95,26 @@ const drawer = tv({
   defaultVariants: { position: 'left', visible: false, mini: false, withOverlay: false },
 });
 
-const ui = computed<string>(() => drawer({ position, visible: modelValue.value, mini: miniVariant, withOverlay: overlay }));
+/**
+ * Consumer classes go through `drawer()` rather than alongside it, so
+ * tailwind-variants' twMerge resolves conflicts in the consumer's favour.
+ * Passed as an argument instead of read off `$attrs` here, so the template
+ * keeps using `$attrs` directly.
+ */
+function rootClass(attrsClass: ClassValue): string {
+  return drawer({
+    position,
+    visible: modelValue.value,
+    mini: miniVariant,
+    withOverlay: overlay,
+    class: cn([
+      temporary && modelValue.value && 'shadow-5',
+      classNames?.content ?? contentClass,
+      classNames?.root,
+      attrsClass,
+    ]),
+  });
+}
 
 function toggle(): void {
   set(modelValue, !get(modelValue));
@@ -160,15 +180,10 @@ onClickOutside(content, () => {
         :data-visible="modelValue || undefined"
         :data-position="position"
         :data-mini="miniVariant || undefined"
-        :class="[
-          ui,
-          temporary && modelValue && 'shadow-5',
-          classNames?.content ?? contentClass,
-          classNames?.root,
-        ]"
+        :class="rootClass($attrs.class)"
         :aria-label="ariaLabel"
         :aria-hidden="miniVariant && !modelValue ? 'true' : undefined"
-        v-bind="getRootAttrs($attrs)"
+        v-bind="getRootAttrs($attrs, [])"
       >
         <slot v-bind="{ attrs: activatorAttrs, close }" />
       </aside>


### PR DESCRIPTION
`RuiNavigationDrawer` listed the variant string and the fallthrough class side by side on the `<aside>`, so the two never merged. A consumer passing `z-[6]` got it appended next to the variant's own `z-[7]` and lost the cascade at equal specificity, which made placing one drawer below another require `!z-[6]` — a plain class was silently ignored.

This bit rotki: the pinned rail set `z-[6]` to sit below the temporary sidebars, stayed at an effective z-7, and covered the notifications drawer.

## Change

Route consumer classes (`$attrs.class`, `classNames.root`, `classNames.content`/`contentClass`) through `drawer()` so tailwind-variants' twMerge resolves conflicts in the consumer's favour. This is the pattern `RuiAutoComplete` and `RuiMenuSelect` already use via `ui.wrapper({ class: cn($attrs.class) })`, and it's documented in `text-input-styles.ts`.

## Compatibility

Classes carrying the important prefix are untouched. tailwind-merge 2.x groups `!z-[6]` separately from `z-[7]`, verified directly:

```
twMerge('z-[7]', 'z-[6]')   => 'z-[6]'          <- the fix
twMerge('z-[7]', '!z-[6]')  => 'z-[7] !z-[6]'   <- existing workarounds unchanged
twMerge('top-0', '!top-16') => 'top-0 !top-16'  <- the example app's own drawer
```

So consumers currently working around this with `!` keep working exactly as before and can drop the `!` at their leisure.

## Verification

Two new unit cases: a plain `z-[6]` replaces `z-[7]`, and a non-conflicting consumer class leaves the variant class intact (the guard against over-merging). Confirmed discriminating — the first fails against the unfixed component.

Unit 1359/1359, typecheck and lint clean, and the drawer renders unchanged in the example app at `/navigation-drawers`.