### PR TITLE
feat(date-time-picker): accept an entry that omits the time

### DIFF
--- a/apps/example/e2e/datetimepicker.spec.ts
+++ b/apps/example/e2e/datetimepicker.spec.ts
@@ -479,6 +479,39 @@ test.describe('datetimepicker partial entries', () => {
     await expect(input).toHaveValue('15/01/2023 HH:mm:ss');
     await expect(page.getByTestId('picker-partial-strict-value')).toHaveText('');
   });
+
+  // The attribute is easy to assert in a unit test and proves nothing about what tab actually
+  // does, so the real key is pressed here against three fields standing in a row.
+  test('tab crosses a field in one stop rather than landing on its calendar toggle', async ({ page }) => {
+    const start = partialInput(page, 'start');
+    await start.focus();
+
+    await page.keyboard.press('Tab');
+
+    await expect(partialInput(page, 'end')).toBeFocused();
+  });
+
+  // What makes skipping the toggle acceptable: the field itself still opens the calendar.
+  test('the calendar is still reachable from the field without the toggle', async ({ page }) => {
+    const input = partialInput(page, 'start');
+    await input.focus();
+
+    await page.keyboard.press('Alt+ArrowDown');
+
+    await expect(page.getByRole('menu')).toBeVisible();
+  });
+
+  // A bound typed as a bare date is committed by tabbing out, the same as by clicking away.
+  test('tabbing out of the field commits a bare date', async ({ page }) => {
+    const input = partialInput(page, 'start');
+    await input.focus();
+    await page.keyboard.type('15012023');
+
+    await page.keyboard.press('Tab');
+
+    await expect(input).toHaveValue('15/01/2023 00:00:00');
+    await expect(page.getByTestId('picker-partial-start-value')).toHaveText(await epochOf(page, 0, 0, 0));
+  });
 });
 
 test.describe('datetimepicker footer actions against a bound', () => {

--- a/apps/example/e2e/datetimepicker.spec.ts
+++ b/apps/example/e2e/datetimepicker.spec.ts
@@ -375,6 +375,112 @@ test.describe('datetimepicker across a DST boundary', () => {
   });
 });
 
+test.describe('datetimepicker partial entries', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/datetimepickers');
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.keyboard.press('Escape');
+  });
+
+  // the three partial pickers start empty and emit an epoch, written out next to each field
+  function partialInput(page: Page, mode: 'start' | 'end' | 'strict') {
+    return page.getByTestId(`picker-partial-${mode}`).locator('input');
+  }
+
+  // computed in the browser, so the expectation follows the timezone the page runs in
+  async function epochOf(page: Page, hour: number, minute: number, second: number): Promise<string> {
+    return page.evaluate(
+      ([h, m, s]) => String(new Date(2023, 0, 15, h, m, s).getTime() / 1000),
+      [hour, minute, second],
+    );
+  }
+
+  test('a bare date becomes the start of its day when the field is left', async ({ page }) => {
+    const input = partialInput(page, 'start');
+    // focused rather than clicked, so the caret starts on the first segment and no calendar opens
+    await input.focus();
+    await page.keyboard.type('15012023');
+
+    // nothing is committed while the user is still in the field
+    await expect(page.getByTestId('picker-partial-start-value')).toHaveText('');
+
+    await page.getByTestId('picker-partial-section').getByRole('heading').click();
+
+    await expect(input).toHaveValue('15/01/2023 00:00:00');
+    await expect(page.getByTestId('picker-partial-start-value')).toHaveText(await epochOf(page, 0, 0, 0));
+  });
+
+  test('a bare date becomes the end of its day for the other bound', async ({ page }) => {
+    const input = partialInput(page, 'end');
+    await input.focus();
+    await page.keyboard.type('15012023');
+
+    await page.getByTestId('picker-partial-section').getByRole('heading').click();
+
+    await expect(input).toHaveValue('15/01/2023 23:59:59');
+    await expect(page.getByTestId('picker-partial-end-value')).toHaveText(await epochOf(page, 23, 59, 59));
+  });
+
+  test('enter commits without waiting for the field to be left', async ({ page }) => {
+    const input = partialInput(page, 'start');
+    await input.focus();
+    await page.keyboard.type('15012023');
+
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByTestId('picker-partial-start-value')).toHaveText(await epochOf(page, 0, 0, 0));
+    await expect(input).toBeFocused();
+  });
+
+  test('an hour entered on its own keeps its hour and fills the rest', async ({ page }) => {
+    const input = partialInput(page, 'end');
+    await input.focus();
+    await page.keyboard.type('1501202309');
+
+    await page.getByTestId('picker-partial-section').getByRole('heading').click();
+
+    await expect(input).toHaveValue('15/01/2023 09:59:59');
+    await expect(page.getByTestId('picker-partial-end-value')).toHaveText(await epochOf(page, 9, 59, 59));
+  });
+
+  // the mouse path leaves the time out just as typing does: the field starts empty, so the
+  // calendar opens on the current month and today is the day that is there to be clicked
+  test('a day picked in the calendar is committed once the user leaves the field', async ({ page }) => {
+    const input = partialInput(page, 'start');
+    await input.click();
+
+    const today = await page.evaluate(() => {
+      const now = new Date();
+      const pad = (value: number): string => value.toString().padStart(2, '0');
+      return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+    });
+    await page.getByRole('grid').getByTestId(today).click();
+
+    // a date on its own is not yet a value
+    await expect(page.getByTestId('picker-partial-start-value')).toHaveText('');
+
+    await page.keyboard.press('Escape');
+    await page.getByTestId('picker-partial-section').getByRole('heading').click();
+
+    await expect(input).toHaveValue(/^\d{2}\/\d{2}\/\d{4} 00:00:00$/);
+    await expect(page.getByTestId('picker-partial-start-value')).not.toHaveText('');
+  });
+
+  // the control: without partial-time the same entry is still not a value
+  test('a bare date stays uncommitted without the prop', async ({ page }) => {
+    const input = partialInput(page, 'strict');
+    await input.focus();
+    await page.keyboard.type('15012023');
+
+    await page.getByTestId('picker-partial-section').getByRole('heading').click();
+
+    await expect(input).toHaveValue('15/01/2023 HH:mm:ss');
+    await expect(page.getByTestId('picker-partial-strict-value')).toHaveText('');
+  });
+});
+
 test.describe('datetimepicker footer actions against a bound', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/datetimepickers');

--- a/apps/example/src/views/DateTimePickerView.vue
+++ b/apps/example/src/views/DateTimePickerView.vue
@@ -14,6 +14,11 @@ const allActionsValue = ref<Date | undefined>(new Date(2023, 0, 2, 20, 20));
 const timezoneValue = ref<Date | undefined>(new Date(2023, 0, 2, 20, 20));
 const boundedValue = ref<Date | undefined>(new Date(2023, 0, 2, 20, 20));
 const boundedMax = new Date(2023, 0, 10, 12, 0);
+// left empty so a test can type an entry that stops short of the full format; the strict one is
+// the control, with no partial-time at all
+const partialStartValue = ref<number>();
+const partialEndValue = ref<number>();
+const partialStrictValue = ref<number>();
 const parentMenuOpen = ref<boolean>(false);
 const pickerMenuOpen = ref<boolean>(false);
 const insideMenuValue = ref<Date | undefined>(new Date(2023, 0, 2, 20, 20));
@@ -79,6 +84,45 @@ const insideMenuValue = ref<Date | undefined>(new Date(2023, 0, 2, 20, 20));
         :max-date="boundedMax"
         variant="outlined"
       />
+    </div>
+    <div
+      class="mt-8"
+      data-id="picker-partial-section"
+    >
+      <h3 class="text-lg font-semibold mb-4">
+        Partial entries
+      </h3>
+      <RuiDateTimePicker
+        v-model="partialStartValue"
+        data-id="picker-partial-start"
+        accuracy="second"
+        allow-empty
+        partial-time="start"
+        type="epoch"
+        variant="outlined"
+      />
+      <span data-id="picker-partial-start-value">{{ partialStartValue ?? '' }}</span>
+      <RuiDateTimePicker
+        v-model="partialEndValue"
+        class="mt-4"
+        data-id="picker-partial-end"
+        accuracy="second"
+        allow-empty
+        partial-time="end"
+        type="epoch"
+        variant="outlined"
+      />
+      <span data-id="picker-partial-end-value">{{ partialEndValue ?? '' }}</span>
+      <RuiDateTimePicker
+        v-model="partialStrictValue"
+        class="mt-4"
+        data-id="picker-partial-strict"
+        accuracy="second"
+        allow-empty
+        type="epoch"
+        variant="outlined"
+      />
+      <span data-id="picker-partial-strict-value">{{ partialStrictValue ?? '' }}</span>
     </div>
     <div
       class="mt-8"

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.spec.ts
@@ -2356,6 +2356,167 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
     });
   });
 
+  describe('partial entries', () => {
+    async function typeDigits(input: ReturnType<VueWrapper['find']>, digits: string): Promise<void> {
+      await input.trigger('focus');
+      await vi.runOnlyPendingTimersAsync();
+      for (const key of digits) {
+        await input.trigger('keydown', { key });
+      }
+      await vi.runOnlyPendingTimersAsync();
+    }
+
+    function lastEmitted(): number | undefined {
+      const emitted = wrapper.emitted('update:modelValue');
+      return emitted?.at(-1)?.[0] as number | undefined;
+    }
+
+    // the field is useless as a filter bound if a date typed on its own is silently dropped
+    it('should commit a bare date on blur', async () => {
+      wrapper = createWrapper({
+        attachTo: document.body,
+        props: {
+          accuracy: 'second',
+          allowEmpty: true,
+          modelValue: undefined,
+          partialTime: 'start',
+          type: 'epoch',
+        },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      const input = wrapper.find('input');
+      await typeDigits(input, '15012023');
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+
+      await input.trigger('blur');
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(lastEmitted()).toBe(dayjs(new Date(2023, 0, 15, 0, 0, 0)).unix());
+      // the filled time is on screen rather than left for the user to infer
+      expect(input.element.value).toBe('15/01/2023 00:00:00');
+    });
+
+    it('should commit a bare date to the end of the day', async () => {
+      wrapper = createWrapper({
+        attachTo: document.body,
+        props: {
+          accuracy: 'second',
+          allowEmpty: true,
+          modelValue: undefined,
+          partialTime: 'end',
+          type: 'epoch',
+        },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      const input = wrapper.find('input');
+      await typeDigits(input, '15012023');
+      await input.trigger('blur');
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(lastEmitted()).toBe(dayjs(new Date(2023, 0, 15, 23, 59, 59)).unix());
+      expect(input.element.value).toBe('15/01/2023 23:59:59');
+    });
+
+    // a consumer that closes its editor on enter unmounts the field before a blur can arrive
+    it('should commit on enter', async () => {
+      wrapper = createWrapper({
+        attachTo: document.body,
+        props: {
+          accuracy: 'second',
+          allowEmpty: true,
+          modelValue: undefined,
+          partialTime: 'start',
+          type: 'epoch',
+        },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      const input = wrapper.find('input');
+      await typeDigits(input, '15012023');
+
+      await input.trigger('keydown', { key: 'Enter' });
+
+      // synchronously, while the key is still bubbling towards that editor
+      expect(lastEmitted()).toBe(dayjs(new Date(2023, 0, 15, 0, 0, 0)).unix());
+    });
+
+    // escape closes a consumer's editor as readily as enter, and it discards nothing here
+    it('should commit on escape once the calendar is shut', async () => {
+      wrapper = createWrapper({
+        attachTo: document.body,
+        props: {
+          accuracy: 'second',
+          allowEmpty: true,
+          modelValue: undefined,
+          partialTime: 'end',
+          type: 'epoch',
+        },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      const input = wrapper.find('input');
+      await typeDigits(input, '15012023');
+
+      await input.trigger('keydown', { key: 'Escape' });
+
+      expect(lastEmitted()).toBe(dayjs(new Date(2023, 0, 15, 23, 59, 59)).unix());
+    });
+
+    // blurring into the open calendar is not the user being done with the field
+    it('should wait for the calendar to close rather than commit on the blur into it', async () => {
+      wrapper = createWrapper({
+        attachTo: document.body,
+        props: {
+          accuracy: 'second',
+          allowEmpty: true,
+          modelValue: undefined,
+          partialTime: 'start',
+          type: 'epoch',
+        },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      const input = wrapper.find('input');
+      await typeDigits(input, '15012023');
+
+      await input.trigger('click');
+      await vi.runOnlyPendingTimersAsync();
+      await input.trigger('blur');
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+
+      await input.trigger('keydown', { key: 'Escape' });
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(lastEmitted()).toBe(dayjs(new Date(2023, 0, 15, 0, 0, 0)).unix());
+    });
+
+    it('should leave a bare date uncommitted without the prop', async () => {
+      wrapper = createWrapper({
+        attachTo: document.body,
+        props: {
+          accuracy: 'second',
+          allowEmpty: true,
+          modelValue: undefined,
+          type: 'epoch',
+        },
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      const input = wrapper.find('input');
+      await typeDigits(input, '15012023');
+      await input.trigger('blur');
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+      expect(input.element.value).toBe('15/01/2023 HH:mm:ss');
+    });
+  });
+
   describe('hide details', () => {
     it('should hide details when hideDetails is true', async () => {
       wrapper = createWrapper({

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.spec.ts
@@ -2858,6 +2858,24 @@ describe('components/date-time-picker/RuiDateTimePicker.vue', () => {
       expect(wrapper.find('button[data-id="append"]').attributes('aria-label')).toBe('Close the calendar');
     });
 
+    // Tabbing through a form should cross a date field in one stop, not two, and a from/to pair
+    // in two rather than four. The button is safe to skip because alt+arrowdown on the field
+    // does the same job, which the test below pins.
+    it('keeps the calendar toggle out of the tab order', () => {
+      wrapper = createWrapper({
+        props: {
+          modelValue: new Date(),
+        },
+      });
+
+      const toggle = wrapper.find('button[data-id="append"]');
+      expect(toggle.exists()).toBe(true);
+      expect(toggle.attributes('tabindex')).toBe('-1');
+      // still a real button, so it keeps announcing what it is and whether it is open
+      expect(toggle.attributes('aria-haspopup')).toBe('dialog');
+      expect(toggle.attributes('aria-label')).toBe('Open the calendar');
+    });
+
     it('leaves the clear button in the tab order', async () => {
       wrapper = createWrapper({
         props: {

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -598,9 +598,15 @@ defineExpose({
           />
         </RuiButton>
 
+        <!-- Out of the tab sequence, following the combobox pattern: the button only duplicates
+             Alt+ArrowDown on the field, so leaving it in cost two stops to cross one date field
+             and four to cross a from/to pair, for nothing a keyboard user could not already do.
+             It stays a real button, so it keeps its label and its expanded state for anyone
+             reaching it by any other means. -->
         <button
           v-if="!disabled && !readonly"
           type="button"
+          tabindex="-1"
           :class="ui.iconWrapper()"
           data-id="append"
           :aria-label="toggleLabel"

--- a/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
+++ b/packages/ui-library/src/components/date-time-picker/RuiDateTimePicker.vue
@@ -63,6 +63,22 @@ export interface RuiDateTimePickerProps {
    * for a picker revealed by an editor or a dialog.
    */
   autofocus?: boolean;
+  /**
+   * Accepts an entry that stops short of the full format, filling the segments
+   * it never reached from one end of the day: `start` gives a bare date
+   * 00:00:00.000 and `end` gives it 23:59:59.999. Meant for a range, where the
+   * two bounds want opposite ends. Left unset, an entry missing its time is not
+   * a value and nothing is emitted.
+   *
+   * The fill runs when the user is done with the field - leaving it, pressing
+   * enter, or closing the calendar - and is written back into the segments, so
+   * what it decided on is on screen.
+   *
+   * Spelled out rather than written as `PartialTimeMode`: a consumer that hands
+   * this whole interface to its own `defineProps` needs every member resolvable
+   * by the SFC compiler, which does not follow the type into the package.
+   */
+  partialTime?: 'start' | 'end';
 }
 
 defineOptions({
@@ -93,6 +109,7 @@ const {
   showTimezone = false,
   actions = ['now'],
   autofocus = false,
+  partialTime,
 } = defineProps<RuiDateTimePickerProps>();
 
 defineSlots<{
@@ -146,6 +163,7 @@ const dateFormat = computed<string>(() => {
 
 const {
   clear: clearSelection,
+  commitPartialTime,
   getDateTime,
   internalErrorMessages,
   maxAllowedDate,
@@ -171,6 +189,7 @@ const {
   maxDate,
   minDate,
   modelValue,
+  partialTime,
   type,
 });
 
@@ -346,6 +365,23 @@ function clear(segmentType?: string): void {
   clearSegment(segmentType);
 }
 
+/**
+ * An entry left incomplete is completed once the user is done with the field,
+ * never while they are still filling it in: a half typed hour is not a segment
+ * they left out. Leaving the field counts, unless the calendar is open, since
+ * then the focus is only moving into it and the menu closing covers that.
+ */
+function onBlur(): void {
+  handleBlur();
+  if (!get(isOpen))
+    commitPartialTime();
+}
+
+watch(isOpen, (open) => {
+  if (!open && !get(searchInputFocused))
+    commitPartialTime();
+});
+
 function handleInputClick(event: MouseEvent): void {
   // Handle segment selection first, before any DOM changes from menu opening
   handleClick(event);
@@ -421,6 +457,15 @@ function onKeyDown(event: KeyboardEvent): void {
     set(isOpen, false);
     return;
   }
+
+  // Enter and Escape are the other ways to be done with the field, and the keys
+  // a consumer tends to close its editor on. Escape reaches here only once the
+  // calendar is already shut, and it discards nothing - the segments stay on
+  // screen either way - so it commits what was entered rather than dropping it
+  // when the field goes. Both write the value before the key carries on
+  // bubbling, so it survives that close.
+  if (event.key === 'Enter' || event.key === 'Escape')
+    commitPartialTime();
 
   handleKeyDown(event);
 }
@@ -523,7 +568,7 @@ defineExpose({
             :aria-required="required || undefined"
             @mousedown="handleMouseDown($event)"
             @focus="handleFocus()"
-            @blur="handleBlur()"
+            @blur="onBlur()"
             @select="handleInputSelection($event)"
             @click.stop="handleInputClick($event)"
             @keydown="onKeyDown($event)"

--- a/packages/ui-library/src/components/date-time-picker/partial-time.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/partial-time.spec.ts
@@ -1,0 +1,73 @@
+import dayjs from 'dayjs';
+import { describe, expect, it } from 'vitest';
+import { completePartialEntry } from './partial-time';
+
+describe('completePartialEntry', () => {
+  const date = { day: 15, month: 6, year: 2023 };
+  const bounds = { maxDate: undefined, minDate: new Date(1970, 0, 1) };
+
+  function format(value: ReturnType<typeof completePartialEntry>): string | undefined {
+    return value?.format('DD/MM/YYYY HH:mm:ss.SSS');
+  }
+
+  it('should give a bare date the start of its day', () => {
+    const result = completePartialEntry(date, { ...bounds, accuracy: 'second', mode: 'start' });
+
+    expect(format(result)).toBe('15/06/2023 00:00:00.000');
+  });
+
+  it('should give a bare date the end of its day', () => {
+    const result = completePartialEntry(date, { ...bounds, accuracy: 'second', mode: 'end' });
+
+    // the accuracy stops at the second, so the milliseconds are not the fill's to set
+    expect(format(result)).toBe('15/06/2023 23:59:59.000');
+  });
+
+  it('should run to the last millisecond when the accuracy exposes them', () => {
+    const result = completePartialEntry(date, { ...bounds, accuracy: 'millisecond', mode: 'end' });
+
+    expect(format(result)).toBe('15/06/2023 23:59:59.999');
+  });
+
+  it('should keep the segments the entry did reach', () => {
+    const result = completePartialEntry({ ...date, hour: 9 }, { ...bounds, accuracy: 'second', mode: 'end' });
+
+    expect(format(result)).toBe('15/06/2023 09:59:59.000');
+  });
+
+  it('should return nothing for an entry with no gaps left', () => {
+    const complete = { ...date, hour: 9, minute: 30, second: 15 };
+
+    expect(completePartialEntry(complete, { ...bounds, accuracy: 'second', mode: 'end' })).toBeUndefined();
+  });
+
+  // at this accuracy the second is not a segment the entry could have reached
+  it('should ignore a missing second the accuracy does not expose', () => {
+    const entry = { ...date, hour: 9, minute: 30 };
+
+    expect(completePartialEntry(entry, { ...bounds, accuracy: 'minute', mode: 'end' })).toBeUndefined();
+  });
+
+  it('should return nothing while the date itself is incomplete', () => {
+    const entry = { day: 15, month: 6 };
+
+    expect(completePartialEntry(entry, { ...bounds, accuracy: 'second', mode: 'start' })).toBeUndefined();
+  });
+
+  it('should pull a fill that overshot back to the bound', () => {
+    const maxDate = new Date(2023, 5, 15, 14, 30, 45);
+
+    const result = completePartialEntry(date, { ...bounds, accuracy: 'second', maxDate, mode: 'end' });
+
+    expect(result?.valueOf()).toBe(dayjs(maxDate).valueOf());
+  });
+
+  // clamping here would move the day the user typed, which is theirs to fix
+  it('should leave a date that is out of range where it is', () => {
+    const maxDate = new Date(2023, 5, 10, 12, 0);
+
+    const result = completePartialEntry(date, { ...bounds, accuracy: 'second', maxDate, mode: 'end' });
+
+    expect(format(result)).toBe('15/06/2023 23:59:59.000');
+  });
+});

--- a/packages/ui-library/src/components/date-time-picker/partial-time.ts
+++ b/packages/ui-library/src/components/date-time-picker/partial-time.ts
@@ -1,0 +1,87 @@
+import type { Dayjs } from 'dayjs';
+import type { TimeAccuracy } from '@/consts/time-accuracy';
+import { buildDateTime, clampToBounds, type SegmentValues } from '@/components/date-time-picker/segment-utils';
+import { includeMilliseconds, includeSeconds } from '@/components/date-time-picker/utils';
+
+/**
+ * Which end of the entered precision an incomplete entry stands for. `start`
+ * fills the segments it never reached with their lowest value and `end` with
+ * their highest, so a bare date means the whole day from either side.
+ */
+export type PartialTimeMode = 'start' | 'end';
+
+interface PartialTimeOptions {
+  mode: PartialTimeMode;
+  accuracy: TimeAccuracy;
+  minDate: Date;
+  maxDate: Date | undefined;
+}
+
+type TimeSegments = Pick<SegmentValues, 'hour' | 'minute' | 'second' | 'millisecond'>;
+
+/** What each side of the day fills a segment the entry never reached with. */
+const FALLBACKS: Record<PartialTimeMode, Required<TimeSegments>> = {
+  end: { hour: 23, millisecond: 999, minute: 59, second: 59 },
+  start: { hour: 0, millisecond: 0, minute: 0, second: 0 },
+};
+
+/**
+ * Reads the segments an entry does hold, with the ones its accuracy does not
+ * expose already answered: those cannot be left out, so they never count as
+ * missing.
+ */
+function timeSegments(segments: SegmentValues, accuracy: TimeAccuracy): TimeSegments {
+  return {
+    hour: segments.hour,
+    millisecond: includeMilliseconds(accuracy) ? segments.millisecond : 0,
+    minute: segments.minute,
+    second: includeSeconds(accuracy) ? segments.second : 0,
+  };
+}
+
+/**
+ * Completes an entry that stopped short of the full format, so a bare date - or
+ * a date and an hour - can still become a value. Returns nothing when there is
+ * nothing to complete: no date to build on, or every segment already entered.
+ *
+ * The result is pulled back inside the bounds when the fill overshot them. The
+ * date is the user's and the filled time is ours, so an `end` fill on today
+ * against a `now` maximum is answered with that maximum rather than refused.
+ * A clamp landing on another day means the date itself is out of range, which
+ * is the user's to fix, so that is handed back unclamped to be rejected with an
+ * error the user can read.
+ *
+ * The fill reaches as far as the entry does. A date and a time down to the
+ * minute is already a value, which its field emits and reads back with a zero
+ * second, and from then on that second is part of the entry rather than a gap
+ * in it: `end` therefore means the last second of a bare date, and the zeroth
+ * second of a date entered with its minutes.
+ */
+export function completePartialEntry(
+  segments: SegmentValues,
+  { accuracy, maxDate, minDate, mode }: PartialTimeOptions,
+): Dayjs | undefined {
+  const { day, month, year } = segments;
+  if (year === undefined || month === undefined || day === undefined)
+    return undefined;
+
+  const time = timeSegments(segments, accuracy);
+  const complete = time.hour !== undefined && time.minute !== undefined
+    && time.second !== undefined && time.millisecond !== undefined;
+  if (complete)
+    return undefined;
+
+  const fallback = FALLBACKS[mode];
+  const candidate = buildDateTime({
+    day,
+    hour: time.hour ?? fallback.hour,
+    millisecond: time.millisecond ?? fallback.millisecond,
+    minute: time.minute ?? fallback.minute,
+    month,
+    second: time.second ?? fallback.second,
+    year,
+  }, accuracy);
+
+  const clamped = clampToBounds(candidate, minDate, maxDate);
+  return clamped.isSame(candidate, 'day') ? clamped : candidate;
+}

--- a/packages/ui-library/src/components/date-time-picker/use-date-bounds.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-date-bounds.ts
@@ -1,0 +1,94 @@
+import type { ComputedRef, Ref } from 'vue';
+import dayjs, { type Dayjs } from 'dayjs';
+import { resolveBound } from '@/components/date-time-picker/segment-utils';
+import { useRuiI8n } from '@/composables/use-rui-i18n';
+import { RUI_I18N_KEYS } from '@/i18n/keys';
+
+interface DateBoundsOptions {
+  minDate: Date | number | undefined;
+  maxDate: Date | number | 'now' | undefined;
+  /** Whether a numeric bound is stated in whole seconds rather than milliseconds. */
+  epochSeconds: boolean;
+  /**
+   * The field's own format, so a bound named in an error message is written the
+   * same way round as the value the user is looking at.
+   */
+  dateFormat: Ref<string>;
+  /** The clock a `now` maximum follows, kept current by the caller. */
+  now: Ref<Dayjs>;
+}
+
+interface DateBoundsReturn {
+  minAllowedDate: ComputedRef<Date>;
+  maxAllowedDate: ComputedRef<Date | undefined>;
+  internalErrorMessages: Ref<string[]>;
+  isDateValid: (date: Dayjs) => boolean;
+}
+
+/**
+ * The range a picked date has to sit in, and the message explaining a date that
+ * does not.
+ */
+export function useDateBounds({
+  dateFormat,
+  epochSeconds,
+  maxDate,
+  minDate,
+  now,
+}: DateBoundsOptions): DateBoundsReturn {
+  const { t } = useRuiI8n();
+
+  const internalErrorMessages = ref<string[]>([]);
+
+  const minAllowedDate = computed<Date>(
+    () => resolveBound(minDate, epochSeconds) ?? new Date(1970, 0, 1),
+  );
+
+  const maxAllowedDate = computed<Date | undefined>(
+    () => (maxDate === 'now' ? get(now).toDate() : resolveBound(maxDate, epochSeconds)),
+  );
+
+  /**
+   * Writes a bound the way the field writes its value. `toLocaleDateString()`
+   * followed the browser locale and ignored the picker's own format, so a
+   * day-first field could report its limit month-first, and it dropped the time
+   * entirely, which left a mid-day bound unable to explain itself.
+   */
+  function formatBound(bound: Date): string {
+    return dayjs(bound).format(get(dateFormat));
+  }
+
+  function isDateValid(date: Dayjs): boolean {
+    const min = get(minAllowedDate);
+    const max = get(maxAllowedDate);
+
+    set(internalErrorMessages, []);
+
+    if (min && date.isBefore(min)) {
+      const formatted = formatBound(min);
+      const errorMessage = t(RUI_I18N_KEYS.dateTimePicker.dateBeforeMin, {
+        date: formatted,
+      }, `Date cannot be before ${formatted}`);
+      set(internalErrorMessages, [...get(internalErrorMessages), errorMessage]);
+      return false;
+    }
+
+    if (max && date.isAfter(max)) {
+      const formatted = formatBound(max);
+      const nowError = t(RUI_I18N_KEYS.dateTimePicker.dateInFuture, 'The selected date cannot be in the future');
+      const maxError = t(RUI_I18N_KEYS.dateTimePicker.dateAfterMax, { date: formatted }, `Date cannot be after ${formatted}`);
+      const errorMessage = maxDate === 'now' ? nowError : maxError;
+      set(internalErrorMessages, [...get(internalErrorMessages), errorMessage]);
+      return false;
+    }
+
+    return true;
+  }
+
+  return {
+    internalErrorMessages,
+    isDateValid,
+    maxAllowedDate,
+    minAllowedDate,
+  };
+}

--- a/packages/ui-library/src/components/date-time-picker/use-date-time-selection.spec.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-date-time-selection.spec.ts
@@ -1236,4 +1236,259 @@ describe('use-date-time-selection', () => {
       unmount();
     });
   });
+
+  describe('partial time', () => {
+    function setDate(result: ReturnType<typeof useDateTimeSelection>): void {
+      set(result.selectedYear, 2023);
+      set(result.selectedMonth, 6);
+      set(result.selectedDay, 15);
+    }
+
+    it('should leave an incomplete entry uncommitted without the option', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        type: 'epoch-ms',
+      }));
+
+      setDate(result);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(get(result.selectedHour)).toBeUndefined();
+
+      unmount();
+    });
+
+    it('should give a bare date the start of its day', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        partialTime: 'start',
+        type: 'epoch-ms',
+      }));
+
+      setDate(result);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 0, 0, 0).getTime());
+      // the fill is written back, so the field shows the value it decided on
+      expect(get(result.selectedHour)).toBe(0);
+      expect(get(result.selectedMinute)).toBe(0);
+      expect(get(result.selectedSecond)).toBe(0);
+
+      unmount();
+    });
+
+    it('should give a bare date the end of its day', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        partialTime: 'end',
+        type: 'epoch-ms',
+      }));
+
+      setDate(result);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 23, 59, 59).getTime());
+      expect(get(result.selectedHour)).toBe(23);
+      expect(get(result.selectedMinute)).toBe(59);
+      expect(get(result.selectedSecond)).toBe(59);
+
+      unmount();
+    });
+
+    it('should fill only the segments left out', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        partialTime: 'end',
+        type: 'epoch-ms',
+      }));
+
+      setDate(result);
+      set(result.selectedHour, 9);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      // the typed hour stands; the minute and second it stopped short of run to the end
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 9, 59, 59).getTime());
+
+      unmount();
+    });
+
+    // hour and minute are already enough to make a value, which is emitted and read back with a
+    // zero second, so from here on the second is a value the entry holds rather than one it left
+    // out. The fill only covers the segments an entry never reached.
+    it('should treat a time entered down to the minute as complete', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        partialTime: 'end',
+        type: 'epoch-ms',
+      }));
+
+      setDate(result);
+      set(result.selectedHour, 9);
+      set(result.selectedMinute, 30);
+      await nextTick();
+
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 9, 30, 0).getTime());
+
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 9, 30, 0).getTime());
+      expect(get(result.selectedSecond)).toBe(0);
+
+      unmount();
+    });
+
+    it('should not touch an entry that is already complete', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        partialTime: 'end',
+        type: 'epoch-ms',
+      }));
+
+      setDate(result);
+      set(result.selectedHour, 9);
+      set(result.selectedMinute, 30);
+      set(result.selectedSecond, 15);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 9, 30, 15).getTime());
+      expect(get(result.selectedSecond)).toBe(15);
+
+      unmount();
+    });
+
+    it('should ignore a date that is still incomplete', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: undefined,
+        minDate: undefined,
+        modelValue,
+        partialTime: 'start',
+        type: 'epoch-ms',
+      }));
+
+      set(result.selectedDay, 15);
+      set(result.selectedMonth, 6);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(get(result.selectedHour)).toBeUndefined();
+
+      unmount();
+    });
+
+    it('should pull the fill back to a bound it overshot', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: 'now',
+        minDate: undefined,
+        modelValue,
+        partialTime: 'end',
+        type: 'epoch-ms',
+      }));
+
+      // today, so the end of the day the fill asks for sits in the future
+      setDate(result);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      expect(get(modelValue)).toBe(new Date(2023, 5, 15, 14, 30, 45).getTime());
+      expect(get(result.internalErrorMessages)).toEqual([]);
+
+      unmount();
+    });
+
+    it('should refuse a date out of range rather than move it', async () => {
+      const modelValue = ref<number | undefined>(undefined);
+
+      const { result, unmount } = withSetup(() => useDateTimeSelection({
+        accuracy: 'second',
+        allowEmpty: true,
+        dateFormat,
+        maxDate: 'now',
+        minDate: undefined,
+        modelValue,
+        partialTime: 'end',
+        type: 'epoch-ms',
+      }));
+
+      set(result.selectedYear, 2030);
+      set(result.selectedMonth, 6);
+      set(result.selectedDay, 15);
+      await nextTick();
+      result.commitPartialTime();
+      await nextTick();
+
+      // the day is the user's to fix, so it keeps its error instead of being pulled to now
+      expect(get(modelValue)).toBeUndefined();
+      expect(get(result.selectedYear)).toBe(2030);
+      expect(get(result.internalErrorMessages).length).toBeGreaterThan(0);
+
+      unmount();
+    });
+  });
 });

--- a/packages/ui-library/src/components/date-time-picker/use-date-time-selection.ts
+++ b/packages/ui-library/src/components/date-time-picker/use-date-time-selection.ts
@@ -2,10 +2,10 @@ import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
 import type { SegmentData } from '@/components/date-time-picker/types';
 import type { TimeAccuracy } from '@/consts/time-accuracy';
 import dayjs, { type Dayjs } from 'dayjs';
-import { buildDateTime, clampToBounds, resolveBound } from '@/components/date-time-picker/segment-utils';
+import { completePartialEntry, type PartialTimeMode } from '@/components/date-time-picker/partial-time';
+import { buildDateTime, clampToBounds } from '@/components/date-time-picker/segment-utils';
+import { useDateBounds } from '@/components/date-time-picker/use-date-bounds';
 import { formatWallClock, guessTimezone, includeMilliseconds, includeSeconds } from '@/components/date-time-picker/utils';
-import { useRuiI8n } from '@/composables/use-rui-i18n';
-import { RUI_I18N_KEYS } from '@/i18n/keys';
 import '@/components/date-time-picker/dayjs-setup';
 
 type DateTimeModelType = 'date' | 'epoch-ms' | 'epoch';
@@ -28,6 +28,8 @@ interface DateTimeSelectionOptions<T extends DateTimeModelType> {
    * same way round as the value the user is looking at.
    */
   dateFormat: Ref<string>;
+  /** See {@link completePartialEntry}; unset, an incomplete entry is not a value. */
+  partialTime?: PartialTimeMode;
 }
 
 interface DateTimeSelectionReturn {
@@ -50,6 +52,7 @@ interface DateTimeSelectionReturn {
   getDateTime: () => Dayjs;
   setNow: () => void;
   setToday: () => void;
+  commitPartialTime: () => void;
   clear: () => void;
   isDateValid: (date: Dayjs) => boolean;
 }
@@ -66,10 +69,9 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
     maxDate,
     minDate,
     modelValue,
+    partialTime,
     type,
   } = options;
-
-  const { t } = useRuiI8n();
 
   const selectedYear = ref<number | undefined>();
   const selectedMonth = ref<number | undefined>();
@@ -81,18 +83,15 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
   const selectedMillisecond = ref<number | undefined>();
   const selectedTimezone = ref<string | undefined>(guessTimezone());
 
-  const internalErrorMessages = ref<string[]>([]);
   const now = ref<Dayjs>(dayjs.tz(undefined, guessTimezone()));
 
-  const epochSeconds = type === 'epoch';
-
-  const minAllowedDate = computed<Date>(
-    () => resolveBound(minDate, epochSeconds) ?? new Date(1970, 0, 1),
-  );
-
-  const maxAllowedDate = computed<Date | undefined>(
-    () => (maxDate === 'now' ? get(now).toDate() : resolveBound(maxDate, epochSeconds)),
-  );
+  const { internalErrorMessages, isDateValid, maxAllowedDate, minAllowedDate } = useDateBounds({
+    dateFormat,
+    epochSeconds: type === 'epoch',
+    maxDate,
+    minDate,
+    now,
+  });
 
   const segmentData: SegmentData = {
     DD: selectedDay,
@@ -159,43 +158,6 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
       second: get(selectedSecond),
       year: get(selectedYear),
     }, accuracy);
-  }
-
-  /**
-   * Writes a bound the way the field writes its value. `toLocaleDateString()`
-   * followed the browser locale and ignored the picker's own format, so a
-   * day-first field could report its limit month-first, and it dropped the time
-   * entirely, which left a mid-day bound unable to explain itself.
-   */
-  function formatBound(bound: Date): string {
-    return dayjs(bound).format(get(dateFormat));
-  }
-
-  function isDateValid(date: Dayjs): boolean {
-    const min = get(minAllowedDate);
-    const max = get(maxAllowedDate);
-
-    set(internalErrorMessages, []);
-
-    if (min && date.isBefore(min)) {
-      const formatted = formatBound(min);
-      const errorMessage = t(RUI_I18N_KEYS.dateTimePicker.dateBeforeMin, {
-        date: formatted,
-      }, `Date cannot be before ${formatted}`);
-      set(internalErrorMessages, [...get(internalErrorMessages), errorMessage]);
-      return false;
-    }
-
-    if (max && date.isAfter(max)) {
-      const formatted = formatBound(max);
-      const nowError = t(RUI_I18N_KEYS.dateTimePicker.dateInFuture, 'The selected date cannot be in the future');
-      const maxError = t(RUI_I18N_KEYS.dateTimePicker.dateAfterMax, { date: formatted }, `Date cannot be after ${formatted}`);
-      const errorMessage = maxDate === 'now' ? nowError : maxError;
-      set(internalErrorMessages, [...get(internalErrorMessages), errorMessage]);
-      return false;
-    }
-
-    return true;
   }
 
   function emitUpdate(updatedModel: Dayjs): void {
@@ -335,6 +297,42 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
     updateModelValue();
   });
 
+  /**
+   * Fills in the segments an incomplete entry never reached and commits it, so
+   * a bare date can become a value. Called when the user is done with the field
+   * rather than on every keystroke, since a segment still being typed is not
+   * yet one they left out. The fill is written back into the field, so the
+   * value it decided on is the one on screen.
+   */
+  function commitPartialTime(): void {
+    if (partialTime === undefined)
+      return;
+
+    const target = completePartialEntry({
+      day: get(selectedDay),
+      hour: get(selectedHour),
+      millisecond: get(selectedMillisecond),
+      minute: get(selectedMinute),
+      month: get(selectedMonth),
+      second: get(selectedSecond),
+      year: get(selectedYear),
+    }, {
+      accuracy,
+      maxDate: get(maxAllowedDate),
+      minDate: get(minAllowedDate),
+      mode: partialTime,
+    });
+
+    if (!target)
+      return;
+
+    // The model is written here rather than left to the watcher: this runs on blur and on enter,
+    // and a consumer that closes the field on that key would drop a value the watcher only emits
+    // on the next tick.
+    ignoreUpdates(() => applySegments(target));
+    updateModelValue();
+  }
+
   function updateInternalModel(value: ModelValueType<T>): void {
     ignoreUpdates(() => {
       const updatedValue = type === 'epoch' && typeof value === 'number'
@@ -374,6 +372,7 @@ export function useDateTimeSelection<T extends DateTimeModelType>(
 
   return {
     clear,
+    commitPartialTime,
     getDateTime,
     internalErrorMessages,
     isDateValid,


### PR DESCRIPTION
Two commits against the date time picker, both driven by what a date range in a filter bar needs.

### Accept an entry that omits the time

A date typed on its own was dropped. The model was only written once year, month, day, hour and minute were all set, so a date-only entry produced no value and no error: the field simply stayed empty.

The new `partial-time` prop names which end of the day an incomplete entry stands for, `start` or `end`. The segments the entry never reached are filled from that when the user is done with the field (leaving it, pressing enter or escape, or closing the calendar), and the fill is written back into the segments so the value it decided on is visible rather than hidden in the model.

- The fill is pulled inside the bounds when it overshoots, which is what an `end` fill on today against a `now` maximum needs. A date that is itself out of range keeps its error instead of being quietly moved.
- Escape commits rather than discards. It reaches the field only once the calendar is shut, the segments stay on screen either way, and a consumer that closes its editor on that key would otherwise lose the entry.
- Seconds were already optional, so `end` means 23:59:59 for a bare date but 09:30:00 for a date typed to the minute. Once a value is emitted it is read back with a zero second, which from then on is part of the entry rather than a gap in it.
- Left unset, the field behaves exactly as before.

### Skip the calendar toggle when tabbing

The append chevron is a real button, so tabbing through a form stopped on it before moving on: two stops to cross one date field, and four to cross a from/to pair, which is precisely what a range filter puts side by side.

It is now out of the tab sequence, following the combobox pattern where the toggle is skipped because the field already carries the same action. Here that is `alt+arrowdown`, so nothing becomes unreachable from the keyboard, and the element stays a button that keeps its label and expanded state.

### Testing

- `partial-time.spec.ts` (9), plus new blocks in `use-date-time-selection.spec.ts`, `RuiDateTimePicker.spec.ts`, and a `datetimepicker partial entries` e2e block on a new section of `DateTimePickerView.vue`.
- The tab-order change is covered by an e2e that presses the real key across three fields in a row, since the attribute on its own proves nothing about what tab actually does. It was negative-controlled: reverting the one-line change fails that test and only that test.
- Full suite green at 1394 unit and 375 e2e, lint 0 errors, typecheck clean.
- Both changes were also driven by hand in the rotki app against a local build of this branch, which is what the consumer-side work needs them for.

### Note for the consumer

`partialTime`'s type is spelled out as a literal union rather than the exported `PartialTimeMode`. rotki's `DateTimePicker.vue` hands the whole `RuiDateTimePickerProps` interface to its own `defineProps`, and the SFC compiler must resolve every member without following a type reference into the package. Named, it compiles here and passes `vue-tsc` in the app, then fails the app's build with "Unresolvable type reference or unsupported built-in utility type".
