### PR TITLE
fix(icon): let a consumer class override the variant class

### DIFF
--- a/packages/ui-library/src/components/icons/RuiIcon.spec.ts
+++ b/packages/ui-library/src/components/icons/RuiIcon.spec.ts
@@ -25,6 +25,43 @@ describe('components/icons/RuiIcon.vue', () => {
     expect(wrapper.classes()).toContain('text-rui-primary');
   });
 
+  it('should let a consumer class replace the conflicting variant class', () => {
+    wrapper = createWrapper({
+      attrs: {
+        class: 'text-rui-error size-4',
+      },
+      props: {
+        color: 'primary',
+        name: 'lu-circle-arrow-down',
+      },
+    });
+
+    const classes = wrapper.classes();
+    expect(classes).toContain('text-rui-error');
+    expect(classes).toContain('size-4');
+    // the variant colour and the base box must be gone, not merely outranked
+    expect(classes).not.toContain('text-rui-primary');
+    expect(classes).not.toContain('w-[var(--rui-icon-size,1.5rem)]');
+    // untouched base classes stay
+    expect(classes).toContain('shrink-0');
+    expect(classes).toContain('rui-icon');
+  });
+
+  it('should still forward non-class attributes to the svg', () => {
+    wrapper = createWrapper({
+      attrs: {
+        'data-id': 'my-icon',
+        'role': 'img',
+      },
+      props: {
+        name: 'lu-circle-arrow-down',
+      },
+    });
+
+    expect(wrapper.attributes('data-id')).toBe('my-icon');
+    expect(wrapper.attributes('role')).toBe('img');
+  });
+
   it('should have aria-hidden="true" on svg', () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/icons/RuiIcon.vue
+++ b/packages/ui-library/src/components/icons/RuiIcon.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
+import type { ClassValue } from 'vue';
 import type { ContextColorsType } from '@/consts/colors';
 import type { RuiIcons } from '@/icons';
+import { objectOmit } from '@vueuse/shared';
 import { useIcons } from '@/composables/icons';
-import { tv } from '@/utils/tv';
+import { cn, tv } from '@/utils/tv';
 
 export interface Props {
   name: RuiIcons;
@@ -12,6 +14,9 @@ export interface Props {
 
 defineOptions({
   name: 'RuiIcon',
+  // the svg is the only root, so a fallthrough class would land beside the
+  // variant classes and leave the cascade to break the tie; `ui` merges instead
+  inheritAttrs: false,
 });
 
 const { name, size, color } = defineProps<Props>();
@@ -42,7 +47,10 @@ const iconStyles = tv({
 });
 
 const hasExplicitSize = computed<boolean>(() => size !== undefined);
-const ui = computed<string>(() => iconStyles({ color }));
+
+function ui(attrsClass: ClassValue): string {
+  return iconStyles({ color, class: cn(attrsClass) });
+}
 
 // Render the `size` prop as an inline CSS custom property on the svg. Because
 // inline style wins against any inherited value for the same property on this
@@ -84,10 +92,11 @@ const components = computed<SvgComponent[] | undefined>(() => {
   <svg
     aria-hidden="true"
     class="rui-icon"
-    :class="ui"
+    :class="ui($attrs.class)"
     :style="sizeStyle"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
+    v-bind="objectOmit($attrs, ['class'])"
   >
     <component
       :is="component[0]"


### PR DESCRIPTION
Third of the fallthrough-class fixes, after #574 (`RuiNavigationDrawer`). The svg is `RuiIcon`'s only root, so a consumer's class landed beside the variant classes and the cascade broke the tie rather than the consumer.

Measured against the real compiled CSS: `<RuiIcon class="w-4" />` renders **24px, not 16px**, because the base `w-[var(--rui-icon-size,1.5rem)]` is emitted after `w-4`. A `text-*` class loses to the `color` prop's own colour the same way.

## Change

Opt out of attribute inheritance and route the class through `iconStyles()`, so tailwind-variants' twMerge resolves conflicts in the consumer's favour. Every other attribute is still forwarded explicitly, `data-id` included.

Note the `size` prop remains the intended way to size an icon; this only stops a class from silently doing nothing.

## Verification

Two new unit cases: a conflicting `text-rui-error size-4` replaces the variant colour and the base box while `shrink-0`/`rui-icon` survive, and a second case pins that non-class attributes (`data-id`, `role`) still reach the svg — the guard against `inheritAttrs: false` dropping them. Confirmed discriminating: the first fails against the unfixed component.

Unit 1362/1362, storybook 464/464, `icon.spec.ts` + `button.spec.ts` e2e green, typecheck and lint clean. Icons on the example app's `/icons` page render unchanged (16px from `--rui-icon-size`, colours intact).