### PR TITLE
fix(auto-complete): keep a value set before its options arrive

### DIFF
--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.spec.ts
@@ -218,6 +218,59 @@ describe('components/forms/auto-complete/RuiAutoComplete.vue', () => {
     });
   });
 
+  it('should not clear the selection when options load after the value', async () => {
+    // Async option lists start empty, so the value is set before its option exists.
+    wrapper = createWrapper<string, string>({
+      props: {
+        modelValue: 'Alice',
+        options: [],
+      },
+    });
+
+    // A first batch arrives that does not contain the selected value yet.
+    await wrapper.setProps({ options: ['Bob'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+
+    // Once the value's own option arrives, it resolves and renders.
+    await wrapper.setProps({ options: ['Alice', 'Bob'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    expect(wrapper.find<HTMLInputElement>('div[data-id=activator] input').element.value).toBe('Alice');
+  });
+
+  it('should not overwrite an empty-string model when options load', async () => {
+    // A consumer whose model is a plain `string` starts at '', which is never a valid
+    // option. Overwriting it with `undefined` breaks that model's declared type.
+    wrapper = createWrapper<string, string>({
+      props: {
+        modelValue: '',
+        options: [],
+      },
+    });
+
+    await wrapper.setProps({ options: ['Alice', 'Bob'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('should clear the selection when its option is removed from a loaded list', async () => {
+    wrapper = createWrapper<string, string>({
+      props: {
+        modelValue: 'Alice',
+        options: ['Alice', 'Bob'],
+      },
+    });
+
+    await wrapper.setProps({ options: ['Bob'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([undefined]);
+  });
+
   it('should multiple values', async () => {
     wrapper = createWrapper<string[], SelectOption>({
       props: {

--- a/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
+++ b/packages/ui-library/src/components/forms/auto-complete/RuiAutoComplete.vue
@@ -207,7 +207,7 @@ const shouldApplyValueAsSearch = computed<boolean>(
   () => !(slots.selection || get(multiple) || chips),
 );
 
-const { value, setSelected } = useAutoCompleteValue<AutoCompleteModelValue<TValue>, TItem>(
+const { resolveIn, value, setSelected } = useAutoCompleteValue<AutoCompleteModelValue<TValue>, TItem>(
   modelValue,
   () => options,
   {
@@ -488,6 +488,12 @@ watch(() => options, (curr, old) => {
 
   // Only do deep comparison if reference changed
   if (isEqual(curr, old))
+    return;
+
+  // Only reconcile a selection the previous options could actually resolve. A value
+  // that was already unresolvable is one the consumer set before its options arrived
+  // (async lists start empty), so clearing it here would discard a legitimate value.
+  if (!get(multiple) && resolveIn(old).length === 0)
     return;
 
   setSelected(get(value));

--- a/packages/ui-library/src/composables/forms/auto-complete/value.ts
+++ b/packages/ui-library/src/composables/forms/auto-complete/value.ts
@@ -14,6 +14,8 @@ export interface UseAutoCompleteValueOptions<TItem> {
 export interface UseAutoCompleteValueReturn<TItem> {
   value: ComputedRef<TItem[]>;
   setSelected: (selected: TItem[]) => void;
+  /** Resolves the current model value against an arbitrary options list. */
+  resolveIn: (options: TItem[]) => TItem[];
 }
 
 export interface UseAutoCompleteValueDeps<TItem> {
@@ -32,15 +34,16 @@ export function useAutoCompleteValue<TValue, TItem>(
   opts: UseAutoCompleteValueOptions<TItem>,
   deps: UseAutoCompleteValueDeps<TItem>,
 ): UseAutoCompleteValueReturn<TItem> {
-  // Create maps for O(1) lookup performance
-  const optionsMap = computed<Map<any, TItem>>(() => {
+  function buildOptionsMap(optionsData: TItem[]): Map<any, TItem> {
     const map = new Map<any, TItem>();
-    const optionsData = toValue(options);
     for (const item of optionsData) {
       map.set(deps.getIdentifier(item), item);
     }
     return map;
-  });
+  }
+
+  // Create maps for O(1) lookup performance
+  const optionsMap = computed<Map<any, TItem>>(() => buildOptionsMap(toValue(options)));
 
   function convertModelValueToArray(modelValueData: TValue | undefined): any[] {
     if (modelValueData === null || modelValueData === undefined)
@@ -112,19 +115,24 @@ export function useAutoCompleteValue<TValue, TItem>(
     return onUpdateModelValue(selection[0] as TValue);
   }
 
+  function resolveAgainst(optionsMapData: Map<any, TItem>): TItem[] {
+    const modelValueData = get(modelValue);
+    const keyAttr = toValue(opts.keyAttr);
+    const returnObject = toValue(opts.returnObject) ?? false;
+    const customValue = toValue(opts.customValue) ?? false;
+
+    if (keyAttr && returnObject)
+      return processReturnObjectValue(modelValueData, optionsMapData, returnObject, customValue);
+
+    return processStandardValue(modelValueData, optionsMapData, returnObject, customValue);
+  }
+
+  function resolveIn(optionsData: TItem[]): TItem[] {
+    return resolveAgainst(buildOptionsMap(optionsData));
+  }
+
   const value = computed<TItem[]>({
-    get: () => {
-      const modelValueData = get(modelValue);
-      const keyAttr = toValue(opts.keyAttr);
-      const returnObject = toValue(opts.returnObject) ?? false;
-      const customValue = toValue(opts.customValue) ?? false;
-      const optionsMapData = get(optionsMap);
-
-      if (keyAttr && returnObject)
-        return processReturnObjectValue(modelValueData, optionsMapData, returnObject, customValue);
-
-      return processStandardValue(modelValueData, optionsMapData, returnObject, customValue);
-    },
+    get: () => resolveAgainst(get(optionsMap)),
     set: (selected: TItem[]): void => {
       setSelected(selected);
     },
@@ -148,6 +156,7 @@ export function useAutoCompleteValue<TValue, TItem>(
   }, { immediate: true });
 
   return {
+    resolveIn,
     setSelected,
     value,
   };


### PR DESCRIPTION
A value set before its options arrive is destroyed. Async option lists start empty, and the options
watcher clears any selection the current options cannot resolve, so a preset value never survives
long enough to be resolved.

## What happens

```ts
watch(() => options, (curr, old) => {
  ...
  setSelected(get(value));
});
```

`value` resolves the model against `optionsMap` and drops whatever it cannot find (`filterValues` in
`value.ts`, unless `customValue`). `setSelected` turns an empty resolution into
`onUpdateModelValue(undefined)`. So on the first content change of an async list, a model the consumer
had already set is emitted away as `undefined`.

For single-select that watcher had no other job: when the value does resolve, `setSelected` writes
back exactly what was already there. Its whole single-select contribution was the clobber.

## The fix

Reconcile only a selection the **previous** options could resolve:

```ts
if (!get(multiple) && resolveIn(old).length === 0)
  return;
```

A value that was already unresolvable is one that arrived ahead of its options, so clearing it
discards something legitimate. Guarding on the *new* resolution being empty instead looks equivalent
and is not: it breaks clearing a selection whose option is genuinely removed from a loaded list,
which is intended behaviour and already covered by a test.

`resolveIn` factors the resolver out of the `value` getter so it can run against an arbitrary options
list. That extraction is pure, with no behaviour change.

## Tests

Three cases driving the real sequence through `setProps` plus a timer flush:

| test | asserts |
|------|---------|
| value survives options loading after it | no `update:modelValue` emitted while `['Bob']` then `['Alice','Bob']` arrive, and the input ends up showing `Alice` |
| an empty-string model is not overwritten | `''` (what a plain `string` model starts as, never a valid option) is left alone |
| a removed option still clears | `update:modelValue` emits `[undefined]` when `Alice` leaves a loaded list |

Negative control: with the guard disabled the first two fail and the third still passes, so they
discriminate and the fix is not simply switching the watcher off.

Full unit suite green (1365 tests, 80 files), typecheck clean, no new lint warnings.

## Not covered

Multi-select has the same exposure, where values are pruned before their options arrive. Fixing it
per item is a more invasive change and is deliberately left out of this one.
