### PR TITLE
fix(data-table): honour an empty item.expand slot

### DIFF
--- a/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
+++ b/packages/ui-library/src/components/tables/RuiDataTable.spec.ts
@@ -267,6 +267,100 @@ describe('components/tables/RuiDataTable.vue', () => {
     expect(wrapper.find('tr[data-id=row-expanded] div[data-id=expanded-content]').exists()).toBeTruthy();
   });
 
+  describe('consumer-owned expand column', () => {
+    // A consumer that provides `#item.expand` decides per row whether a toggle
+    // exists. The built-in toggle is a fallback for consumers that provide no
+    // slot at all, so it must not reappear on the rows the consumer left empty.
+    const expandSlots = {
+      'expanded-item': '<div data-id="expanded-content">Expanded content</div>',
+      // Only the first row is expandable; on every other row the `v-if` leaves
+      // the slot rendering a comment, which is what used to trip the fallback.
+      'item.expand': `<template #item.expand="{ row }">
+        <button
+          v-if="row.id === 1"
+          data-id="custom-expander"
+        >toggle</button>
+      </template>`,
+    };
+
+    it('should render the built-in toggle when no item.expand slot is provided', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          expanded: [],
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: {
+          'expanded-item': '<div data-id="expanded-content">Expanded content</div>',
+        },
+      });
+
+      // Negative control for the two tests below: without a consumer slot the
+      // fallback is still the only thing that renders a toggle.
+      expect(wrapper.find('tbody tr:nth-child(1) button[data-id="expand-button"]').exists()).toBeTruthy();
+      expect(wrapper.find('tbody tr:nth-child(2) button[data-id="expand-button"]').exists()).toBeTruthy();
+    });
+
+    it('should not fall back to the built-in toggle on a row the item.expand slot leaves empty', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          expanded: [],
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: expandSlots,
+      });
+
+      const expandable = wrapper.find('tbody tr:nth-child(1)');
+      expect(expandable.find('button[data-id="custom-expander"]').exists()).toBeTruthy();
+      expect(expandable.find('button[data-id="expand-button"]').exists()).toBeFalsy();
+
+      // The row the consumer withheld a toggle from must have no toggle at all.
+      const notExpandable = wrapper.find('tbody tr:nth-child(2)');
+      expect(notExpandable.find('button[data-id="custom-expander"]').exists()).toBeFalsy();
+      expect(notExpandable.find('button[data-id="expand-button"]').exists()).toBeFalsy();
+    });
+
+    it('should leave the expand cell empty rather than printing the row value', () => {
+      // A row that happens to carry an `expand` field proves the empty case
+      // renders nothing at all, instead of falling through to the cell value.
+      const rowsWithExpandField = data.map(user => ({ ...user, expand: 'leaked' }));
+
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          expanded: [],
+          rowAttr: 'id',
+          rows: rowsWithExpandField,
+        },
+        slots: expandSlots,
+      });
+
+      const cells = wrapper.find('tbody tr:nth-child(2)').findAll('td');
+      expect(cells.at(-1)!.text()).toBe('');
+    });
+
+    it('should let the item.expand slot win over the built-in toggle in the mobile card header', () => {
+      wrapper = createWrapper({
+        props: {
+          cols: columns,
+          expanded: [],
+          mobile: true,
+          rowAttr: 'id',
+          rows: data,
+        },
+        slots: expandSlots,
+      });
+
+      const header = wrapper.find('tbody tr:nth-child(1) [data-id=mobile-card-header]');
+      expect(header.exists()).toBeTruthy();
+      expect(header.find('button[data-id="custom-expander"]').exists()).toBeTruthy();
+      expect(header.find('button[data-id="expand-button"]').exists()).toBeFalsy();
+    });
+  });
+
   it('should sticky header behaves as expected', async () => {
     wrapper = createWrapper({
       props: {

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableCell.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableCell.vue
@@ -14,9 +14,15 @@ defineSlots<{
   default?: (props: { column: TableColumn<T>; row: T; index: number }) => any;
 }>();
 
-const { cellValue, columnAttr } = useDataTableColumns<T>();
+const { cellValue, columnAttr, itemSlotKeys } = useDataTableColumns<T>();
 const { isExpanded, onToggleExpand } = useDataTableExpansion<T>();
 const { isMobile } = useDataTableStyling();
+
+// The built-in toggle is only a fallback for consumers that do not drive the
+// expand column themselves. A consumer that provides `#item.expand` owns the
+// decision per row, including rendering nothing for a row that cannot expand,
+// so slot emptiness must not fall back to a toggle they deliberately withheld.
+const ownsExpandColumn = computed<boolean>(() => itemSlotKeys.has('expand'));
 
 const mobileLabel = computed<string>(() => {
   const label = column[columnAttr];
@@ -50,11 +56,11 @@ const showMobileLabel = computed<boolean>(() => get(isMobile) && column.key !== 
         :index="index"
       >
         <RuiExpandButton
-          v-if="column.key === 'expand'"
+          v-if="column.key === 'expand' && !ownsExpandColumn"
           :expanded="rowId !== undefined && isExpanded(rowId)"
           @click="onToggleExpand(row)"
         />
-        <template v-else>
+        <template v-else-if="column.key !== 'expand'">
           {{ cellValue(row, column.key) }}
         </template>
       </slot>

--- a/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
+++ b/packages/ui-library/src/components/tables/data-table/RuiDataTableRow.vue
@@ -113,17 +113,17 @@ const mobileCardClass = computed<string>(() => {
           v-for="(column, headerIndex) in mobileHeaderColumns"
           :key="`header-${headerIndex}`"
         >
-          <RuiExpandButton
-            v-if="column.key === 'expand'"
-            :expanded="isExpanded(rowId)"
-            @click="onToggleExpand(row)"
-          />
           <slot
-            v-else-if="itemSlotKeys.has(column.key.toString())"
+            v-if="itemSlotKeys.has(column.key.toString())"
             :name="`item.${column.key.toString()}`"
             :column="column"
             :row="row"
             :index="index"
+          />
+          <RuiExpandButton
+            v-else-if="column.key === 'expand'"
+            :expanded="isExpanded(rowId)"
+            @click="onToggleExpand(row)"
           />
           <template v-else>
             {{ cellValue(row, column.key) }}


### PR DESCRIPTION
A consumer that provides `#item.expand` decides per row whether an expand toggle exists. Since the
data-table decomposition, a row the consumer deliberately left without a toggle gets the built-in one
back, and clicking it opens an empty expanded panel.

## What broke

Before `e984b997` (first released in v2.22.0) the built-in toggle carried an explicit guard:

```vue
<slot v-if="column.key === 'expand'" :name="`item.${column.key.toString()}`" ...>
  <RuiExpandButton
    v-if="!slots['item.expand']"
    :expanded="isExpanded(row[rowAttr])"
    @click="onToggleExpand(row)"
  />
</slot>
```

`!slots['item.expand']` asks whether the consumer provided the slot at all. The decomposition turned
that into an ordinary Vue slot fallback in `RuiDataTableCell`, which asks a different question: did
the slot render anything *this time*. A consumer gate of the shape

```vue
<template #item.expand="{ row }">
  <RuiTableRowExpander v-if="isRowExpandable(row)" ... />
</template>
```

renders a comment when the condition is false, `ensureValidVNode` treats an all-comment slot as
empty, and the fallback runs. So the consumer's gate silently became a no-op and every row in the
table became expandable.

Nothing failed loudly: the slot type is a permissive ``Record<`item.${string}`, ...>``, so
`item.expand` still type-checks, and the built-in toggle looks identical to
`RuiTableRowExpander` (which is an alias export of `RuiExpandButton`).

## Where it shows

On the rotki dashboard asset table, which gates the expander on whether the asset has a breakdown or
more than one protocol. An asset with neither, for example an ERC20 held at a single address, has no
detail to show. The row still gets a toggle, and it opens an empty white panel.

## The fix

- `RuiDataTableCell` takes `itemSlotKeys` from the columns context and renders the built-in toggle
  only when the consumer does not own the expand column, restoring the old slot-presence semantics.
- The cell-value branch now skips the expand column, so the empty case renders nothing rather than
  falling through to `{{ cellValue(row, 'expand') }}`. A row carrying an `expand` field would
  otherwise print it.
- In the mobile card header of `RuiDataTableRow`, the consumer slot now takes precedence over the
  built-in toggle. There the built-in one won outright, so `#item.expand` never rendered on mobile at
  all, even for rows where it had content.

## Tests

A `consumer-owned expand column` block in `RuiDataTable.spec.ts`, using a slot with a `v-if` that
renders for one row and leaves a comment on the rest, which is the shape that triggered the bug:

| test | on `main` |
|------|-----------|
| built-in toggle renders when no `item.expand` slot is provided | passes (negative control) |
| no fallback toggle on a row the slot leaves empty | **fails** |
| expand cell stays empty instead of printing the row value | passes on `main`, **fails** against a partial fix that drops the cell-value guard |
| `item.expand` wins over the built-in toggle in the mobile card header | **fails** |

Full unit suite green (1366 tests), typecheck clean, no new lint warnings.
